### PR TITLE
Add two-Lambda neighborhood bar sync: googleBarSync and dbBarSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,82 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 - Favorites are now persisted in the background whenever a user favorites/unfavorites a special.
 - Endpoint used by the web app:
   - `https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite`
+
+## New two-Lambda neighborhood bar sync flow
+
+### `googleBarSync`
+Purpose:
+- Runs outside the VPC.
+- Searches Google Places for bars in a neighborhood polygon.
+- Fetches images only for brand-new bars.
+- Uploads new images to S3 and returns only `image_path` back to the caller.
+- Never connects to MySQL directly.
+
+Expected input event:
+- `action = search_neighborhood_bars`
+- `neighborhood_name`
+- `polygon`
+- `search_center_lat`
+- `search_center_lng`
+- `search_radius`
+- optional `keyword` (defaults to `bar`)
+
+or:
+- `action = enrich_new_bars`
+- `new_bars`
+
+Expected output:
+- For `search_neighborhood_bars`: `bars[]` with `google_place_id`, `bar_name`, `address`, and `open_hours`.
+- For `enrich_new_bars`: `new_bars[]` with `image_path` added when an image upload succeeds.
+
+Required environment variables:
+- `GOOGLE_API_KEY`
+- `S3_BUCKET_NAME`
+- `BAR_IMAGE_FOLDER`
+
+### `dbBarSync`
+Purpose:
+- Runs inside the VPC.
+- Uses the same RDS environment variables and connection pattern as the repo's other DB Lambdas.
+- Categorizes incoming Google candidates into `new_bars` and `existing_bars`.
+- Inserts new bars and upserts open-hours rows.
+- Never calls Google APIs directly.
+
+Expected input event:
+- `action = categorize_bars`
+- `neighborhood_name`
+- `bars`
+
+or:
+- `action = apply_bar_updates`
+- `new_bars`
+- `existing_bars`
+
+Expected output:
+- For `categorize_bars`: `new_bars[]` and `existing_bars[]`, with `bar_id` added to existing bars.
+- For `apply_bar_updates`: counts for inserted bars, updated existing bars, inserted open-hours rows, and updated open-hours rows.
+
+Required environment variables:
+- `RDS_HOST`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_NAME`
+
+### Orchestration sequence
+1. Call `googleBarSync` with `action = search_neighborhood_bars`.
+2. Send its `bars` list to `dbBarSync` with `action = categorize_bars`.
+3. If `new_bars` is not empty, call `googleBarSync` with `action = enrich_new_bars`.
+4. Call `dbBarSync` with `action = apply_bar_updates` using enriched `new_bars` plus `existing_bars`.
+5. Existing bars still receive open-hours updates even when `new_bars` is empty.
+
+### Schema areas you may need to edit
+- `functions/dbBarSync/db_bar_sync.py`
+  - `BAR_TABLE` if your bar table has a different name.
+  - `OPEN_HOURS_TABLE` if your open-hours table has a different name.
+  - `insert_new_bars()` if your `bar` table requires additional columns such as `neighborhood`, `is_active`, or timestamps.
+  - `upsert_open_hours()` if your `open_hours` table uses different column names or a different unique key.
+  - `build_open_hours_rows()` if your open-hours table stores data in a different shape.
+
+### Required Python packages beyond the AWS Lambda standard environment
+- `requests`
+- `PyMySQL`

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -1,0 +1,262 @@
+import json
+import logging
+import os
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pymysql
+
+RDS_HOST = os.environ['RDS_HOST']
+DB_USER = os.environ['DB_USER']
+DB_PASSWORD = os.environ['DB_PASSWORD']
+DB_NAME = os.environ['DB_NAME']
+
+ALLOWED_ACTIONS = {'categorize_bars', 'apply_bar_updates'}
+BAR_TABLE = 'bar'
+OPEN_HOURS_TABLE = 'open_hours'
+DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class ValidationError(Exception):
+    pass
+
+
+def build_response(status_code: int, body: Dict) -> Dict:
+    return {
+        'statusCode': status_code,
+        'body': json.dumps(body),
+    }
+
+
+def get_connection():
+    return pymysql.connect(
+        host=RDS_HOST,
+        user=DB_USER,
+        passwd=DB_PASSWORD,
+        db=DB_NAME,
+        connect_timeout=5,
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=False,
+    )
+
+
+def require_bars_list(payload: Dict, field_name: str) -> List[Dict]:
+    bars = payload.get(field_name)
+    if not isinstance(bars, list):
+        raise ValidationError(f'"{field_name}" must be a list.')
+    return bars
+
+
+def normalize_open_hours(open_hours: Optional[Dict]) -> Dict[str, Dict]:
+    if not isinstance(open_hours, dict):
+        return {}
+
+    normalized = {}
+    for day_key, value in open_hours.items():
+        if day_key not in DAY_KEYS or not isinstance(value, dict):
+            continue
+        normalized[day_key] = {
+            'open_time': value.get('open_time'),
+            'close_time': value.get('close_time'),
+            'closed': bool(value.get('closed', False)),
+            'display_text': value.get('display_text'),
+        }
+    return normalized
+
+
+def fetch_existing_bars(cursor, google_place_ids: Sequence[str]) -> Dict[str, Dict]:
+    # Batch lookup keeps DB round-trips low during large neighborhood syncs.
+    if not google_place_ids:
+        return {}
+
+    placeholders = ', '.join(['%s'] * len(google_place_ids))
+    cursor.execute(
+        f"""
+        SELECT bar_id, google_place_id, image_path
+        FROM {BAR_TABLE}
+        WHERE google_place_id IN ({placeholders})
+        """,
+        tuple(google_place_ids),
+    )
+    rows = cursor.fetchall()
+    return {row['google_place_id']: row for row in rows}
+
+
+def categorize_bars(event: Dict) -> Dict:
+    # Compare Google candidates against DB state without making any external API calls here.
+    bars = require_bars_list(event, 'bars')
+    google_place_ids = [bar.get('google_place_id') for bar in bars if bar.get('google_place_id')]
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cursor:
+            existing_by_place_id = fetch_existing_bars(cursor, google_place_ids)
+    finally:
+        conn.close()
+
+    new_bars = []
+    existing_bars = []
+    for bar in bars:
+        google_place_id = bar.get('google_place_id')
+        if not google_place_id:
+            logger.warning('Skipping bar without google_place_id during categorization: %s', bar)
+            continue
+
+        normalized_bar = {
+            'google_place_id': google_place_id,
+            'bar_name': bar.get('bar_name'),
+            'address': bar.get('address'),
+            'open_hours': normalize_open_hours(bar.get('open_hours')),
+        }
+
+        existing_bar = existing_by_place_id.get(google_place_id)
+        if existing_bar:
+            normalized_bar['bar_id'] = existing_bar['bar_id']
+            existing_bars.append(normalized_bar)
+        else:
+            new_bars.append(normalized_bar)
+
+    return build_response(
+        200,
+        {
+            'status': 'success',
+            'action': 'categorize_bars',
+            'neighborhood_name': event.get('neighborhood_name'),
+            'new_bars': new_bars,
+            'existing_bars': existing_bars,
+        },
+    )
+
+
+def build_open_hours_rows(bar_id: int, open_hours: Dict[str, Dict]) -> List[Tuple]:
+    # Centralize the payload->row transform so schema tweaks only happen in one place.
+    rows = []
+    for day_key in DAY_KEYS:
+        hours = open_hours.get(day_key)
+        if not hours:
+            continue
+
+        is_closed = 'Y' if hours.get('closed') else 'N'
+        rows.append((
+            bar_id,
+            day_key,
+            hours.get('open_time'),
+            hours.get('close_time'),
+            is_closed,
+        ))
+    return rows
+
+
+def insert_new_bars(cursor, new_bars: List[Dict]) -> Dict[str, int]:
+    # Insert one bar at a time so we can reliably capture each new bar_id for open-hours inserts.
+    inserted_bar_ids = {}
+    if not new_bars:
+        return inserted_bar_ids
+
+    sql = f"""
+        INSERT INTO {BAR_TABLE} (name, address, google_place_id, image_path)
+        VALUES (%s, %s, %s, %s)
+    """
+
+    for bar in new_bars:
+        cursor.execute(
+            sql,
+            (
+                bar.get('bar_name'),
+                bar.get('address'),
+                bar.get('google_place_id'),
+                bar.get('image_path'),
+            ),
+        )
+        inserted_bar_ids[bar['google_place_id']] = cursor.lastrowid
+
+    return inserted_bar_ids
+
+
+def upsert_open_hours(cursor, rows: Iterable[Tuple]) -> int:
+    rows = list(rows)
+    if not rows:
+        return 0
+
+    # Adjust column names here if your open_hours schema differs.
+    sql = f"""
+        INSERT INTO {OPEN_HOURS_TABLE} (bar_id, day_of_week, open_time, close_time, is_closed)
+        VALUES (%s, %s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            open_time = VALUES(open_time),
+            close_time = VALUES(close_time),
+            is_closed = VALUES(is_closed)
+    """
+    return cursor.executemany(sql, rows)
+
+
+def apply_bar_updates(event: Dict) -> Dict:
+    # Persist both paths together so new inserts and hours updates share one transaction.
+    new_bars = require_bars_list(event, 'new_bars')
+    existing_bars = require_bars_list(event, 'existing_bars')
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cursor:
+            inserted_bar_ids = insert_new_bars(cursor, new_bars)
+
+            new_hours_rows = []
+            for bar in new_bars:
+                bar_id = inserted_bar_ids.get(bar.get('google_place_id'))
+                if not bar_id:
+                    continue
+                new_hours_rows.extend(build_open_hours_rows(bar_id, normalize_open_hours(bar.get('open_hours'))))
+
+            existing_hours_rows = []
+            for bar in existing_bars:
+                bar_id = bar.get('bar_id')
+                if not bar_id:
+                    continue
+                existing_hours_rows.extend(build_open_hours_rows(bar_id, normalize_open_hours(bar.get('open_hours'))))
+
+            upsert_open_hours(cursor, new_hours_rows)
+            upsert_open_hours(cursor, existing_hours_rows)
+            inserted_hours_count = len(new_hours_rows)
+            updated_hours_count = len(existing_hours_rows)
+            conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return build_response(
+        200,
+        {
+            'status': 'success',
+            'action': 'apply_bar_updates',
+            'new_bars_inserted': len(inserted_bar_ids),
+            'existing_bars_updated': len([bar for bar in existing_bars if bar.get('bar_id')]),
+            'open_hours_rows_inserted': inserted_hours_count,
+            'open_hours_rows_updated': updated_hours_count,
+        },
+    )
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    action = event.get('action')
+
+    try:
+        if action not in ALLOWED_ACTIONS:
+            raise ValidationError(f'Unsupported action "{action}". Allowed actions: {sorted(ALLOWED_ACTIONS)}')
+
+        if action == 'categorize_bars':
+            return categorize_bars(event)
+        if action == 'apply_bar_updates':
+            return apply_bar_updates(event)
+
+        raise ValidationError(f'Unhandled action "{action}"')
+    except ValidationError as exc:
+        logger.warning('Validation error: %s', exc)
+        return build_response(400, {'status': 'error', 'message': str(exc), 'action': action})
+    except Exception as exc:
+        logger.exception('Unexpected error in db_bar_sync action=%s', action)
+        return build_response(500, {'status': 'error', 'message': str(exc), 'action': action})

--- a/functions/googleBarSync/google_bar_sync.py
+++ b/functions/googleBarSync/google_bar_sync.py
@@ -1,0 +1,375 @@
+import json
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
+
+import boto3
+import requests
+
+GOOGLE_API_KEY = os.environ['GOOGLE_API_KEY']
+S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
+BAR_IMAGE_FOLDER = os.environ['BAR_IMAGE_FOLDER'].strip('/')
+
+GOOGLE_NEARBY_SEARCH_URL = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json'
+GOOGLE_PLACE_DETAILS_URL = 'https://maps.googleapis.com/maps/api/place/details/json'
+ALLOWED_ACTIONS = {'search_neighborhood_bars', 'enrich_new_bars'}
+DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+DAY_MAP = {0: 'SUN', 1: 'MON', 2: 'TUE', 3: 'WED', 4: 'THU', 5: 'FRI', 6: 'SAT'}
+CONTENT_TYPE_EXTENSION_MAP = {
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/png': '.png',
+    'image/webp': '.webp',
+    'image/gif': '.gif',
+}
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+s3_client = boto3.client('s3')
+
+
+class ValidationError(Exception):
+    pass
+
+
+class GooglePlacesError(Exception):
+    pass
+
+
+def build_response(status_code: int, body: Dict) -> Dict:
+    return {
+        'statusCode': status_code,
+        'body': json.dumps(body),
+    }
+
+
+def require_fields(payload: Dict, required_fields: List[str]) -> None:
+    missing = [field for field in required_fields if payload.get(field) in (None, '')]
+    if missing:
+        raise ValidationError(f'Missing required field(s): {missing}')
+
+
+def normalize_polygon(polygon: List[Dict]) -> List[Dict[str, float]]:
+    if not isinstance(polygon, list) or len(polygon) < 3:
+        raise ValidationError('"polygon" must contain at least 3 coordinate points.')
+
+    normalized = []
+    for point in polygon:
+        if not isinstance(point, dict) or 'lat' not in point or 'lng' not in point:
+            raise ValidationError('Each polygon point must include "lat" and "lng".')
+        normalized.append({'lat': float(point['lat']), 'lng': float(point['lng'])})
+
+    return normalized
+
+
+def point_in_polygon(lat: float, lng: float, polygon: List[Dict[str, float]]) -> bool:
+    inside = False
+    j = len(polygon) - 1
+
+    for i in range(len(polygon)):
+        yi = polygon[i]['lat']
+        xi = polygon[i]['lng']
+        yj = polygon[j]['lat']
+        xj = polygon[j]['lng']
+
+        intersects = ((yi > lat) != (yj > lat)) and (
+            lng < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi
+        )
+        if intersects:
+            inside = not inside
+        j = i
+
+    return inside
+
+
+def filter_places_by_polygon(places: List[Dict], polygon: List[Dict[str, float]]) -> List[Dict]:
+    # Keep only places whose lat/lng fall inside the caller-provided neighborhood boundary.
+    filtered = []
+    for place in places:
+        location = place.get('geometry', {}).get('location', {})
+        lat = location.get('lat')
+        lng = location.get('lng')
+        if lat is None or lng is None:
+            continue
+        if point_in_polygon(float(lat), float(lng), polygon):
+            filtered.append(place)
+    return filtered
+
+
+def fetch_nearby_places(search_center_lat: float, search_center_lng: float, search_radius: int, keyword: str) -> List[Dict]:
+    places = []
+    next_page_token = None
+
+    while True:
+        params = {
+            'location': f'{search_center_lat},{search_center_lng}',
+            'radius': int(search_radius),
+            'keyword': keyword,
+            'type': 'bar',
+            'key': GOOGLE_API_KEY,
+        }
+        if next_page_token:
+            params = {'pagetoken': next_page_token, 'key': GOOGLE_API_KEY}
+
+        response = requests.get(GOOGLE_NEARBY_SEARCH_URL, params=params, timeout=15)
+        response.raise_for_status()
+        payload = response.json()
+        status = payload.get('status')
+
+        if status == 'INVALID_REQUEST' and next_page_token:
+            import time
+            time.sleep(2)
+            continue
+        if status not in ('OK', 'ZERO_RESULTS'):
+            raise GooglePlacesError(payload.get('error_message') or status or 'Unknown nearby search error')
+
+        places.extend(payload.get('results', []))
+        if next_page_token and payload.get('results'):
+            import time
+            time.sleep(2)
+        next_page_token = payload.get('next_page_token')
+        if not next_page_token:
+            break
+
+    deduped_by_place_id = {}
+    for place in places:
+        place_id = place.get('place_id')
+        if place_id:
+            deduped_by_place_id[place_id] = place
+
+    return list(deduped_by_place_id.values())
+
+
+def fetch_place_details(place_id: str, fields: str) -> Dict:
+    response = requests.get(
+        GOOGLE_PLACE_DETAILS_URL,
+        params={
+            'place_id': place_id,
+            'fields': fields,
+            'key': GOOGLE_API_KEY,
+        },
+        timeout=15,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    status = payload.get('status')
+
+    if status not in ('OK', 'ZERO_RESULTS'):
+        raise GooglePlacesError(payload.get('error_message') or status or f'Failed to fetch details for {place_id}')
+
+    return payload.get('result', {})
+
+
+def parse_google_time(raw_time: Optional[str]) -> Optional[str]:
+    if not raw_time or len(raw_time) != 4:
+        return None
+    return f'{raw_time[:2]}:{raw_time[2:]}:00'
+
+
+def format_open_hours(periods: List[Dict]) -> Dict[str, Dict[str, Optional[str]]]:
+    # Mirror the app's existing open-hours shape so the DB lambda can persist rows directly.
+    hours_map = {}
+    for day_key in DAY_KEYS:
+        hours_map[day_key] = {
+            'open_time': None,
+            'close_time': None,
+            'closed': True,
+            'display_text': 'Closed',
+        }
+
+    for period in periods or []:
+        open_info = period.get('open') or {}
+        close_info = period.get('close') or {}
+        open_day = DAY_MAP.get(open_info.get('day'))
+        if not open_day:
+            continue
+
+        open_time = parse_google_time(open_info.get('time'))
+        close_time = parse_google_time(close_info.get('time'))
+
+        hours_map[open_day] = {
+            'open_time': open_time,
+            'close_time': close_time,
+            'closed': False,
+            'display_text': 'Hours unavailable' if not open_time or not close_time else f'{format_display_time(open_time)} – {format_display_time(close_time)}',
+        }
+
+    return hours_map
+
+
+def format_display_time(time_value: Optional[str]) -> Optional[str]:
+    if not time_value:
+        return None
+    hour_str, minute_str, *_ = time_value.split(':')
+    hour = int(hour_str)
+    minute = int(minute_str)
+    ampm = 'AM' if hour < 12 else 'PM'
+    hour = hour % 12
+    if hour == 0:
+        hour = 12
+    return f'{hour}:{minute:02d} {ampm}'
+
+
+def build_bar_record(place: Dict, place_details: Dict) -> Optional[Dict]:
+    place_id = place.get('place_id')
+    bar_name = (place.get('name') or '').strip()
+    address = (place.get('vicinity') or place.get('formatted_address') or '').strip()
+
+    if not place_id or not bar_name or not address:
+        return None
+
+    periods = place_details.get('opening_hours', {}).get('periods', [])
+    return {
+        'google_place_id': place_id,
+        'bar_name': bar_name,
+        'address': address,
+        'open_hours': format_open_hours(periods),
+    }
+
+
+def search_neighborhood_bars(event: Dict) -> Dict:
+    # This is the kickoff action for the whole sync flow.
+    require_fields(
+        event,
+        ['neighborhood_name', 'polygon', 'search_center_lat', 'search_center_lng', 'search_radius'],
+    )
+    keyword = (event.get('keyword') or 'bar').strip()
+    polygon = normalize_polygon(event['polygon'])
+    search_center_lat = float(event['search_center_lat'])
+    search_center_lng = float(event['search_center_lng'])
+    search_radius = int(event['search_radius'])
+
+    logger.info('Searching Google Places for neighborhood=%s keyword=%s radius=%s', event['neighborhood_name'], keyword, search_radius)
+    candidate_places = fetch_nearby_places(search_center_lat, search_center_lng, search_radius, keyword)
+    filtered_places = filter_places_by_polygon(candidate_places, polygon)
+
+    bars = []
+    # Pull only the fields the DB lambda needs for categorization and later persistence.
+    for place in filtered_places:
+        place_id = place.get('place_id')
+        if not place_id:
+            continue
+        try:
+            details = fetch_place_details(place_id, 'opening_hours')
+            record = build_bar_record(place, details)
+            if record:
+                bars.append(record)
+        except Exception as exc:
+            logger.warning('Skipping place_id=%s because details lookup failed: %s', place_id, exc)
+
+    bars.sort(key=lambda row: (row['bar_name'].lower(), row['google_place_id']))
+    return build_response(
+        200,
+        {
+            'status': 'success',
+            'action': 'search_neighborhood_bars',
+            'neighborhood_name': event['neighborhood_name'],
+            'candidate_count': len(candidate_places),
+            'matched_count': len(bars),
+            'bars': bars,
+        },
+    )
+
+
+def get_photo_reference(place_id: str) -> Optional[str]:
+    details = fetch_place_details(place_id, 'photos')
+    photos = details.get('photos') or []
+    if not photos:
+        return None
+    return photos[0].get('photo_reference')
+
+
+def map_content_type_to_extension(content_type: Optional[str]) -> str:
+    normalized = (content_type or '').split(';', 1)[0].strip().lower()
+    return CONTENT_TYPE_EXTENSION_MAP.get(normalized, '.jpg')
+
+
+def fetch_google_place_image(place_id: str) -> Tuple[Optional[bytes], Optional[str]]:
+    photo_reference = get_photo_reference(place_id)
+    if not photo_reference:
+        return None, None
+
+    response = requests.get(
+        'https://maps.googleapis.com/maps/api/place/photo',
+        params={
+            'maxwidth': 1600,
+            'photo_reference': photo_reference,
+            'key': GOOGLE_API_KEY,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.content, response.headers.get('Content-Type')
+
+
+def upload_image_to_s3(image_bytes: bytes, google_place_id: str, content_type: Optional[str]) -> str:
+    # Key format intentionally uses google_place_id so image lookup stays deterministic across runs.
+    extension = map_content_type_to_extension(content_type)
+    key = f'{BAR_IMAGE_FOLDER}/{google_place_id}{extension}'
+    s3_client.put_object(
+        Bucket=S3_BUCKET_NAME,
+        Key=key,
+        Body=image_bytes,
+        ContentType=(content_type or 'image/jpeg'),
+    )
+    return key
+
+
+def enrich_new_bars(event: Dict) -> Dict:
+    new_bars = event.get('new_bars') or []
+    if not isinstance(new_bars, list):
+        raise ValidationError('"new_bars" must be a list.')
+
+    enriched_bars = []
+    # Best-effort enrichment: one failed image should not block the rest of the batch.
+    for bar in new_bars:
+        google_place_id = bar.get('google_place_id')
+        if not google_place_id:
+            logger.warning('Skipping new bar with missing google_place_id: %s', bar)
+            continue
+
+        enriched_bar = dict(bar)
+        enriched_bar['image_path'] = None
+        try:
+            image_bytes, content_type = fetch_google_place_image(google_place_id)
+            if image_bytes:
+                enriched_bar['image_path'] = upload_image_to_s3(image_bytes, google_place_id, content_type)
+        except Exception as exc:
+            logger.warning('Image enrichment failed for place_id=%s: %s', google_place_id, exc)
+
+        enriched_bars.append(enriched_bar)
+
+    return build_response(
+        200,
+        {
+            'status': 'success',
+            'action': 'enrich_new_bars',
+            'new_bars': enriched_bars,
+        },
+    )
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    action = event.get('action')
+
+    try:
+        if action not in ALLOWED_ACTIONS:
+            raise ValidationError(f'Unsupported action "{action}". Allowed actions: {sorted(ALLOWED_ACTIONS)}')
+
+        if action == 'search_neighborhood_bars':
+            return search_neighborhood_bars(event)
+        if action == 'enrich_new_bars':
+            return enrich_new_bars(event)
+
+        raise ValidationError(f'Unhandled action "{action}"')
+    except ValidationError as exc:
+        logger.warning('Validation error: %s', exc)
+        return build_response(400, {'status': 'error', 'message': str(exc), 'action': action})
+    except requests.RequestException as exc:
+        logger.exception('Google request failed for action=%s', action)
+        return build_response(502, {'status': 'error', 'message': str(exc), 'action': action})
+    except Exception as exc:
+        logger.exception('Unexpected error in google_bar_sync action=%s', action)
+        return build_response(500, {'status': 'error', 'message': str(exc), 'action': action})


### PR DESCRIPTION
### Motivation

- Introduce a split sync flow that isolates Google Places API calls from database access so image fetching can run outside the VPC while DB writes run inside the VPC.
- Provide a reliable neighborhood-level discovery and persistence path for bars and their open-hours to reduce manual imports and keep data up-to-date.

### Description

- Add `functions/googleBarSync/google_bar_sync.py` implementing `search_neighborhood_bars` to query and filter Google Places within a polygon and `enrich_new_bars` to fetch and upload images to S3, returning `image_path` for enriched bars.
- Add `functions/dbBarSync/db_bar_sync.py` implementing `categorize_bars` to split Google candidates into `new_bars` and `existing_bars` and `apply_bar_updates` to insert new bars and upsert `open_hours` rows within a single transaction.
- Update `README.md` with orchestration steps, required environment variables (`GOOGLE_API_KEY`, `S3_BUCKET_NAME`, `BAR_IMAGE_FOLDER`, `RDS_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`), schema extension points (`BAR_TABLE`, `OPEN_HOURS_TABLE`, `insert_new_bars()`, `upsert_open_hours()`, `build_open_hours_rows()`), and required Python packages (`requests`, `PyMySQL`).
- Implement polygon point-in-polygon filtering, Google details/fetch logic, image content-type handling and deterministic S3 keying by `google_place_id`, and DB batching/transaction logic using `pymysql` with structured JSON HTTP-style responses from each Lambda.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd9298825083308f9ba251e6914475)