### PR TITLE
Add README with AWS Lambda function overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Bar App Functions Overview
+
+The folders inside `functions/` each correspond to an AWS Lambda function.
+
+## Lambda functions
+
+- **`getStartupData`**  
+  Returns the startup payload used when the app launches.
+
+- **`refreshOpenHours`**  
+  Works together with **`fetchGoogleAPIHours`** to retrieve current open-hours data directly from Google and update the database. This process is currently triggered manually.
+
+- **`insertUserReport`**  
+  Used on the special details view. When a user marks a special for review, this function is called to insert a report record in the database.


### PR DESCRIPTION
### Motivation
- Provide a concise reference documenting that each folder under `functions/` maps to an AWS Lambda function and clarify the responsibilities of `getStartupData`, `refreshOpenHours` (with `fetchGoogleAPIHours`), and `insertUserReport`.

### Description
- Add a new `README.md` at the repository root that explains the `functions/` folder mapping and describes the roles of `getStartupData`, `refreshOpenHours` (and its relation to `fetchGoogleAPIHours`), and `insertUserReport`.

### Testing
- Verified the new file contents with `nl -ba README.md` and inspected repository status with `git status --short`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4874f7c848330b27730ab716b8d25)