### PR TITLE
Refactor detail and special rendering to use startup payload, normalize IDs, and add neutral time styling

### DIFF
--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -1,4 +1,30 @@
-function showDetail(bar, previousScreen = currentTab) {
+function getDayKeyFromName(dayName) {
+  const dayIndex = DAYS_FULL.findIndex((name) => name === dayName);
+  if (dayIndex < 0) return '';
+  return DAYS_FULL[dayIndex].slice(0, 3).toUpperCase();
+}
+
+function getOrderedDaysForDetail(todayKey) {
+  const todayIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === todayKey);
+  if (todayIndex < 0) return DAYS_FULL.slice();
+  return DAYS_FULL.slice(todayIndex).concat(DAYS_FULL.slice(0, todayIndex));
+}
+
+function getBarFromPayload(barOrId) {
+  const barId = String(typeof barOrId === 'object' ? barOrId?.bar_id : barOrId);
+  const barData = startupPayload?.bars?.[barId];
+  if (!barData) return null;
+
+  return {
+    bar_id: Number(barId),
+    ...barData
+  };
+}
+
+function showDetail(barOrId, previousScreen = currentTab) {
+  const selectedBar = getBarFromPayload(barOrId) || (typeof barOrId === 'object' ? barOrId : null);
+  if (!selectedBar) return;
+
   previousScreenState = { type: previousScreen };
   document.getElementById('home-screen').style.display = 'none';
   document.getElementById('bars-screen').style.display = 'none';
@@ -7,23 +33,29 @@ function showDetail(bar, previousScreen = currentTab) {
   document.getElementById('detail-screen').style.display = 'block';
   setScreenLayout(false);
 
-  document.getElementById('detail-image').src = bar.image_url || '';
-  document.getElementById('detail-name').textContent = bar.name.toUpperCase();
+  document.getElementById('detail-image').src = selectedBar.image_url || '';
+  document.getElementById('detail-name').textContent = (selectedBar.name || '').toUpperCase();
+
+  const todayKey = startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
+  const orderedDays = getOrderedDaysForDetail(todayKey);
+  const openHoursForBar = startupPayload?.open_hours?.[String(selectedBar.bar_id)] || {};
 
   const hoursEl = document.getElementById('detail-hours');
   hoursEl.innerHTML = '';
 
-  const todayIndex = new Date().getDay();
-  const DAYS_ORDERED = DAYS_FULL.slice(todayIndex).concat(DAYS_FULL.slice(0, todayIndex));
+  orderedDays.forEach((day) => {
+    const dayKey = getDayKeyFromName(day);
+    const hours = openHoursForBar[dayKey] || null;
 
-  DAYS_ORDERED.forEach((day) => {
-    const h = bar.hours_by_day ? bar.hours_by_day[day.slice(0, 3).toUpperCase()] : null;
     const row = document.createElement('tr');
-    if (day === DAYS_FULL[todayIndex]) row.classList.add('today');
+    if (dayKey === todayKey) row.classList.add('today');
+
     const dayCell = document.createElement('td');
     dayCell.textContent = day;
+
     const hoursCell = document.createElement('td');
-    hoursCell.textContent = h ? (h.closed ? 'Closed' : `${format12Hour(h.open_time)} – ${format12Hour(h.close_time)}`) : '';
+    hoursCell.textContent = hours?.display_text || '';
+
     row.appendChild(dayCell);
     row.appendChild(hoursCell);
     hoursEl.appendChild(row);
@@ -31,19 +63,22 @@ function showDetail(bar, previousScreen = currentTab) {
 
   const specialsContainer = document.getElementById('detail-specials');
   specialsContainer.innerHTML = '';
-  DAYS_ORDERED.forEach((day) => {
-    const key = day.slice(0, 3).toUpperCase();
-    const specials = (bar.specials_by_day && bar.specials_by_day[key]) || [];
+
+  orderedDays.forEach((day) => {
+    const dayKey = getDayKeyFromName(day);
+    const dayEntries = startupPayload?.specials_by_day?.[dayKey] || [];
+    const barEntry = dayEntries.find((entry) => String(entry.bar_id) === String(selectedBar.bar_id));
+    const specialIds = barEntry?.specials || [];
 
     const wrapper = document.createElement('div');
     wrapper.className = 'day-group';
 
     const header = document.createElement('div');
     header.className = 'day-header';
-    if (day === DAYS_FULL[todayIndex]) header.classList.add('today');
+    if (dayKey === todayKey) header.classList.add('today');
 
     const label = document.createElement('span');
-    label.textContent = day === DAYS_FULL[todayIndex] ? `${day} (Today)` : day;
+    label.textContent = dayKey === todayKey ? `${day} (Today)` : day;
 
     const arrow = document.createElement('span');
     arrow.className = 'arrow rotate';
@@ -55,15 +90,30 @@ function showDetail(bar, previousScreen = currentTab) {
     const content = document.createElement('div');
     content.className = 'day-content expanded';
 
-    if (specials.length > 0) {
-      specials.forEach((special) => {
+    if (specialIds.length > 0) {
+      specialIds.forEach((specialId) => {
+        const specialData = startupPayload?.specials?.[String(specialId)];
+        if (!specialData) return;
+
+        const special = {
+          special_id: String(specialId),
+          ...specialData
+        };
+
         const div = buildSpecialItem(special, {
+          neutralTimeBadgeStyle: true,
           clickable: true,
-          onClick: () => showSpecialDetail(bar, special, { previousScreen: 'detail', returnTo: previousScreenState?.type || currentTab, dayLabel: day === DAYS_FULL[todayIndex] ? `${day} (Today)` : day })
+          onClick: () => showSpecialDetail(selectedBar, special, {
+            previousScreen: 'detail',
+            returnTo: previousScreenState?.type || currentTab,
+            dayLabel: dayKey === todayKey ? `${day} (Today)` : day
+          })
         });
         content.appendChild(div);
       });
-    } else {
+    }
+
+    if (content.children.length === 0) {
       const noSpecials = document.createElement('div');
       noSpecials.className = 'special-item no-specials-item';
 

--- a/js/render-special-detail.js
+++ b/js/render-special-detail.js
@@ -1,5 +1,40 @@
+function resolveSpecialId(special, bar) {
+  if (special?.special_id !== undefined && special?.special_id !== null) return String(special.special_id);
+
+  const barId = special?.bar_id ?? bar?.bar_id;
+  if (!startupPayload?.specials || barId === undefined || barId === null) return null;
+
+  const matched = Object.entries(startupPayload.specials).find(([, candidate]) => {
+    if (String(candidate.bar_id) !== String(barId)) return false;
+    return candidate.day === special?.day
+      && candidate.description === special?.description
+      && candidate.special_type === (special?.special_type || special?.type)
+      && candidate.start_time === special?.start_time
+      && candidate.end_time === special?.end_time
+      && Boolean(candidate.all_day) === Boolean(special?.all_day);
+  });
+
+  return matched ? String(matched[0]) : null;
+}
+
 function showSpecialDetail(bar, special, { previousScreen = 'specials', returnTo = 'specials', dayLabel = '' } = {}) {
-  previousScreenState = { type: previousScreen, bar, returnTo };
+  const specialId = resolveSpecialId(special, bar);
+  const payloadSpecial = specialId ? startupPayload?.specials?.[specialId] : null;
+  const selectedSpecial = payloadSpecial
+    ? { special_id: specialId, ...payloadSpecial }
+    : special;
+
+  const barId = selectedSpecial?.bar_id ?? bar?.bar_id;
+  const payloadBar = barId !== undefined && barId !== null
+    ? startupPayload?.bars?.[String(barId)]
+    : null;
+  const selectedBar = payloadBar
+    ? { bar_id: Number(barId), ...payloadBar }
+    : bar;
+
+  if (!selectedSpecial || !selectedBar) return;
+
+  previousScreenState = { type: previousScreen, bar: selectedBar, returnTo };
 
   document.getElementById('home-screen').style.display = 'none';
   document.getElementById('bars-screen').style.display = 'none';
@@ -9,7 +44,7 @@ function showSpecialDetail(bar, special, { previousScreen = 'specials', returnTo
   setScreenLayout(false);
 
   const barImage = document.getElementById('special-bar-image');
-  barImage.src = (bar.image_url && bar.image_url !== 'null') ? bar.image_url : 'https://placehold.co/640x360?text=Bar';
+  barImage.src = (selectedBar.image_url && selectedBar.image_url !== 'null') ? selectedBar.image_url : 'https://placehold.co/640x360?text=Bar';
 
   const specialCard = document.getElementById('special-card');
   specialCard.innerHTML = '';
@@ -19,9 +54,9 @@ function showSpecialDetail(bar, special, { previousScreen = 'specials', returnTo
 
   const barName = document.createElement('div');
   barName.className = 'special-bar-name';
-  barName.textContent = bar.name;
+  barName.textContent = selectedBar.name;
 
-  const cardFavoriteButton = createFavoriteButton(bar, special, dayLabel || 'Day unavailable');
+  const cardFavoriteButton = createFavoriteButton(selectedBar, selectedSpecial, dayLabel || 'Day unavailable');
 
   specialHeader.appendChild(barName);
   specialHeader.appendChild(cardFavoriteButton);
@@ -34,16 +69,16 @@ function showSpecialDetail(bar, special, { previousScreen = 'specials', returnTo
   specialDay.textContent = dayLabel || 'Day unavailable';
   specialMeta.appendChild(specialDay);
 
-  currentSpecialContext = { bar, special, dayLabel: dayLabel || 'Day unavailable' };
+  currentSpecialContext = { bar: selectedBar, special: selectedSpecial, dayLabel: dayLabel || 'Day unavailable' };
 
-  const specialRow = buildSpecialItem(special);
+  const specialRow = buildSpecialItem(selectedSpecial, { neutralTimeBadgeStyle: true });
 
   specialCard.appendChild(specialHeader);
   specialCard.appendChild(specialMeta);
   specialCard.appendChild(specialRow);
 
   resetSpecialReportForm();
-  updateSpecialFavoriteButton(isFavoriteSpecial(bar, special, dayLabel || 'Day unavailable'));
+  updateSpecialFavoriteButton(isFavoriteSpecial(selectedBar, selectedSpecial, dayLabel || 'Day unavailable'));
   lucide.createIcons();
 }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -114,7 +114,7 @@ function sortBarsBySpecials(bars, dayKey, isToday) {
   });
 }
 
-function buildSpecialItem(special, { isToday = false, clickable = false, onClick = null } = {}) {
+function buildSpecialItem(special, { isToday = false, clickable = false, onClick = null, neutralTimeBadgeStyle = false } = {}) {
   const item = document.createElement('div');
   item.className = 'special-item';
 
@@ -129,15 +129,15 @@ function buildSpecialItem(special, { isToday = false, clickable = false, onClick
   }
 
   const currentStatus = special.current_status || null;
-  if (currentStatus === 'past') {
+  if (!neutralTimeBadgeStyle && currentStatus === 'past') {
     timeBadge.classList.add('past');
-  } else if (!special.all_day && isToday && isSpecialPast(special, true)) {
+  } else if (!neutralTimeBadgeStyle && !special.all_day && isToday && isSpecialPast(special, true)) {
     timeBadge.classList.add('past');
   }
 
-  if (currentStatus === 'active' || currentStatus === 'live') {
+  if (!neutralTimeBadgeStyle && (currentStatus === 'active' || currentStatus === 'live')) {
     item.classList.add('live');
-  } else if (isToday && isSpecialActive(special)) {
+  } else if (!neutralTimeBadgeStyle && isToday && isSpecialActive(special)) {
     item.classList.add('live');
   }
 
@@ -155,7 +155,7 @@ function buildSpecialItem(special, { isToday = false, clickable = false, onClick
   item.appendChild(desc);
   item.appendChild(typeIcon);
 
-  if (currentStatus === 'active' || currentStatus === 'live' || (isToday && isSpecialActive(special))) {
+  if (!neutralTimeBadgeStyle && (currentStatus === 'active' || currentStatus === 'live' || (isToday && isSpecialActive(special)))) {
     const dot = document.createElement('span');
     dot.className = 'active-dot';
     item.appendChild(dot);


### PR DESCRIPTION
### Motivation
- Ensure detail and special screens render authoritative data from `startupPayload` and accept either an object or an id for bars and specials.
- Order days and highlight "Today" consistently using the app's `current_day` when available.
- Avoid showing time-based active/past visual cues in contexts where a neutral display is desired (e.g. detail view list).

### Description
- Added helpers `getDayKeyFromName`, `getOrderedDaysForDetail`, and `getBarFromPayload`, and refactored `showDetail` to accept either a bar object or id and to pull hours and specials from `startupPayload` using ordered days starting from `startupPayload.general_data.current_day` when present.
- Reworked specials rendering in `showDetail` to resolve per-day entries via `startupPayload.specials_by_day` and to fetch special records by id before building items, passing a `neutralTimeBadgeStyle` flag and proper `onClick` handlers that call `showSpecialDetail` with normalized arguments.
- Added `resolveSpecialId` and enhanced `showSpecialDetail` to normalize and prefer payload-backed `special` and `bar` objects, update `previousScreenState` with resolved objects, and use the resolved data for UI elements and favorite handling.
- Extended `buildSpecialItem` signature with `neutralTimeBadgeStyle` to suppress time-based `past` and `live` decorations when requested, and used it in the detail/special card contexts.

### Testing
- Ran lint with `npm run lint` and the linter succeeded with no errors.
- Ran unit tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b588de36788330a27cae95ac6fb151)