### PR TITLE
Fix startup specials ordering around 2am rollover

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -242,6 +242,8 @@ def build_startup_payload(device_id=None):
             'startup_payload': {
                 'general_data': {
                     'current_day': current_day_key,
+                    'current_time': now.strftime('%H:%M:%S'),
+                    'effective_current_time': effective_now.strftime('%H:%M:%S'),
                     'generated_at': now.isoformat()
                 },
                 'bars': bars_lookup,


### PR DESCRIPTION
### Motivation
- The startup payload could show the wrong day ordering for late-night use: after midnight but before 2:00 AM the UI should still treat the time as the previous day.  
- Ensure `current_day` and `specials_by_day` ordering reflect that effective day so the UI shows the expected day first (e.g., `SAT` at 1:59 AM Sunday).

### Description
- Added `DAY_INDEX` for quick day -> index lookup and implemented `get_effective_now(now)` to treat times before 2:00 AM as part of the previous calendar day.  
- Derived `current_day` and `current_minutes` from `get_effective_now` instead of the raw system `now`.  
- Added `get_ordered_day_keys(start_day_key)` and rotated `specials_by_day` / `day_bar_entries` to start from the effective current day.  
- Reordered `specials` in-memory using the effective day offset and additional tie-breakers (`bar_id`, `all_day`, `start_time`, `special_id`) so the payload ordering begins with the effective current day.

### Testing
- Ran `python -m py_compile functions/getStartupData/get_startup_data.py` which succeeded.  
- Ran `node --test tests/app.test.js` and all tests passed (`7` tests, `0` failures).  
- Attempted a targeted Python runtime assertion import but the environment lacked `pymysql`, so direct module import assertions could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61b0db7a48330bb7a93da0a80e5d0)