### PR TITLE
Normalize special status handling for time badge styling

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -128,7 +128,8 @@ function buildSpecialItem(special, { isToday = false, clickable = false, onClick
     timeBadge.innerHTML = `${startFormatted}<br>${endFormatted}`;
   }
 
-  const currentStatus = special.current_status || null;
+  const rawStatus = special.current_status ?? special.status ?? null;
+  const currentStatus = typeof rawStatus === 'string' ? rawStatus.trim().toLowerCase() : null;
   if (!neutralTimeBadgeStyle && currentStatus === 'past') {
     timeBadge.classList.add('past');
   } else if (!neutralTimeBadgeStyle && !special.all_day && isToday && isSpecialPast(special, true)) {


### PR DESCRIPTION
### Motivation
- Ensure specials marked as `past` in the startup payload consistently render the grey `.time-badge.past` style because incoming status fields may use different property names, casing, or whitespace.

### Description
- Updated `buildSpecialItem` in `js/utils.js` to read `special.current_status` with a fallback to `special.status`, normalize the value with `trim().toLowerCase()`, and use the normalized `currentStatus` for applying the `time-badge past` class, the `live` row styling, and the active dot.

### Testing
- Ran `node --test tests/app.test.js` and all tests passed (7/7).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63302c6d48330bbebc2aa1547f6a8)