### PR TITLE
Add updateDeviceFavorite Lambda and persist favorites from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 
 - **`insertUserReport`**  
   Used on the special details view. When a user marks a special for review, this function is called to insert a report record in the database.
+
+- **`updateDeviceFavorite`**  
+  Updates records in `device_favorite` for a given `device_id` and `special_id`. Pass `is_favorite: true` to insert (or keep) a favorite row, and `is_favorite: false` to delete the row.
+
+  Example payload:
+
+  ```json
+  {
+    "device_id": "abc123",
+    "special_id": 28,
+    "is_favorite": true
+  }
+  ```
+
+## Front-end integration
+
+- Favorites are now persisted in the background whenever a user favorites/unfavorites a special.
+- Endpoint used by the web app:
+  - `https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite`

--- a/functions/updateDeviceFavorite/update_device_favorite.py
+++ b/functions/updateDeviceFavorite/update_device_favorite.py
@@ -1,0 +1,86 @@
+import json
+import os
+
+import pymysql
+
+DB_HOST = os.environ['RDS_HOST']
+DB_USER = os.environ['DB_USER']
+DB_PASSWORD = os.environ['DB_PASSWORD']
+DB_NAME = os.environ['DB_NAME']
+
+
+def parse_event_body(event):
+    if not event:
+        return {}
+
+    body = event.get('body') if isinstance(event, dict) else None
+
+    if body is None and isinstance(event, dict):
+        return event
+
+    if isinstance(body, str):
+        return json.loads(body)
+
+    if isinstance(body, dict):
+        return body
+
+    return {}
+
+
+def lambda_handler(event, context):
+    try:
+        body = parse_event_body(event)
+
+        device_id = body.get('device_id')
+        special_id = body.get('special_id')
+        is_favorite = body.get('is_favorite')
+
+        if not device_id or special_id is None or not isinstance(is_favorite, bool):
+            return {
+                'statusCode': 400,
+                'body': json.dumps({
+                    'error': 'Missing or invalid required fields: device_id, special_id, is_favorite (boolean)'
+                })
+            }
+
+        connection = pymysql.connect(
+            host=DB_HOST,
+            user=DB_USER,
+            password=DB_PASSWORD,
+            database=DB_NAME,
+            cursorclass=pymysql.cursors.DictCursor
+        )
+
+        with connection.cursor() as cursor:
+            if is_favorite:
+                cursor.execute(
+                    """
+                    INSERT INTO device_favorite (device_id, special_id)
+                    VALUES (%s, %s)
+                    ON DUPLICATE KEY UPDATE device_id = VALUES(device_id)
+                    """,
+                    (device_id, special_id)
+                )
+                message = 'Favorite added'
+            else:
+                cursor.execute(
+                    """
+                    DELETE FROM device_favorite
+                    WHERE device_id = %s AND special_id = %s
+                    """,
+                    (device_id, special_id)
+                )
+                message = 'Favorite removed'
+
+        connection.commit()
+        connection.close()
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({'message': message})
+        }
+    except Exception as error:
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'error': str(error)})
+        }

--- a/js/api.js
+++ b/js/api.js
@@ -1,5 +1,6 @@
 const STARTUP_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
 const SPECIAL_REPORT_API_URL = 'https://3kz7x6tvvi.execute-api.us-east-2.amazonaws.com/default/insertUserReport';
+const UPDATE_DEVICE_FAVORITE_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite';
 
 function buildLegacyBarsData(payload) {
   const barsLookup = payload?.bars || {};
@@ -63,10 +64,29 @@ async function loadBars() {
 }
 
 async function persistFavoriteChangeInBackground(specialId, isFavorited) {
-  // Placeholder for future backend persistence to device_favorite.
-  // Intentionally left unimplemented until the write endpoint is available.
-  void specialId;
-  void isFavorited;
+  if (!deviceId || specialId === null || specialId === undefined) return;
+
+  const payload = {
+    device_id: deviceId,
+    special_id: Number(specialId),
+    is_favorite: Boolean(isFavorited)
+  };
+
+  try {
+    const response = await fetch(UPDATE_DEVICE_FAVORITE_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      console.error('Failed to persist favorite change:', response.status);
+    }
+  } catch (err) {
+    console.error('Failed to persist favorite change:', err);
+  }
 }
 
 async function submitSpecialReport(event) {


### PR DESCRIPTION
### Motivation
- Provide a write endpoint to persist user favorites into the `device_favorite` table so front-end favorite/unfavorite actions are stored server-side.
- Integrate the web app to call the new backend so favorites are persisted in the background when users toggle them.

### Description
- Add a new Lambda function `updateDeviceFavorite` (`functions/updateDeviceFavorite/update_device_favorite.py`) that validates `device_id`, `special_id`, and boolean `is_favorite`, and either inserts (with upsert) or deletes a row in `device_favorite`; it uses `RDS_HOST`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` from environment variables.
- Update the front-end API module (`js/api.js`) with `UPDATE_DEVICE_FAVORITE_API_URL` and implement `persistFavoriteChangeInBackground` to POST a JSON payload (`device_id`, `special_id`, `is_favorite`) to the new endpoint and log failures.
- Document the new function, example payload, and the endpoint URL in `README.md` under Lambda functions and front-end integration.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d963e1648330806a099604c2dd4b)