### PR TITLE
Restore home open status indicator and weekly specials rendering

### DIFF
--- a/js/render-home.js
+++ b/js/render-home.js
@@ -46,7 +46,25 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
   const hoursDiv = document.createElement('div');
   hoursDiv.className = 'open-hours';
   const displayText = startupPayload?.open_hours?.[bar.bar_id]?.[dayKey]?.display_text;
-  hoursDiv.textContent = displayText ? `Hours: ${displayText}` : 'Hours unavailable';
+  const isToday = dayKey === startupPayload?.general_data?.current_day;
+  const isCurrentlyOpen = bar.currently_open ?? bar.is_open_now;
+
+  if (displayText) {
+    if (isToday) {
+      const statusSpan = document.createElement('span');
+      statusSpan.className = isCurrentlyOpen ? 'open' : 'closed';
+      statusSpan.textContent = isCurrentlyOpen ? 'Open' : 'Closed';
+      hoursDiv.appendChild(statusSpan);
+      const hoursText = document.createElement('span');
+      hoursText.textContent = ` • Hours: ${displayText}`;
+      hoursDiv.appendChild(hoursText);
+    } else {
+      hoursDiv.textContent = `Hours: ${displayText}`;
+    }
+  } else {
+    hoursDiv.textContent = 'Hours unavailable';
+  }
+
   if (!displayText) {
     hoursDiv.classList.add('future');
   }
