### PR TITLE
Add getBarDetails lambda and on-demand bar detail fetching with startup payload filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 ## Lambda functions
 
 - **`getStartupData`**  
-  Returns the startup payload used when the app launches.
+  Returns the startup payload used when the app launches. This payload now includes only active bars and only open-hours rows for bars that currently have an active special in the returned week view.
+
+- **`getBarDetails`**  
+  Returns only open hours and specials for a single active bar when the user opens the bar details screen.
 
 - **`refreshOpenHours`**  
   Works together with **`fetchGoogleAPIHours`** to retrieve current open-hours data directly from Google and update the database. This process is currently triggered manually.

--- a/functions/getBarDetails/get_bar_details.py
+++ b/functions/getBarDetails/get_bar_details.py
@@ -1,0 +1,257 @@
+import json
+import os
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pymysql
+
+RDS_HOST = os.environ['RDS_HOST']
+DB_USER = os.environ['DB_USER']
+DB_PASSWORD = os.environ['DB_PASSWORD']
+DB_NAME = os.environ['DB_NAME']
+
+DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+DAY_INDEX = {day: idx for idx, day in enumerate(DAY_KEYS)}
+EASTERN_TZ = ZoneInfo('America/New_York')
+
+
+def get_connection():
+    return pymysql.connect(host=RDS_HOST, user=DB_USER, passwd=DB_PASSWORD, db=DB_NAME, connect_timeout=5)
+
+
+def query_bar(cursor, bar_id):
+    cursor.execute(
+        """
+        SELECT bar_id, name, neighborhood, image_url
+        FROM bar
+        WHERE bar_id = %s AND is_active = 'Y'
+        """,
+        (bar_id,)
+    )
+    return cursor.fetchone()
+
+
+def query_open_hours(cursor, bar_id):
+    cursor.execute(
+        "SELECT bar_id, day_of_week, open_time, close_time, is_closed FROM open_hours WHERE bar_id = %s",
+        (bar_id,)
+    )
+    return cursor.fetchall()
+
+
+def query_specials(cursor, bar_id):
+    cursor.execute(
+        """
+        SELECT special_id, bar_id, day_of_week, all_day, start_time, end_time, description, type
+        FROM special
+        WHERE bar_id = %s AND is_active = 'Y'
+        ORDER BY day_of_week, all_day DESC, start_time, special_id
+        """,
+        (bar_id,)
+    )
+    return cursor.fetchall()
+
+
+def to_time_string(value):
+    return None if value is None else str(value)
+
+
+def get_hour_minute(time_value):
+    if time_value is None:
+        return None, None
+
+    if isinstance(time_value, timedelta):
+        total_minutes = int(time_value.total_seconds() // 60)
+        return (total_minutes // 60) % 24, total_minutes % 60
+
+    if hasattr(time_value, 'hour') and hasattr(time_value, 'minute'):
+        return time_value.hour, time_value.minute
+
+    if isinstance(time_value, str) and ':' in time_value:
+        try:
+            hour_str, minute_str = time_value.split(':', 1)
+            return int(hour_str), int(minute_str)
+        except ValueError:
+            return None, None
+
+    return None, None
+
+
+def format_display_time(time_value):
+    if time_value is None:
+        return None
+
+    hour, minute = get_hour_minute(time_value)
+    if hour is None or minute is None:
+        return None
+
+    ampm = 'AM' if hour < 12 else 'PM'
+    hour = hour % 12
+    if hour == 0:
+        hour = 12
+    return f"{hour}:{minute:02d} {ampm}"
+
+
+def build_hours_display_text(open_time, close_time, is_closed):
+    if is_closed == 'Y':
+        return 'Closed'
+
+    open_text = format_display_time(open_time)
+    close_text = format_display_time(close_time)
+    if not open_text or not close_text:
+        return 'Hours unavailable'
+
+    return f"{open_text} – {close_text}"
+
+
+def to_minutes(time_value):
+    if time_value is None:
+        return None
+
+    hour, minute = get_hour_minute(time_value)
+    if hour is None or minute is None:
+        return None
+    if hour == 0 and minute == 0:
+        return 24 * 60
+    return (hour * 60) + minute
+
+
+def get_effective_now(now=None):
+    now = now or datetime.now(EASTERN_TZ)
+    if now.hour < 2:
+        return now - timedelta(days=1)
+    return now
+
+
+def get_special_status(special_day, all_day, start_time, end_time, current_day_key, current_minutes):
+    if special_day != current_day_key:
+        return 'upcoming'
+
+    if all_day == 'Y':
+        return 'active'
+
+    start_minutes = to_minutes(start_time)
+    end_minutes = to_minutes(end_time)
+    if start_minutes is None or end_minutes is None:
+        return 'upcoming'
+
+    adjusted_current_minutes = current_minutes
+    adjusted_end_minutes = end_minutes
+
+    if end_minutes < start_minutes:
+        adjusted_end_minutes = end_minutes + (24 * 60)
+        if adjusted_current_minutes < start_minutes:
+            adjusted_current_minutes += 24 * 60
+
+    if adjusted_current_minutes < start_minutes:
+        return 'upcoming'
+    if adjusted_current_minutes > adjusted_end_minutes:
+        return 'past'
+    return 'active'
+
+
+def get_ordered_day_keys(start_day_key):
+    if start_day_key not in DAY_INDEX:
+        return DAY_KEYS[:]
+    start_index = DAY_INDEX[start_day_key]
+    return DAY_KEYS[start_index:] + DAY_KEYS[:start_index]
+
+
+def build_bar_details_payload(bar_id):
+    conn = get_connection()
+    try:
+        with conn.cursor(pymysql.cursors.DictCursor) as cursor:
+            bar = query_bar(cursor, bar_id)
+            if not bar:
+                return None
+
+            open_hours_rows = query_open_hours(cursor, bar_id)
+            special_rows = query_specials(cursor, bar_id)
+
+        now = datetime.now(EASTERN_TZ)
+        effective_now = get_effective_now(now)
+        current_day_key = effective_now.strftime('%a').upper()
+        current_minutes = (effective_now.hour * 60) + effective_now.minute
+        if now.hour < 2:
+            current_minutes += 24 * 60
+        ordered_day_keys = get_ordered_day_keys(current_day_key)
+
+        open_hours = {}
+        for row in open_hours_rows:
+            day_key = row['day_of_week']
+            open_hours[day_key] = {
+                'open_time': to_time_string(row['open_time']),
+                'close_time': to_time_string(row['close_time']),
+                'display_text': build_hours_display_text(row['open_time'], row['close_time'], row['is_closed'])
+            }
+
+        specials = {}
+        specials_by_day = {day: [] for day in ordered_day_keys}
+
+        ordered_special_rows = sorted(
+            special_rows,
+            key=lambda row: (
+                (DAY_INDEX.get(row['day_of_week'], 0) - DAY_INDEX.get(current_day_key, 0)) % 7,
+                1 if row['all_day'] == 'Y' else 0,
+                to_minutes(row['start_time']) if to_minutes(row['start_time']) is not None else 10 ** 9,
+                row['special_id']
+            )
+        )
+
+        for row in ordered_special_rows:
+            special_id = str(row['special_id'])
+            day_key = row['day_of_week']
+            specials[special_id] = {
+                'bar_id': row['bar_id'],
+                'day': day_key,
+                'special_type': row['type'],
+                'description': row['description'],
+                'all_day': row['all_day'] == 'Y',
+                'start_time': to_time_string(row['start_time']),
+                'end_time': to_time_string(row['end_time']),
+                'current_status': get_special_status(day_key, row['all_day'], row['start_time'], row['end_time'], current_day_key, current_minutes)
+            }
+            specials_by_day.setdefault(day_key, []).append(special_id)
+
+        return {
+            'bar_details_payload': {
+                'bar': {
+                    'bar_id': bar['bar_id'],
+                    'name': bar['name'],
+                    'neighborhood': bar['neighborhood'],
+                    'image_url': bar['image_url']
+                },
+                'general_data': {
+                    'current_day': current_day_key,
+                    'generated_at': now.isoformat()
+                },
+                'open_hours': open_hours,
+                'specials': specials,
+                'specials_by_day': specials_by_day
+            }
+        }
+    finally:
+        conn.close()
+
+
+def lambda_handler(event, context):
+    query_params = (event or {}).get('queryStringParameters') or {}
+    bar_id = query_params.get('bar_id')
+
+    if not bar_id:
+        return {
+            'statusCode': 400,
+            'body': json.dumps({'error': 'bar_id is required'})
+        }
+
+    payload = build_bar_details_payload(bar_id=bar_id)
+    if payload is None:
+        return {
+            'statusCode': 404,
+            'body': json.dumps({'error': 'Bar not found'})
+        }
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps(payload)
+    }

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -20,11 +20,23 @@ def get_connection():
 
 # Query helpers
 def query_bars(cursor):
-    cursor.execute("SELECT bar_id, name, neighborhood, image_url FROM bar ORDER BY neighborhood, name")
+    cursor.execute("""
+        SELECT bar_id, name, neighborhood, image_url
+        FROM bar
+        WHERE is_active = 'Y'
+        ORDER BY neighborhood, name
+    """)
     return cursor.fetchall()
 
-def query_open_hours(cursor):
-    cursor.execute("SELECT bar_id, day_of_week, open_time, close_time, is_closed FROM open_hours")
+def query_open_hours(cursor, bar_ids=None):
+    if bar_ids:
+        placeholders = ', '.join(['%s'] * len(bar_ids))
+        cursor.execute(
+            f"SELECT bar_id, day_of_week, open_time, close_time, is_closed FROM open_hours WHERE bar_id IN ({placeholders})",
+            tuple(bar_ids)
+        )
+    else:
+        cursor.execute("SELECT bar_id, day_of_week, open_time, close_time, is_closed FROM open_hours")
     return cursor.fetchall()
 
 def query_specials(cursor):
@@ -177,6 +189,8 @@ def build_startup_payload(device_id=None):
             specials = query_specials(cursor)
             favorite_special_ids = query_device_favorite_special_ids(cursor, device_id)
 
+        active_bar_ids = {bar['bar_id'] for bar in bars}
+
         now = datetime.now(EASTERN_TZ)
         effective_now = get_effective_now(now)
         current_day_key = effective_now.strftime('%a').upper()
@@ -206,8 +220,12 @@ def build_startup_payload(device_id=None):
                 'has_special_this_week': False
             }
 
