### PR TITLE
Mark bars inactive when Google reports non-operational

### DIFF
--- a/functions/fetchGoogleAPIHours/fetch_google_api_hours.py
+++ b/functions/fetchGoogleAPIHours/fetch_google_api_hours.py
@@ -18,14 +18,18 @@ ALL_DAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
 
 # Google Places API helper
 def fetch_place_open_hours(place_id):
-    url = f'https://maps.googleapis.com/maps/api/place/details/json?place_id={place_id}&fields=opening_hours&key={GOOGLE_API_KEY}'
+    url = f'https://maps.googleapis.com/maps/api/place/details/json?place_id={place_id}&fields=opening_hours,business_status&key={GOOGLE_API_KEY}'
     response = requests.get(url, timeout=5)
     if response.status_code != 200:
-        print(f"Error fetching place {place_id}: {resp.text}")
+        print(f"Error fetching place {place_id}: {response.text}")
         return None
 
     data = response.json()
-    return data.get('result', {}).get('opening_hours', {}).get('periods', [])
+    result = data.get('result', {})
+    return {
+        'business_status': result.get('business_status'),
+        'periods': result.get('opening_hours', {}).get('periods', [])
+    }
 
 # Lambda function handler
 def lambda_handler(event, context):
@@ -38,7 +42,9 @@ def lambda_handler(event, context):
         bar_id = bar['bar_id']
         place_id = bar['google_place_id']
 
-        periods = fetch_place_open_hours(place_id)
+        place_details = fetch_place_open_hours(place_id) or {}
+        periods = place_details.get('periods', [])
+        business_status = place_details.get('business_status')
 
         # Initialize all days as CLOSED
         hours_map = {day: "CLOSED" for day in ALL_DAYS}
@@ -56,7 +62,8 @@ def lambda_handler(event, context):
 
         result.append({
             'bar_id': bar_id,
-            'hours': hours_map
+            'hours': hours_map,
+            'business_status': business_status
         })
     
     return {

--- a/functions/refreshOpenHours/refresh_open_hours.py
+++ b/functions/refreshOpenHours/refresh_open_hours.py
@@ -64,6 +64,15 @@ def lambda_handler(event, context):
             for bar in google_bars:
                 bar_id = bar['bar_id']
                 hours = bar['hours']
+                business_status = bar.get('business_status')
+                is_active = 'Y' if business_status in (None, 'OPERATIONAL') else 'N'
+
+                cursor.execute("""
+                    UPDATE bar
+                    SET is_active = %s,
+                        update_date = NOW()
+                    WHERE bar_id = %s
+                """, (is_active, bar_id))
 
                 for day, value in hours.items():
                     if value == "CLOSED":


### PR DESCRIPTION
### Motivation
- Ensure the app reflects Google Places `business_status` so bars that are closed/removed are marked inactive in the database.
- Include `business_status` in the hours fetch flow so the refresh job can make active/inactive decisions while still updating open hours.

### Description
- Update `fetch_place_open_hours` in `functions/fetchGoogleAPIHours/fetch_google_api_hours.py` to request `opening_hours,business_status` from Google and return a dict containing `business_status` and `periods` for each place.
- Change the `lambda_handler` in the same file to include `business_status` in each bar entry returned in the payload to the caller (`'bars': result`).
- Update `functions/refreshOpenHours/refresh_open_hours.py` to read `business_status` from the Google payload and run an `UPDATE bar SET is_active = %s` using `is_active = 'N'` when the business status is present and not `OPERATIONAL`, otherwise keep `is_active = 'Y'`.
- Fix the Google API non-200 error log to reference `response.text` instead of the wrong variable.

### Testing
- Ran `python -m py_compile functions/fetchGoogleAPIHours/fetch_google_api_hours.py functions/refreshOpenHours/refresh_open_hours.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baab7ebe0083309aab83559283bc9f)