@@ -63,71 +81,75 @@ function renderBarsWeek() {
   container.innerHTML = '';
 
   const currentDay = startupPayload?.general_data?.current_day;
-  const barsForDay = startupPayload?.specials_by_day?.[currentDay] || [];
-  const dayIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === currentDay);
-  const dayName = dayIndex >= 0 ? DAYS_FULL[dayIndex] : currentDay;
-  const dayLabel = `${dayName} (Today)`;
-
-  const dayHeader = document.createElement('div');
-  dayHeader.className = 'day-header-week';
-  dayHeader.textContent = dayLabel;
-  container.appendChild(dayHeader);
-
-  let renderedCardCount = 0;
-
-  if (barsForDay.length === 0) {
-    const noSpecialsLine = document.createElement('div');
-    noSpecialsLine.className = 'no-specials-line';
-    noSpecialsLine.textContent = 'No specials available for today.';
-    noSpecialsLine.style.padding = '12px';
-    noSpecialsLine.style.fontStyle = 'italic';
-    container.appendChild(noSpecialsLine);
-  }
-
-  barsForDay.forEach((entry) => {
-    const barId = String(entry.bar_id);
-    const barInfo = startupPayload?.bars?.[barId];
-    if (!barInfo) return;
-
-    if (activeFilters.neighborhoods.length > 0 && !activeFilters.neighborhoods.includes(barInfo.neighborhood)) return;
-
-    const bar = {
-      bar_id: Number(barId),
-      name: barInfo.name,
-      neighborhood: barInfo.neighborhood,
-      image_url: barInfo.image_url,
-      is_open_now: barInfo.is_open_now,
-      has_special_this_week: barInfo.has_special_this_week
+  const configuredStartIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === currentDay);
+  const startIndex = configuredStartIndex >= 0 ? configuredStartIndex : new Date().getDay();
+  const orderedDays = Array.from({ length: 7 }, (_, offset) => {
+    const dayName = DAYS_FULL[(startIndex + offset + 7) % 7];
+    return {
+      dayKey: dayName.slice(0, 3).toUpperCase(),
+      dayLabel: offset === 0 ? `${dayName} (Today)` : dayName
     };
-
-    const card = document.createElement('div');
-    card.className = 'bar-card';
-    card.onclick = () => showDetail(bar, currentTab);
-
-    if (bar.image_url && bar.image_url !== 'null') {
-      const img = document.createElement('img');
-      img.className = 'card-image';
-      img.src = bar.image_url;
-      img.alt = bar.name;
-      card.appendChild(img);
-    }
-
-    const homeContent = buildHomeBarSpecials(bar, entry.specials || [], currentDay, dayLabel);
-    if (!homeContent) return;
-
-    card.appendChild(homeContent);
-    container.appendChild(card);
-    renderedCardCount += 1;
   });
 
-  if (renderedCardCount === 0 && barsForDay.length > 0) {
-    const noSpecialsLine = document.createElement('div');
-    noSpecialsLine.className = 'no-specials-line';
-    noSpecialsLine.textContent = 'No specials match your current filters.';
-    noSpecialsLine.style.padding = '12px';
-    noSpecialsLine.style.fontStyle = 'italic';
-    container.appendChild(noSpecialsLine);
-  }
+
+  orderedDays.forEach(({ dayKey, dayLabel }) => {
+    const barsForDay = startupPayload?.specials_by_day?.[dayKey] || [];
+
+    const dayHeader = document.createElement('div');
+    dayHeader.className = 'day-header-week';
+    dayHeader.textContent = dayLabel;
+    container.appendChild(dayHeader);
+
+    let renderedCardCountForDay = 0;
+
+    barsForDay.forEach((entry) => {
+      const barId = String(entry.bar_id);
+      const barInfo = startupPayload?.bars?.[barId];
+      if (!barInfo) return;
+
+      if (activeFilters.neighborhoods.length > 0 && !activeFilters.neighborhoods.includes(barInfo.neighborhood)) return;
+
+      const bar = {
+        bar_id: Number(barId),
+        name: barInfo.name,
+        neighborhood: barInfo.neighborhood,
+        image_url: barInfo.image_url,
+        currently_open: barInfo.currently_open,
+        is_open_now: barInfo.is_open_now,
+        has_special_this_week: barInfo.has_special_this_week
+      };
+
+      const card = document.createElement('div');
+      card.className = 'bar-card';
+      card.onclick = () => showDetail(bar, currentTab);
+
+      if (bar.image_url && bar.image_url !== 'null') {
+        const img = document.createElement('img');
+        img.className = 'card-image';
+        img.src = bar.image_url;
+        img.alt = bar.name;
+        card.appendChild(img);
+      }
+
+      const homeContent = buildHomeBarSpecials(bar, entry.specials || [], dayKey, dayLabel);
+      if (!homeContent) return;
+
+      card.appendChild(homeContent);
+      container.appendChild(card);
+      renderedCardCountForDay += 1;
+    });
+
+    if (renderedCardCountForDay === 0) {
+      const noSpecialsLine = document.createElement('div');
+      noSpecialsLine.className = 'no-specials-line';
+      noSpecialsLine.textContent = barsForDay.length === 0
+        ? 'No specials available.'
+        : 'No specials match your current filters.';
+      noSpecialsLine.style.padding = '12px';
+      noSpecialsLine.style.fontStyle = 'italic';
+      container.appendChild(noSpecialsLine);
+    }
+  });
 
   requestAnimationFrame(() => {
     container.style.opacity = 1;

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -204,6 +204,10 @@ function mountBaseNodes(document) {
 
   const home = document.createElement('div');
   home.setAttribute('id', 'home-screen');
+  const homeBars = document.createElement('div');
+  homeBars.setAttribute('id', 'home-bars');
+  home.appendChild(homeBars);
+
   const bars = document.createElement('div');
   bars.setAttribute('id', 'bars-screen');
   const detail = document.createElement('div');
@@ -428,4 +432,58 @@ test('submitSpecialReport sends null comment when left blank', async () => {
 
   const body = JSON.parse(fetchCalls[0].options.body);
   assert.equal(body.comment, null);
+});
+
+
+test('renderBarsWeek shows today through next 6 days and open status only for today', () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  vm.runInContext(`
+    startupPayload = {
+      general_data: { current_day: 'MON' },
+      bars: {
+        '1': { name: 'Today Bar', neighborhood: 'Downtown', image_url: null, currently_open: true },
+        '2': { name: 'Tomorrow Bar', neighborhood: 'Midtown', image_url: null, currently_open: false }
+      },
+      open_hours: {
+        '1': { MON: { display_text: '4:00 PM - 2:00 AM' } },
+        '2': { TUE: { display_text: '5:00 PM - 1:00 AM' } }
+      },
+      specials: {
+        '11': { bar_id: 1, description: '$5 Beer', special_type: 'drink', all_day: false, start_time: '16:00', end_time: '18:00', current_status: 'active' },
+        '22': { bar_id: 2, description: '$4 Wells', special_type: 'drink', all_day: false, start_time: '17:00', end_time: '19:00', current_status: 'upcoming' }
+      },
+      specials_by_day: {
+        MON: [{ bar_id: 1, specials: ['11'] }],
+        TUE: [{ bar_id: 2, specials: ['22'] }],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: []
+      }
+    };
+    currentTab = 'specials';
+    activeFilters.types = [];
+    activeFilters.neighborhoods = [];
+  `, ctx);
+
+  ctx.renderBarsWeek();
+
+  const dayHeaders = document.querySelectorAll('.day-header-week');
+  assert.equal(dayHeaders.length, 7, 'renders all 7 day sections');
+  assert.equal(dayHeaders[0].textContent, 'Monday (Today)');
+  assert.equal(dayHeaders[1].textContent, 'Tuesday');
+
+  const openHours = document.querySelectorAll('.open-hours');
+  assert.equal(openHours.length, 2, 'renders hours for cards in multiple days');
+
+  const todayStatus = openHours[0].querySelector('.open');
+  assert.ok(todayStatus, 'today card shows open/closed status label');
+  assert.equal(todayStatus.textContent, 'Open');
+
+  const futureStatus = openHours[1].querySelector('.open') || openHours[1].querySelector('.closed');
+  assert.equal(futureStatus, null, 'future day card does not render open/closed status label');
 });


### PR DESCRIPTION
### Motivation
- Reintroduce the small open/closed status label that used to appear before hours on Home screen bar cards for today, now simplified to use `currently_open` from the startup payload (with compatibility fallback to `is_open_now`).
- Fix a regression where the Home screen only rendered specials for today instead of the full week (today + next 6 days).

### Description
- Updated `buildHomeBarSpecials` to render a status `span` (`Open` or `Closed`) for cards whose `dayKey` is today and to fall back from `bar.currently_open` to `bar.is_open_now` for compatibility.
- Reworked `renderBarsWeek` to build an ordered 7-day sequence starting at `current_day`, render a header for each day, and render each day’s bar cards from `startupPayload.specials_by_day[dayKey]` (keeping future-day cards using standard hours-only styling).
- Added a small defensive fallback to compute the start index when `current_day` is missing, using `new Date().getDay()`.
- Expanded the tests and DOM mock (`tests/app.test.js`) to mount `#home-bars` and added a regression test asserting all 7 day sections render and that only today’s cards show the open/closed label.

### Testing
- Ran unit tests with `node --test tests/app.test.js`, which completed successfully (all tests passed). 
- Attempted an automated Playwright render/screenshot run to exercise the UI in a browser, but the Chromium process crashed in this environment (SIGSEGV) and that run failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a038061c8330b282f303bc90d39f)