### PR TITLE
Use Eastern timezone and effective day ordering for specials and open hours

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -2,6 +2,7 @@ import pymysql
 import json
 import os
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 # Environment variables
 RDS_HOST = os.environ['RDS_HOST']
@@ -10,6 +11,8 @@ DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 
 DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+DAY_INDEX = {day: idx for idx, day in enumerate(DAY_KEYS)}
+EASTERN_TZ = ZoneInfo('America/New_York')
 
 # Database connection helper
 def get_connection():
@@ -125,6 +128,20 @@ def get_special_status(special_day, all_day, start_time, end_time, current_day_k
         return 'past'
     return 'active'
 
+
+def get_effective_now(now=None):
+    now = now or datetime.now(EASTERN_TZ)
+    if now.hour < 2:
+        return now - timedelta(days=1)
+    return now
+
+
+def get_ordered_day_keys(start_day_key):
+    if start_day_key not in DAY_INDEX:
+        return DAY_KEYS[:]
+    start_index = DAY_INDEX[start_day_key]
+    return DAY_KEYS[start_index:] + DAY_KEYS[:start_index]
+
 #Payload builder
 def build_startup_payload(device_id=None):
     conn = get_connection()
@@ -135,9 +152,22 @@ def build_startup_payload(device_id=None):
             specials = query_specials(cursor)
             favorite_special_ids = query_device_favorite_special_ids(cursor, device_id)
 
-        now = datetime.now()
-        current_day_key = now.strftime('%a').upper()
-        current_minutes = (now.hour * 60) + now.minute
+        now = datetime.now(EASTERN_TZ)
+        effective_now = get_effective_now(now)
+        current_day_key = effective_now.strftime('%a').upper()
+        current_minutes = (effective_now.hour * 60) + effective_now.minute
+        ordered_day_keys = get_ordered_day_keys(current_day_key)
+
+        specials = sorted(
+            specials,
+            key=lambda row: (
+                (DAY_INDEX.get(row['day_of_week'], 0) - DAY_INDEX.get(current_day_key, 0)) % 7,
+                row['bar_id'],
+                0 if row['all_day'] == 'Y' else 1,
+                to_minutes(row['start_time']) if to_minutes(row['start_time']) is not None else 10 ** 9,
+                row['special_id']
+            )
+        )
 
         bars_lookup = {}
         for bar in bars:
@@ -172,8 +202,8 @@ def build_startup_payload(device_id=None):
                     bars_lookup.get(bar_id, {})['is_open_now'] = True
 
         specials_lookup = {}
-        specials_by_day = {day: [] for day in DAY_KEYS}
-        day_bar_entries = {day: {} for day in DAY_KEYS}
+        specials_by_day = {day: [] for day in ordered_day_keys}
+        day_bar_entries = {day: {} for day in ordered_day_keys}
 
         for row in specials:
             bar_id = str(row['bar_id'])


### PR DESCRIPTION
### Motivation
- Ensure time calculations use the `America/New_York` timezone so open hours and specials align with local time.
- Treat early-morning timestamps (before 2:00) as belonging to the previous day so bars/specials that span past midnight are classified correctly.
- Present specials ordered starting from the effective current day and group day buckets in that same rotated order for consistent UI consumption.

### Description
- Import `ZoneInfo` and add `EASTERN_TZ` constant to run all time logic in the Eastern timezone (`America/New_York`).
- Add `DAY_INDEX` mapping and `get_ordered_day_keys` helper to produce a rotated list of day keys starting at the effective current day.
- Add `get_effective_now` helper that shifts times before 2:00 back one day to treat them as the previous day.
- Use `get_effective_now` in `build_startup_payload` and compute `current_day_key`/`current_minutes` from the effective time.
- Sort `specials` by day relative to the current day, `bar_id`, `all_day` first, `start_time`, and `special_id` to provide a deterministic, user-centered ordering.
- Initialize `specials_by_day` and `day_bar_entries` using the rotated `ordered_day_keys` so the payload's day buckets align with the sorted specials.

### Testing
- Ran the repository's automated unit test suite which covers time and ordering logic; all tests passed.
- Executed the startup payload builder against a local dev database to validate time-shift behavior and ordering; no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61b0db7a48330bb7a93da0a80e5d0)