### PR TITLE
Fix startup special status classification between midnight and 2 AM

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -139,9 +139,17 @@ def get_special_status(special_day, all_day, start_time, end_time, current_day_k
     if start_minutes is None or end_minutes is None:
         return 'upcoming'
 
-    if current_minutes < start_minutes:
+    adjusted_current_minutes = current_minutes
+    adjusted_end_minutes = end_minutes
+
+    if end_minutes < start_minutes:
+        adjusted_end_minutes = end_minutes + (24 * 60)
+        if adjusted_current_minutes < start_minutes:
+            adjusted_current_minutes += 24 * 60
+
+    if adjusted_current_minutes < start_minutes:
         return 'upcoming'
-    if current_minutes > end_minutes:
+    if adjusted_current_minutes > adjusted_end_minutes:
         return 'past'
     return 'active'
 
@@ -173,6 +181,8 @@ def build_startup_payload(device_id=None):
         effective_now = get_effective_now(now)
         current_day_key = effective_now.strftime('%a').upper()
         current_minutes = (effective_now.hour * 60) + effective_now.minute
+        if now.hour < 2:
+            current_minutes += 24 * 60
         ordered_day_keys = get_ordered_day_keys(current_day_key)
 
         specials = sorted(


### PR DESCRIPTION
### Motivation
- Startup payload was misclassifying specials during the midnight–2 AM window (e.g. at 12:28 AM a previous-day special showed `upcoming` instead of `past`), due to mismatched minute timelines for overnight windows.

### Description
- Adjusted `get_special_status` to normalize overnight windows by mapping `end_minutes` and `current_minutes` onto the same timeline when `end_minutes < start_minutes`, and then compare using `adjusted_current_minutes` and `adjusted_end_minutes` in `functions/getStartupData/get_startup_data.py`.
- Updated `build_startup_payload` so that when `now.hour < 2` the `current_minutes` used for status evaluation is incremented by `24 * 60` to reflect the previous-day timeline.
- These changes make specials that span past midnight (for example `22:00 -> 02:00`) evaluate as `active` after midnight and make previous-day earlier specials evaluate as `past` during the midnight–2 AM window.

### Testing
- Ran a direct Python import test which initially failed due to missing `pymysql` in the environment (automated failure reproduced at import time).
- Performed automated Python checks with `pymysql` and environment variables stubbed and verified expected pre-2AM behavior: prior daytime special => `past`, overnight special (`22:00->02:00`) => `active`, and short early-morning special => `past` (all succeeded).
- Committed the change to `functions/getStartupData/get_startup_data.py` and validated the diff to confirm the inserted adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6359e04a48330b68bf13df242f9ca)