### PR TITLE
Add loadCsvToMysql Lambda to import CSVs from S3 into MySQL and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   Used on the special details view. When a user marks a special for review, this function is called to insert a report record in the database.
 
 - **`loadCsvToMysql`**  
-  Loads CSV files from S3 into MySQL in RDS. This Lambda reads `S3_BUCKET` and `S3_DATA_FOLDER` from required environment variables, reads metadata from row 1 (`table_name`, `transaction_type`), uses row 2 as headers, and processes rows 3+ with batch SQL operations via `executemany()`. If no `key` is provided in the event, it automatically selects the oldest file in `${S3_DATA_FOLDER}/input/`.
+  Loads CSV files from S3 into MySQL in RDS. This Lambda reads `S3_BUCKET` and `S3_DATA_FOLDER` from required environment variables, reads table name from row 1, transaction type from row 2, uses row 3 as headers, and processes rows 4+ with batch SQL operations via `executemany()`. If no `key` is provided in the event, it automatically selects the oldest file in `${S3_DATA_FOLDER}/input/`.
 
   Supported tables:
   - `bar`
@@ -42,7 +42,8 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   CSV format:
 
   ```csv
-  bar,IU
+  bar
+  IU
   bar_id,name,address,neighborhood,image_url
   1,Mike's Beer Bar,123 North Shore Dr,North Shore,https://example.com/mike.jpg
   2,Cinderlands,456 Butler St,Lawrenceville,https://example.com/cinderlands.jpg
@@ -51,7 +52,8 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   Delete file format (`D` transaction only supports one key column):
 
   ```csv
-  special,D
+  special
+  D
   special_id
   55
   56

--- a/functions/loadCsvToMysql/load_csv_to_mysql.py
+++ b/functions/loadCsvToMysql/load_csv_to_mysql.py
@@ -37,26 +37,35 @@ def parse_csv_from_s3(bucket, key):
     csv_content = response['Body'].read().decode('utf-8-sig')
     rows = list(csv.reader(io.StringIO(csv_content)))
 
-    if len(rows) < 2:
-        raise ValueError('CSV must include metadata row and header row.')
+    if len(rows) < 3:
+        raise ValueError('CSV must include table row, transaction row, and header row.')
 
-    metadata_row = rows[0]
-    if len(metadata_row) < 2:
-        raise ValueError('Metadata row must include table name and transaction type.')
+    table_row = rows[0]
+    if not table_row:
+        raise ValueError('Row 1 must include table name.')
 
-    table_name = metadata_row[0].strip()
-    transaction_type = metadata_row[1].strip().upper()
+    table_name = table_row[0].strip()
+    if not table_name:
+        raise ValueError('Row 1 table name cannot be empty.')
 
-    headers = [header.strip() for header in rows[1] if header is not None]
+    transaction_row = rows[1]
+    if not transaction_row:
+        raise ValueError('Row 2 must include transaction type.')
+
+    transaction_type = transaction_row[0].strip().upper()
+    if not transaction_type:
+        raise ValueError('Row 2 transaction type cannot be empty.')
+
+    headers = [header.strip() for header in rows[2] if header is not None]
     if not headers or all(not header for header in headers):
-        raise ValueError('Header row is required and cannot be empty.')
+        raise ValueError('Row 3 header row is required and cannot be empty.')
 
     clean_headers = [header for header in headers if header]
     if len(clean_headers) != len(headers):
         raise ValueError('Header row contains empty column names.')
 
     data_rows = []
-    for row in rows[2:]:
+    for row in rows[3:]:
         if not row or all(not str(value).strip() for value in row):
             continue
 


### PR DESCRIPTION
### Motivation

- Provide an automated Lambda to ingest CSV files placed in S3 into the RDS MySQL database with support for insert, upsert, and delete operations. 
- Make the CSV import workflow explicit in the repository README including required environment variables, IAM permissions, file layout, and examples.

### Description

- Added `functions/loadCsvToMysql/load_csv_to_mysql.py`, a new Lambda that reads CSVs from `S3_BUCKET`/`S3_DATA_FOLDER`, parses a metadata row (`table_name`, `transaction_type`), header row, and data rows, and performs batch SQL operations via `executemany()` against RDS using `pymysql` and `boto3` for S3 access. 
- Implemented support for transaction types `I` (insert), `IU` (insert/update via `ON DUPLICATE KEY UPDATE`), and `D` (delete), with allowed target tables limited to `bar`, `special`, and `open_hours`. 
- Added logic to auto-select the oldest file in the `data/input/` folder when no `key` is provided, and to move processed files to `data/complete/` or errored files to `data/error/` using S3 copy+delete with a UTC timestamp prefix to avoid overwrites. 
- Updated `README.md` with usage details, CSV format examples, required environment variables, and necessary IAM permissions for operating the Lambda.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b831ebbdfc8330b227a8c9ce54b30b)