+        bars_with_specials = {row['bar_id'] for row in specials if row['bar_id'] in active_bar_ids}
+
         open_hours_lookup = {}
         for row in hours:
+            if row['bar_id'] not in bars_with_specials:
+                continue
             bar_id = str(row['bar_id'])
             if bar_id not in open_hours_lookup:
                 open_hours_lookup[bar_id] = {}

--- a/js/api.js
+++ b/js/api.js
@@ -1,4 +1,5 @@
 const STARTUP_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
+const BAR_DETAILS_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getBarDetails';
 const SPECIAL_REPORT_API_URL = 'https://3kz7x6tvvi.execute-api.us-east-2.amazonaws.com/default/insertUserReport';
 const UPDATE_DEVICE_FAVORITE_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite';
 
@@ -45,12 +46,19 @@ function buildStartupUrl() {
   return url.toString();
 }
 
+function buildBarDetailsUrl(barId) {
+  const url = new URL(BAR_DETAILS_API_URL);
+  url.searchParams.set('bar_id', String(barId));
+  return url.toString();
+}
+
 async function loadBars() {
   try {
     const response = await fetch(buildStartupUrl());
     const data = await response.json();
     const parsed = typeof data.body === 'string' ? JSON.parse(data.body) : data;
     startupPayload = parsed.startup_payload || null;
+    barDetailsById = {};
 
     barsData = startupPayload ? buildLegacyBarsData(startupPayload) : [];
     generateNeighborhoodFilters();
@@ -61,6 +69,24 @@ async function loadBars() {
     renderCurrentTabData();
     hideInitialLoadingOverlay();
   }
+}
+
+async function loadBarDetails(barId) {
+  const normalizedBarId = String(barId);
+  if (barDetailsById[normalizedBarId]) {
+    return barDetailsById[normalizedBarId];
+  }
+
+  const response = await fetch(buildBarDetailsUrl(normalizedBarId));
+  const data = await response.json();
+  const parsed = typeof data.body === 'string' ? JSON.parse(data.body) : data;
+  const payload = parsed.bar_details_payload || null;
+
+  if (payload) {
+    barDetailsById[normalizedBarId] = payload;
+  }
+
+  return payload;
 }
 
 async function persistFavoriteChangeInBackground(specialId, isFavorited) {

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -21,24 +21,10 @@ function getBarFromPayload(barOrId) {
   };
 }
 
-function showDetail(barOrId, previousScreen = currentTab) {
-  const selectedBar = getBarFromPayload(barOrId) || (typeof barOrId === 'object' ? barOrId : null);
-  if (!selectedBar) return;
-
-  previousScreenState = { type: previousScreen };
-  document.getElementById('home-screen').style.display = 'none';
-  document.getElementById('bars-screen').style.display = 'none';
-  document.getElementById('favorites-screen').style.display = 'none';
-  document.getElementById('special-screen').style.display = 'none';
-  document.getElementById('detail-screen').style.display = 'block';
-  setScreenLayout(false);
-
-  document.getElementById('detail-image').src = selectedBar.image_url || '';
-  document.getElementById('detail-name').textContent = (selectedBar.name || '').toUpperCase();
-
-  const todayKey = startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
+function renderBarDetailContent(selectedBar, detailPayload) {
+  const todayKey = detailPayload?.general_data?.current_day || startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
   const orderedDays = getOrderedDaysForDetail(todayKey);
-  const openHoursForBar = startupPayload?.open_hours?.[String(selectedBar.bar_id)] || {};
+  const openHoursForBar = detailPayload?.open_hours || {};
 
   const hoursEl = document.getElementById('detail-hours');
   const hoursEmptyEl = document.getElementById('detail-hours-empty');
@@ -80,9 +66,7 @@ function showDetail(barOrId, previousScreen = currentTab) {
 
   orderedDays.forEach((day) => {
     const dayKey = getDayKeyFromName(day);
-    const dayEntries = startupPayload?.specials_by_day?.[dayKey] || [];
-    const barEntry = dayEntries.find((entry) => String(entry.bar_id) === String(selectedBar.bar_id));
-    const specialIds = barEntry?.specials || [];
+    const specialIds = detailPayload?.specials_by_day?.[dayKey] || [];
 
     const wrapper = document.createElement('div');
     wrapper.className = 'day-group';
@@ -106,7 +90,7 @@ function showDetail(barOrId, previousScreen = currentTab) {
 
     if (specialIds.length > 0) {
       specialIds.forEach((specialId) => {
-        const specialData = startupPayload?.specials?.[String(specialId)];
+        const specialData = detailPayload?.specials?.[String(specialId)];
         if (!specialData) return;
 
         const special = {
@@ -161,4 +145,45 @@ function showDetail(barOrId, previousScreen = currentTab) {
       }
     };
   });
+}
+
+async function showDetail(barOrId, previousScreen = currentTab) {
+  const selectedBar = getBarFromPayload(barOrId) || (typeof barOrId === 'object' ? barOrId : null);
+  if (!selectedBar) return;
+
+  previousScreenState = { type: previousScreen };
+  document.getElementById('home-screen').style.display = 'none';
+  document.getElementById('bars-screen').style.display = 'none';
+  document.getElementById('favorites-screen').style.display = 'none';
+  document.getElementById('special-screen').style.display = 'none';
+  document.getElementById('detail-screen').style.display = 'block';
+  setScreenLayout(false);
+
+  document.getElementById('detail-image').src = selectedBar.image_url || '';
+  document.getElementById('detail-name').textContent = (selectedBar.name || '').toUpperCase();
+
+  const hoursEl = document.getElementById('detail-hours');
+  const hoursEmptyEl = document.getElementById('detail-hours-empty');
+  const specialsContainer = document.getElementById('detail-specials');
+
+  hoursEl.innerHTML = '';
+  hoursEl.style.display = 'none';
+  hoursEmptyEl.style.display = 'block';
+  hoursEmptyEl.textContent = 'Loading open hours...';
+  specialsContainer.innerHTML = '<div class="no-specials-line" style="padding:12px;">Loading specials...</div>';
+
+  try {
+    const detailPayload = await loadBarDetails(selectedBar.bar_id);
+    if (!detailPayload) {
+      hoursEmptyEl.textContent = 'No open hours found';
+      specialsContainer.innerHTML = '<div class="no-specials-line" style="padding:12px;">Unable to load bar details.</div>';
+      return;
+    }
+
+    renderBarDetailContent(selectedBar, detailPayload);
+  } catch (err) {
+    console.error('Failed to load bar details:', err);
+    hoursEmptyEl.textContent = 'No open hours found';
+    specialsContainer.innerHTML = '<div class="no-specials-line" style="padding:12px;">Unable to load bar details.</div>';
+  }
 }

--- a/js/state.js
+++ b/js/state.js
@@ -1,5 +1,6 @@
 let barsData = [];
 let startupPayload = null;
+let barDetailsById = {};
 const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 let currentTab = 'specials';
 let barsSearchQuery = '';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -167,6 +167,7 @@ function loadAppWithoutBoot(document) {
     console,
     document,
     window: { document, localStorage },
+    URL,
     localStorage,
     lucide: { createIcons() {} },
     fetch: async () => ({ json: async () => ({ bars: [] }) }),
@@ -212,6 +213,27 @@ function mountBaseNodes(document) {
   bars.setAttribute('id', 'bars-screen');
   const detail = document.createElement('div');
   detail.setAttribute('id', 'detail-screen');
+
+  const detailImage = document.createElement('img');
+  detailImage.setAttribute('id', 'detail-image');
+  detail.appendChild(detailImage);
+
+  const detailName = document.createElement('div');
+  detailName.setAttribute('id', 'detail-name');
+  detail.appendChild(detailName);
+
+  const detailHours = document.createElement('table');
+  detailHours.setAttribute('id', 'detail-hours');
+  detail.appendChild(detailHours);
+
+  const detailHoursEmpty = document.createElement('p');
+  detailHoursEmpty.setAttribute('id', 'detail-hours-empty');
+  detail.appendChild(detailHoursEmpty);
+
+  const detailSpecials = document.createElement('div');
+  detailSpecials.setAttribute('id', 'detail-specials');
+  detail.appendChild(detailSpecials);
+
   const special = document.createElement('div');
   special.setAttribute('id', 'special-screen');
   document.body.appendChild(home);
@@ -491,4 +513,71 @@ test('renderBarsWeek shows today through next 6 days and open status only for to
   const futureSpecialItem = cards[1].querySelector('.special-item');
   assert.equal(futureSpecialItem.classList.contains('live'), false, 'future all-day special should not render live styling');
   assert.equal(cards[1].querySelector('.active-dot'), null, 'future all-day special should not render active dot');
+});
+
+
+test('showDetail fetches and renders bar-specific hours and specials', async () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  const calls = [];
+  ctx.fetch = async (url) => {
+    calls.push(String(url));
+    return {
+      json: async () => ({
+        bar_details_payload: {
+          general_data: { current_day: 'MON' },
+          open_hours: {
+            MON: { display_text: '4:00 PM – 10:00 PM', open_time: '16:00', close_time: '22:00' }
+          },
+          specials: {
+            '11': {
+              bar_id: 1,
+              day: 'MON',
+              special_type: 'drink',
+              description: '$5 Beer',
+              all_day: false,
+              start_time: '16:00',
+              end_time: '18:00',
+              current_status: 'active'
+            }
+          },
+          specials_by_day: {
+            MON: ['11'],
+            TUE: [],
+            WED: [],
+            THU: [],
+            FRI: [],
+            SAT: [],
+            SUN: []
+          }
+        }
+      })
+    };
+  };
+
+  vm.runInContext(`
+    startupPayload = {
+      general_data: { current_day: 'MON' },
+      bars: {
+        '1': { name: 'Detail Bar', neighborhood: 'Downtown', image_url: 'bar.jpg', is_open_now: false, has_special_this_week: true }
+      },
+      open_hours: {},
+      specials: {},
+      specials_by_day: { MON: [], TUE: [], WED: [], THU: [], FRI: [], SAT: [], SUN: [] }
+    };
+  `, ctx);
+
+  await ctx.showDetail(1, 'bars');
+
+  assert.equal(calls.length, 1, 'fetches bar details on first open');
+  assert.match(calls[0], /getBarDetails/);
+  assert.doesNotMatch(calls[0], /device_id=/, 'does not send favorite-related device info to bar details endpoint');
+  assert.equal(document.getElementById('detail-name').textContent, 'DETAIL BAR');
+  assert.equal(document.getElementById('detail-hours').children.length > 0, true, 'renders fetched open hours');
+  assert.equal(document.querySelectorAll('.special-item').length > 0, true, 'renders fetched specials');
+
+  await ctx.showDetail(1, 'bars');
+  assert.equal(calls.length, 1, 'reuses cached bar details on second open');
 });


### PR DESCRIPTION
### Motivation
- Provide a dedicated per-bar details endpoint so the client can load open hours and specials on demand instead of bundling everything into the startup payload.
- Reduce startup payload size by only including active bars and only open-hours rows for bars that have an active special in the returned week view.
- Improve client UX by fetching and caching bar-specific details when the user opens a bar detail screen.

### Description
- Added a new Lambda function `functions/getBarDetails/get_bar_details.py` that returns open hours and specials for a single active bar and computes display times and special statuses.
- Updated `functions/getStartupData/get_startup_data.py` to only select `is_active = 'Y'` bars and to limit `open_hours` rows to bars that have specials in the week view.
- Updated frontend code: added `BAR_DETAILS_API_URL`, `buildBarDetailsUrl()`, `loadBarDetails()` and `barDetailsById` cache in `js/api.js` and `js/state.js`, refactored `js/render-bar-detail.js` to separate `renderBarDetailContent()` and make `showDetail()` fetch and render details asynchronously with basic loading/error UI, and wired the new API URL in `js/api.js`.
- Updated `README.md` to document the new `getBarDetails` behavior and the changed startup payload semantics.
- Added and updated unit tests in `tests/app.test.js` to cover fetching and caching of bar details and adjusted test DOM scaffolding for detail elements.

### Testing
- Ran the repository test suite with the updated tests (including `tests/app.test.js`) and the new `showDetail fetches and renders bar-specific hours and specials` test passed.
- Existing frontend-related unit tests were executed and continued to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab7fbbbd883308ae925526f99d556)