### PR TITLE
Special report: fix reset behavior, add reported UI state, and update tests

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -812,13 +812,17 @@ body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   background: #f5f5f5;
 }
 
 .special-toolbar {
-  position: sticky;
+  position: fixed;
   top: 0;
-  z-index: 8;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  box-sizing: border-box;
   background-color: #007bff;
   color: #fff;
   height: 48px;
@@ -846,8 +850,12 @@ body {
   justify-content: center;
 }
 
+.special-back-button {
+  cursor: pointer;
+}
+
 .special-content {
-  padding: 14px;
+  padding: 62px 14px 14px;
 }
 
 .special-bar-image {
@@ -962,6 +970,13 @@ body {
   border-radius: 10px;
   padding: 10px 12px;
   cursor: pointer;
+}
+
+.special-report-toggle.reported {
+  border-color: #c5c9d3;
+  background: #e9ecf2;
+  color: #5f6673;
+  cursor: default;
 }
 
 .special-report-form {

--- a/js/app.js
+++ b/js/app.js
@@ -747,8 +747,9 @@ function resetSpecialReportForm() {
   if (!form || !reasonSelect) return;
   
   if (reportButton) {
-	  reportButton.textContext = "Mark for review";
+	  reportButton.textContent = "Report this special";
 	  reportButton.disabled = false;
+	  reportButton.classList.remove('reported');
   }
 
   form.style.display = 'none';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -145,10 +145,21 @@ class DocumentMock {
 function loadAppWithoutBoot(document) {
   const source = fs.readFileSync('js/app.js', 'utf8');
   const trimmed = source.split('// ===== Initialize =====')[0];
+  const storage = new Map();
+  const localStorage = {
+    getItem(key) {
+      return storage.has(key) ? storage.get(key) : null;
+    },
+    setItem(key, value) {
+      storage.set(key, String(value));
+    }
+  };
+
   const context = {
     console,
     document,
-    window: { document },
+    window: { document, localStorage },
+    localStorage,
     lucide: { createIcons() {} },
     fetch: async () => ({ json: async () => ({ bars: [] }) }),
     setTimeout,
@@ -191,6 +202,11 @@ function mountBaseNodes(document) {
 }
 
 function mountSpecialReportNodes(document) {
+  const toggle = document.createElement('button');
+  toggle.setAttribute('id', 'special-report-toggle');
+  toggle.textContent = 'Report this special';
+  document.body.appendChild(toggle);
+
   const form = document.createElement('form');
   form.setAttribute('id', 'special-report-form');
   form.style.display = 'flex';
@@ -279,7 +295,7 @@ test('submitSpecialReport posts special report payload and resets form', async (
   };
 
   const bar = { id: 12, name: 'Sample Bar' };
-  const special = { day: 'MON', start_time: '16:00', end_time: '18:00', description: 'Half off', type: 'drink', all_day: false };
+  const special = { special_id: 'sp-123', day: 'MON', start_time: '16:00', end_time: '18:00', description: 'Half off', type: 'drink', all_day: false };
   vm.runInContext(`currentSpecialContext = ${JSON.stringify({ bar, special, dayLabel: 'Monday' })};`, ctx);
 
   document.getElementById('special-report-reason').value = 'Special details are inaccurate';
@@ -298,6 +314,34 @@ test('submitSpecialReport posts special report payload and resets form', async (
   assert.equal(document.getElementById('special-report-form').style.display, 'none', 'form is closed after submit');
   assert.equal(document.getElementById('special-report-reason').value, '', 'reason reset');
   assert.equal(document.getElementById('special-report-comment').value, '', 'comment reset');
+  assert.equal(document.getElementById('special-report-toggle').textContent, 'Thanks for your feedback!', 'report button shows success state');
+  assert.equal(document.getElementById('special-report-toggle').disabled, true, 'report button disabled after submit');
+  assert.equal(document.getElementById('special-report-toggle').classList.contains('reported'), true, 'reported style applied');
+});
+
+test('resetSpecialReportForm clears success mode for the next special', () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  mountSpecialReportNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  const reportButton = document.getElementById('special-report-toggle');
+  reportButton.textContent = 'Thanks for your feedback!';
+  reportButton.disabled = true;
+  reportButton.classList.add('reported');
+
+  document.getElementById('special-report-form').style.display = 'flex';
+  document.getElementById('special-report-reason').value = 'Other';
+  document.getElementById('special-report-comment').value = 'Some comment';
+
+  ctx.resetSpecialReportForm();
+
+  assert.equal(reportButton.textContent, 'Report this special');
+  assert.equal(reportButton.disabled, false);
+  assert.equal(reportButton.classList.contains('reported'), false);
+  assert.equal(document.getElementById('special-report-form').style.display, 'none');
+  assert.equal(document.getElementById('special-report-reason').value, '');
+  assert.equal(document.getElementById('special-report-comment').value, '');
 });
 
 test('submitSpecialReport sends null comment when left blank', async () => {
@@ -313,7 +357,7 @@ test('submitSpecialReport sends null comment when left blank', async () => {
   };
 
   const bar = { id: 12, name: 'Sample Bar' };
-  const special = { day: 'MON', start_time: '16:00', end_time: '18:00', description: 'Half off', type: 'drink', all_day: false };
+  const special = { special_id: 'sp-456', day: 'MON', start_time: '16:00', end_time: '18:00', description: 'Half off', type: 'drink', all_day: false };
   vm.runInContext(`currentSpecialContext = ${JSON.stringify({ bar, special, dayLabel: 'Monday' })};`, ctx);
 
   document.getElementById('special-report-reason').value = 'Other';


### PR DESCRIPTION
### Motivation
- Ensure the special-report UI shows the correct success state after submitting and that the report form is properly reset when navigating between specials.
- Keep the special detail toolbar pinned to the top and avoid horizontal overflow on the special screen.
- Make tests reflect the new UI/behavior and provide required runtime shims for headless test context.

### Description
- Adjusted special detail styles in `css/styles.css` to add `overflow-x: hidden` for `#special-screen`, make `.special-toolbar` `position: fixed` with `left/right` and higher `z-index`, add `box-sizing`, increase top padding in `.special-content`, and make `.special-back-button` show a pointer cursor.
- Added a reported visual state for the toggle by introducing `.special-report-toggle.reported` styles to show a disabled/success appearance.
- Fixed a bug in `js/app.js` where `textContext` was used instead of `textContent`, changed the reset label to `Report this special`, and ensured `resetSpecialReportForm` removes the `reported` class and re-enables the toggle button.
- Updated tests in `tests/app.test.js` to mock `localStorage` in `loadAppWithoutBoot`, add the report toggle node in `mountSpecialReportNodes`, include `special_id` in special fixtures, and add/adjust tests to assert the toggle text, disabled state, and `reported` class and to verify `resetSpecialReportForm` clears success state.

### Testing
- Ran the unit test suite in `tests/app.test.js` which includes `submitSpecialReport posts special report payload and resets form`, `resetSpecialReportForm clears success mode for the next special`, and `submitSpecialReport sends null comment when left blank` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c78b25408330b3b6f8834911c749)