### PR TITLE
Add googleBarSync and dbBarSync Lambdas for neighborhood bar sync flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,88 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 - Favorites are now persisted in the background whenever a user favorites/unfavorites a special.
 - Endpoint used by the web app:
   - `https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite`
+
+## New two-Lambda neighborhood bar sync flow
+
+### `googleBarSync`
+Purpose:
+- Runs outside the VPC.
+- Kicks off the full sync flow.
+- Looks up the neighborhood polygon and search settings from code using `neighborhood_name`.
+- Calls Google Places and uploads images to S3.
+- Invokes `dbBarSync` directly for categorization and persistence.
+- Never connects to MySQL directly.
+
+Expected input event:
+- `action = sync_neighborhood_bars` to kick off the full Google -> DB flow
+- `neighborhood_name`
+- optional `keyword` override
+
+Also supports:
+- `action = search_neighborhood_bars` with `neighborhood_name` for search-only behavior
+- `action = enrich_new_bars` with `new_bars` for image enrichment only
+
+Expected output:
+- For `sync_neighborhood_bars`: combined search, categorization, enrichment, and DB update summaries.
+- For `search_neighborhood_bars`: `bars[]` with `google_place_id`, `bar_name`, `address`, and `open_hours`.
+- For `enrich_new_bars`: `new_bars[]` with `image_path` added when an image upload succeeds.
+
+Required environment variables:
+- `GOOGLE_API_KEY`
+- `S3_BUCKET_NAME`
+- `BAR_IMAGE_FOLDER`
+- `DB_BAR_SYNC_FUNCTION_NAME`
+
+Neighborhood config note:
+- The kickoff event should only send the neighborhood name.
+- The polygon, search center, and radius are stored in `functions/googleBarSync/google_bar_sync.py` in `NEIGHBORHOOD_CONFIGS`.
+- The current implementation includes a `downtown` config and is structured so more neighborhoods can be added in the same place.
+
+### `dbBarSync`
+Purpose:
+- Runs inside the VPC.
+- Uses the same RDS environment variables and connection pattern as the repo's other DB Lambdas.
+- Categorizes incoming Google candidates into `new_bars` and `existing_bars`.
+- Inserts new bars and upserts open-hours rows.
+- Never calls Google APIs directly.
+
+Expected input event:
+- `action = categorize_bars`
+- `neighborhood_name`
+- `bars`
+
+or:
+- `action = apply_bar_updates`
+- `new_bars`
+- `existing_bars`
+
+Expected output:
+- For `categorize_bars`: `new_bars[]` and `existing_bars[]`, with `bar_id` added to existing bars.
+- For `apply_bar_updates`: counts for inserted bars, updated existing bars, inserted open-hours rows, and updated open-hours rows.
+
+Required environment variables:
+- `RDS_HOST`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_NAME`
+
+### Orchestration sequence
+1. Call `googleBarSync` with `action = sync_neighborhood_bars` and `neighborhood_name`.
+2. `googleBarSync` loads that neighborhood's polygon and search settings from `NEIGHBORHOOD_CONFIGS`.
+3. `googleBarSync` searches Google Places, filters results to the stored polygon, and formats open hours.
+4. `googleBarSync` invokes `dbBarSync` with `action = categorize_bars`.
+5. If `new_bars` is not empty, `googleBarSync` enriches only those bars with S3 image paths.
+6. `googleBarSync` invokes `dbBarSync` again with `action = apply_bar_updates`.
+7. Existing bars still receive open-hours updates even when `new_bars` is empty.
+
+### Schema areas you may need to edit
+- `functions/dbBarSync/db_bar_sync.py`
+  - `BAR_TABLE` if your bar table has a different name.
+  - `OPEN_HOURS_TABLE` if your open-hours table has a different name.
+  - `insert_new_bars()` if your `bar` table requires additional columns such as `neighborhood`, `is_active`, or timestamps.
+  - `upsert_open_hours()` if your `open_hours` table uses different column names or a different unique key.
+  - `build_open_hours_rows()` if your open-hours table stores data in a different shape.
+
+### Required Python packages beyond the AWS Lambda standard environment
+- `requests`
+- `PyMySQL`

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -1,0 +1,243 @@
+import json
+import logging
+import os
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+import pymysql
+
+RDS_HOST = os.environ['RDS_HOST']
+DB_USER = os.environ['DB_USER']
+DB_PASSWORD = os.environ['DB_PASSWORD']
+DB_NAME = os.environ['DB_NAME']
+
+ALLOWED_ACTIONS = {'categorize_bars', 'apply_bar_updates'}
+BAR_TABLE = 'bar'
+OPEN_HOURS_TABLE = 'open_hours'
+DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+class ValidationError(Exception):
+    pass
+
+
+def build_response(status_code: int, body: Dict) -> Dict:
+    return {'statusCode': status_code, 'body': json.dumps(body)}
+
+
+def get_connection():
+    return pymysql.connect(
+        host=RDS_HOST,
+        user=DB_USER,
+        passwd=DB_PASSWORD,
+        db=DB_NAME,
+        connect_timeout=5,
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=False,
+    )
+
+
+def require_bars_list(payload: Dict, field_name: str) -> List[Dict]:
+    bars = payload.get(field_name)
+    if not isinstance(bars, list):
+        raise ValidationError(f'"{field_name}" must be a list.')
+    return bars
+
+
+# Support the repo's existing fetchGoogleApiHours shape:
+#   {"MON": "CLOSED"}
+#   {"TUE": ["17:00:00", "23:00:00"]}
+def normalize_open_hours(open_hours) -> Dict[str, Dict]:
+    if not isinstance(open_hours, dict):
+        return {}
+
+    normalized = {}
+    for day_key in DAY_KEYS:
+        value = open_hours.get(day_key)
+        if value == 'CLOSED':
+            normalized[day_key] = {'open_time': None, 'close_time': None, 'is_closed': 'Y'}
+        elif isinstance(value, list) and len(value) == 2:
+            normalized[day_key] = {
+                'open_time': value[0],
+                'close_time': value[1],
+                'is_closed': 'N',
+            }
+    return normalized
+
+
+def fetch_existing_bars(cursor, google_place_ids: Sequence[str]) -> Dict[str, Dict]:
+    if not google_place_ids:
+        return {}
+
+    placeholders = ', '.join(['%s'] * len(google_place_ids))
+    cursor.execute(
+        f"""
+        SELECT bar_id, google_place_id, image_path
+        FROM {BAR_TABLE}
+        WHERE google_place_id IN ({placeholders})
+        """,
+        tuple(google_place_ids),
+    )
+    return {row['google_place_id']: row for row in cursor.fetchall()}
+
+
+def categorize_bars(event: Dict) -> Dict:
+    bars = require_bars_list(event, 'bars')
+    google_place_ids = [bar.get('google_place_id') for bar in bars if bar.get('google_place_id')]
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cursor:
+            existing_by_place_id = fetch_existing_bars(cursor, google_place_ids)
+    finally:
+        conn.close()
+
+    new_bars = []
+    existing_bars = []
+    for bar in bars:
+        google_place_id = bar.get('google_place_id')
+        if not google_place_id:
+            logger.warning('Skipping bar without google_place_id during categorization: %s', bar)
+            continue
+
+        normalized_bar = {
+            'google_place_id': google_place_id,
+            'bar_name': bar.get('bar_name'),
+            'address': bar.get('address'),
+            'open_hours': normalize_open_hours(bar.get('open_hours')),
+        }
+        existing_bar = existing_by_place_id.get(google_place_id)
+        if existing_bar:
+            normalized_bar['bar_id'] = existing_bar['bar_id']
+            existing_bars.append(normalized_bar)
+        else:
+            new_bars.append(normalized_bar)
+
+    return {
+        'status': 'success',
+        'action': 'categorize_bars',
+        'neighborhood_name': event.get('neighborhood_name'),
+        'new_bars': new_bars,
+        'existing_bars': existing_bars,
+    }
+
+
+def build_open_hours_rows(bar_id: int, open_hours: Dict[str, Dict]) -> List[Tuple]:
+    rows = []
+    for day_key in DAY_KEYS:
+        hours = open_hours.get(day_key)
+        if not hours:
+            continue
+        rows.append((
+            bar_id,
+            day_key,
+            hours.get('open_time'),
+            hours.get('close_time'),
+            hours.get('is_closed', 'N'),
+        ))
+    return rows
+
+
+def insert_new_bars(cursor, new_bars: List[Dict]) -> Dict[str, int]:
+    inserted_bar_ids = {}
+    if not new_bars:
+        return inserted_bar_ids
+
+    sql = f"""
+        INSERT INTO {BAR_TABLE} (name, address, google_place_id, image_path)
+        VALUES (%s, %s, %s, %s)
+    """
+
+    for bar in new_bars:
+        cursor.execute(
+            sql,
+            (
+                bar.get('bar_name'),
+                bar.get('address'),
+                bar.get('google_place_id'),
+                bar.get('image_path'),
+            ),
+        )
+        inserted_bar_ids[bar['google_place_id']] = cursor.lastrowid
+
+    return inserted_bar_ids
+
+
+def upsert_open_hours(cursor, rows: Iterable[Tuple]) -> int:
+    rows = list(rows)
+    if not rows:
+        return 0
+
+    sql = f"""
+        INSERT INTO {OPEN_HOURS_TABLE} (bar_id, day_of_week, open_time, close_time, is_closed)
+        VALUES (%s, %s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            open_time = VALUES(open_time),
+            close_time = VALUES(close_time),
+            is_closed = VALUES(is_closed)
+    """
+    return cursor.executemany(sql, rows)
+
+
+def apply_bar_updates(event: Dict) -> Dict:
+    new_bars = require_bars_list(event, 'new_bars')
+    existing_bars = require_bars_list(event, 'existing_bars')
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cursor:
+            inserted_bar_ids = insert_new_bars(cursor, new_bars)
+
+            new_hours_rows = []
+            for bar in new_bars:
+                bar_id = inserted_bar_ids.get(bar.get('google_place_id'))
+                if bar_id:
+                    new_hours_rows.extend(build_open_hours_rows(bar_id, normalize_open_hours(bar.get('open_hours'))))
+
+            existing_hours_rows = []
+            for bar in existing_bars:
+                bar_id = bar.get('bar_id')
+                if bar_id:
+                    existing_hours_rows.extend(build_open_hours_rows(bar_id, normalize_open_hours(bar.get('open_hours'))))
+
+            upsert_open_hours(cursor, new_hours_rows)
+            upsert_open_hours(cursor, existing_hours_rows)
+            conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return {
+        'status': 'success',
+        'action': 'apply_bar_updates',
+        'new_bars_inserted': len(inserted_bar_ids),
+        'existing_bars_updated': len([bar for bar in existing_bars if bar.get('bar_id')]),
+        'open_hours_rows_inserted': len(new_hours_rows),
+        'open_hours_rows_updated': len(existing_hours_rows),
+    }
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    action = event.get('action')
+
+    try:
+        if action not in ALLOWED_ACTIONS:
+            raise ValidationError(f'Unsupported action "{action}". Allowed actions: {sorted(ALLOWED_ACTIONS)}')
+
+        if action == 'categorize_bars':
+            return build_response(200, categorize_bars(event))
+        if action == 'apply_bar_updates':
+            return build_response(200, apply_bar_updates(event))
+
+        raise ValidationError(f'Unhandled action "{action}"')
+    except ValidationError as exc:
+        logger.warning('Validation error: %s', exc)
+        return build_response(400, {'status': 'error', 'message': str(exc), 'action': action})
+    except Exception as exc:
+        logger.exception('Unhandled exception in dbBarSync')
+        return build_response(500, {'status': 'error', 'message': str(exc), 'action': action})

--- a/functions/googleBarSync/google_bar_sync.py
+++ b/functions/googleBarSync/google_bar_sync.py
@@ -1,0 +1,428 @@
+import json
+import logging
+import os
+import time
+from typing import Dict, List, Optional, Tuple
+
+import boto3
+import requests
+
+GOOGLE_API_KEY = os.environ['GOOGLE_API_KEY']
+S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
+BAR_IMAGE_FOLDER = os.environ['BAR_IMAGE_FOLDER'].strip('/')
+DB_BAR_SYNC_FUNCTION_NAME = os.environ['DB_BAR_SYNC_FUNCTION_NAME']
+
+GOOGLE_NEARBY_SEARCH_URL = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json'
+GOOGLE_PLACE_DETAILS_URL = 'https://maps.googleapis.com/maps/api/place/details/json'
+GOOGLE_PLACE_PHOTO_URL = 'https://maps.googleapis.com/maps/api/place/photo'
+ALLOWED_ACTIONS = {'search_neighborhood_bars', 'enrich_new_bars', 'sync_neighborhood_bars'}
+DAY_MAP = {0: 'SUN', 1: 'MON', 2: 'TUE', 3: 'WED', 4: 'THU', 5: 'FRI', 6: 'SAT'}
+ALL_DAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+CONTENT_TYPE_EXTENSION_MAP = {
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/png': '.png',
+    'image/webp': '.webp',
+    'image/gif': '.gif',
+}
+
+# Keep this neighborhood config in code, matching the older neighborhood-driven flow.
+NEIGHBORHOOD_CONFIGS = {
+    "downtown": {
+        "neighborhood_name": "Downtown",
+        "search_center_lat": 40.4418,
+        "search_center_lng": -79.9959,
+        "search_radius": 1800,
+        "keyword": "bar",
+        "polygon": [
+            {"lat": 40.442357, "lng": -80.015060},
+            {"lat": 40.447582, "lng": -79.994819},
+            {"lat": 40.443094, "lng": -79.991779},
+            {"lat": 40.434590, "lng": -79.996123},
+            {"lat": 40.442357, "lng": -80.015060},
+        ],
+    },
+}
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+s3_client = boto3.client('s3')
+lambda_client = boto3.client('lambda')
+
+
+class ValidationError(Exception):
+    pass
+
+
+class GooglePlacesError(Exception):
+    pass
+
+
+def build_response(status_code: int, body: Dict) -> Dict:
+    return {'statusCode': status_code, 'body': json.dumps(body)}
+
+
+def parse_lambda_body(response: Dict) -> Dict:
+    body = response.get('body', '{}')
+    if isinstance(body, str):
+        return json.loads(body)
+    return body if isinstance(body, dict) else {}
+
+
+def require_neighborhood_name(event: Dict) -> str:
+    neighborhood_name = (event.get('neighborhood_name') or event.get('neighborhood') or '').strip()
+    if not neighborhood_name:
+        raise ValidationError('Event field "neighborhood_name" is required.')
+    return neighborhood_name
+
+
+def get_neighborhood_config(neighborhood_name: str) -> Dict:
+    config = NEIGHBORHOOD_CONFIGS.get(neighborhood_name.strip().lower())
+    if not config:
+        supported = sorted(NEIGHBORHOOD_CONFIGS.keys())
+        raise ValidationError(
+            f'Unsupported neighborhood "{neighborhood_name}". Supported neighborhoods: {supported}'
+        )
+    return config
+
+
+def point_in_polygon(lat: float, lng: float, polygon: List[Dict[str, float]]) -> bool:
+    inside = False
+    j = len(polygon) - 1
+
+    for i in range(len(polygon)):
+        yi = polygon[i]['lat']
+        xi = polygon[i]['lng']
+        yj = polygon[j]['lat']
+        xj = polygon[j]['lng']
+
+        intersects = ((yi > lat) != (yj > lat)) and (
+            lng < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi
+        )
+        if intersects:
+            inside = not inside
+        j = i
+
+    return inside
+
+
+def filter_places_by_polygon(places: List[Dict], polygon: List[Dict[str, float]]) -> List[Dict]:
+    filtered = []
+    for place in places:
+        location = place.get('geometry', {}).get('location', {})
+        lat = location.get('lat')
+        lng = location.get('lng')
+        if lat is None or lng is None:
+            continue
+        if point_in_polygon(float(lat), float(lng), polygon):
+            filtered.append(place)
+    return filtered
+
+
+def fetch_nearby_places(search_center_lat: float, search_center_lng: float, search_radius: int, keyword: str) -> List[Dict]:
+    places = []
+    next_page_token = None
+
+    while True:
+        params = {
+            'location': f'{search_center_lat},{search_center_lng}',
+            'radius': int(search_radius),
+            'keyword': keyword,
+            'type': 'bar',
+            'key': GOOGLE_API_KEY,
+        }
+        if next_page_token:
+            params = {'pagetoken': next_page_token, 'key': GOOGLE_API_KEY}
+
+        response = requests.get(GOOGLE_NEARBY_SEARCH_URL, params=params, timeout=15)
+        response.raise_for_status()
+        payload = response.json()
+        status = payload.get('status')
+
+        if status == 'INVALID_REQUEST' and next_page_token:
+            time.sleep(2)
+            continue
+        if status not in ('OK', 'ZERO_RESULTS'):
+            raise GooglePlacesError(payload.get('error_message') or status or 'Unknown nearby search error')
+
+        places.extend(payload.get('results', []))
+        next_page_token = payload.get('next_page_token')
+        if not next_page_token:
+            break
+        time.sleep(2)
+
+    deduped = {}
+    for place in places:
+        place_id = place.get('place_id')
+        if place_id:
+            deduped[place_id] = place
+    return list(deduped.values())
+
+
+def fetch_place_details(place_id: str, fields: str) -> Dict:
+    response = requests.get(
+        GOOGLE_PLACE_DETAILS_URL,
+        params={'place_id': place_id, 'fields': fields, 'key': GOOGLE_API_KEY},
+        timeout=15,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    status = payload.get('status')
+
+    if status not in ('OK', 'ZERO_RESULTS'):
+        raise GooglePlacesError(payload.get('error_message') or status or f'Failed to fetch details for {place_id}')
+
+    return payload.get('result', {})
+
+
+def parse_google_time(raw_time: Optional[str]) -> Optional[str]:
+    if not raw_time or len(raw_time) != 4:
+        return None
+    return f'{raw_time[:2]}:{raw_time[2:]}:00'
+
+
+# Match the older fetchGoogleApiHours shape as closely as possible: each day is either
+# "CLOSED" or a two-item [open_time, close_time] list.
+def format_open_hours(periods: List[Dict]) -> Dict[str, object]:
+    hours_map = {day: 'CLOSED' for day in ALL_DAYS}
+
+    for period in periods or []:
+        open_info = period.get('open') or {}
+        close_info = period.get('close') or {}
+        open_day = DAY_MAP.get(open_info.get('day'))
+        if not open_day:
+            continue
+
+        open_time = parse_google_time(open_info.get('time'))
+        close_time = parse_google_time(close_info.get('time')) if close_info else None
+        hours_map[open_day] = [open_time, close_time]
+
+    return hours_map
+
+
+def build_bar_record(place: Dict, place_details: Dict) -> Optional[Dict]:
+    place_id = place.get('place_id')
+    bar_name = (place.get('name') or '').strip()
+    address = (place.get('vicinity') or place.get('formatted_address') or '').strip()
+
+    if not place_id or not bar_name or not address:
+        return None
+
+    return {
+        'google_place_id': place_id,
+        'bar_name': bar_name,
+        'address': address,
+        'open_hours': format_open_hours(place_details.get('opening_hours', {}).get('periods', [])),
+    }
+
+
+def search_neighborhood_bars(event: Dict) -> Dict:
+    neighborhood_name = require_neighborhood_name(event)
+    config = get_neighborhood_config(neighborhood_name)
+
+    keyword = (event.get('keyword') or config.get('keyword') or 'bar').strip()
+    candidate_places = fetch_nearby_places(
+        config['search_center_lat'],
+        config['search_center_lng'],
+        config['search_radius'],
+        keyword,
+    )
+    matched_places = filter_places_by_polygon(candidate_places, config['polygon'])
+
+    bars = []
+    for place in matched_places:
+        place_id = place.get('place_id')
+        if not place_id:
+            continue
+        details = fetch_place_details(place_id, 'opening_hours')
+        bar_record = build_bar_record(place, details)
+        if bar_record:
+            bars.append(bar_record)
+
+    return {
+        'status': 'success',
+        'action': 'search_neighborhood_bars',
+        'neighborhood_name': config['neighborhood_name'],
+        'candidate_count': len(candidate_places),
+        'matched_count': len(bars),
+        'bars': bars,
+    }
+
+
+def get_photo_media(place_id: str) -> Tuple[Optional[bytes], Optional[str]]:
+    details = fetch_place_details(place_id, 'photos')
+    photos = details.get('photos', [])
+    if not photos:
+        return None, None
+
+    photo_reference = photos[0].get('photo_reference')
+    if not photo_reference:
+        return None, None
+
+    response = requests.get(
+        GOOGLE_PLACE_PHOTO_URL,
+        params={
+            'photoreference': photo_reference,
+            'maxwidth': 1200,
+            'key': GOOGLE_API_KEY,
+        },
+        timeout=30,
+        allow_redirects=True,
+    )
+    response.raise_for_status()
+    content_type = response.headers.get('Content-Type', '').split(';')[0].strip().lower()
+    return response.content, content_type
+
+
+def content_type_to_extension(content_type: Optional[str]) -> str:
+    return CONTENT_TYPE_EXTENSION_MAP.get(content_type or '', '.jpg')
+
+
+def build_s3_key(folder: str, place_id: str, extension: str) -> str:
+    return f'{folder}/{place_id}{extension}' if folder else f'{place_id}{extension}'
+
+
+def upload_image_to_s3(image_bytes: bytes, content_type: str, s3_key: str) -> None:
+    s3_client.put_object(
+        Bucket=S3_BUCKET_NAME,
+        Key=s3_key,
+        Body=image_bytes,
+        ContentType=content_type or 'image/jpeg',
+    )
+
+
+def enrich_new_bars(event: Dict) -> Dict:
+    new_bars = event.get('new_bars')
+    if not isinstance(new_bars, list):
+        raise ValidationError('"new_bars" must be a list.')
+
+    enriched_bars = []
+    for bar in new_bars:
+        enriched_bar = {
+            'google_place_id': bar.get('google_place_id'),
+            'bar_name': bar.get('bar_name'),
+            'address': bar.get('address'),
+            'open_hours': bar.get('open_hours'),
+            'image_path': None,
+        }
+        place_id = enriched_bar['google_place_id']
+
+        if not place_id:
+            logger.warning('Skipping image enrichment for bar without google_place_id: %s', bar)
+            enriched_bars.append(enriched_bar)
+            continue
+
+        try:
+            image_bytes, content_type = get_photo_media(place_id)
+            if image_bytes:
+                extension = content_type_to_extension(content_type)
+                s3_key = build_s3_key(BAR_IMAGE_FOLDER, place_id, extension)
+                upload_image_to_s3(image_bytes, content_type or 'image/jpeg', s3_key)
+                enriched_bar['image_path'] = s3_key
+        except Exception as exc:
+            logger.warning('Image enrichment failed for %s: %s', place_id, exc)
+
+        enriched_bars.append(enriched_bar)
+
+    return {
+        'status': 'success',
+        'action': 'enrich_new_bars',
+        'new_bars': enriched_bars,
+    }
+
+
+def invoke_db_bar_sync(payload: Dict) -> Dict:
+    response = lambda_client.invoke(
+        FunctionName=DB_BAR_SYNC_FUNCTION_NAME,
+        InvocationType='RequestResponse',
+        Payload=json.dumps(payload).encode('utf-8'),
+    )
+    payload_bytes = response['Payload'].read()
+    lambda_payload = json.loads(payload_bytes or '{}')
+    status_code = int(lambda_payload.get('statusCode', 500))
+    body = parse_lambda_body(lambda_payload)
+
+    if status_code >= 400:
+        raise RuntimeError(f'DB lambda action {payload.get("action")} failed: {body}')
+
+    return body
+
+
+def sync_neighborhood_bars(event: Dict) -> Dict:
+    neighborhood_name = require_neighborhood_name(event)
+    search_payload = search_neighborhood_bars({'neighborhood_name': neighborhood_name, 'keyword': event.get('keyword')})
+
+    categorized = invoke_db_bar_sync(
+        {
+            'action': 'categorize_bars',
+            'neighborhood_name': search_payload['neighborhood_name'],
+            'bars': search_payload['bars'],
+        }
+    )
+
+    new_bars = categorized.get('new_bars', [])
+    existing_bars = categorized.get('existing_bars', [])
+    if new_bars:
+        enrich_result = enrich_new_bars({'new_bars': new_bars})
+        new_bars = enrich_result['new_bars']
+
+    applied = invoke_db_bar_sync(
+        {
+            'action': 'apply_bar_updates',
+            'new_bars': new_bars,
+            'existing_bars': existing_bars,
+        }
+    )
+
+    return {
+        'status': 'success',
+        'action': 'sync_neighborhood_bars',
+        'neighborhood_name': search_payload['neighborhood_name'],
+        'search_summary': {
+            'candidate_count': search_payload['candidate_count'],
+            'matched_count': search_payload['matched_count'],
+        },
+        'categorize_summary': {
+            'new_bar_count': len(new_bars),
+            'existing_bar_count': len(existing_bars),
+        },
+        'apply_summary': {
+            'new_bars_inserted': applied.get('new_bars_inserted', 0),
+            'existing_bars_updated': applied.get('existing_bars_updated', 0),
+            'open_hours_rows_inserted': applied.get('open_hours_rows_inserted', 0),
+            'open_hours_rows_updated': applied.get('open_hours_rows_updated', 0),
+        },
+        'new_bars': new_bars,
+        'existing_bars': existing_bars,
+    }
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    action = event.get('action')
+
+    try:
+        if action not in ALLOWED_ACTIONS:
+            raise ValidationError(f'Unsupported action "{action}". Allowed actions: {sorted(ALLOWED_ACTIONS)}')
+
+        if action == 'search_neighborhood_bars':
+            return build_response(200, search_neighborhood_bars(event))
+        if action == 'enrich_new_bars':
+            return build_response(200, enrich_new_bars(event))
+        if action == 'sync_neighborhood_bars':
+            return build_response(200, sync_neighborhood_bars(event))
+
+        raise ValidationError(f'Unhandled action "{action}"')
+    except ValidationError as exc:
+        logger.warning('Validation error: %s', exc)
+        return build_response(400, {'status': 'error', 'message': str(exc), 'action': action})
+    except requests.RequestException as exc:
+        logger.exception('Google API request failed')
+        return build_response(502, {'status': 'error', 'message': str(exc), 'action': action})
+    except GooglePlacesError as exc:
+        logger.warning('Google Places returned an error: %s', exc)
+        return build_response(502, {'status': 'error', 'message': str(exc), 'action': action})
+    except Exception as exc:
+        logger.exception('Unhandled exception in googleBarSync')
+        return build_response(500, {'status': 'error', 'message': str(exc), 'action': action})


### PR DESCRIPTION
### Motivation

- Split the neighborhood bar sync into two Lambdas to keep Google API calls outside the VPC and database operations inside the VPC for security and connectivity reasons.
- Provide a neighborhood-driven full sync that searches Google Places, filters by polygon, enriches new bars with images uploaded to S3, and persists bars and open-hours to RDS.
- Document the new flow and configuration points so additional neighborhoods can be added and schema differences can be accommodated.

### Description

- Add `functions/googleBarSync/google_bar_sync.py` which implements `search_neighborhood_bars`, `enrich_new_bars`, and `sync_neighborhood_bars`, calls Google Places APIs, uploads photos to S3, filters by polygon, formats open-hours, and invokes the DB lambda using `DB_BAR_SYNC_FUNCTION_NAME`.
- Add `functions/dbBarSync/db_bar_sync.py` which implements `categorize_bars` and `apply_bar_updates`, connects to RDS using `pymysql`, classifies incoming candidates into `new_bars`/`existing_bars`, inserts rows into the `bar` table, and upserts `open_hours` using `ON DUPLICATE KEY UPDATE`.
- Update `README.md` with a new "two-Lambda neighborhood bar sync flow" section describing orchestration, required environment variables (for example `GOOGLE_API_KEY`, `S3_BUCKET_NAME`, `BAR_IMAGE_FOLDER`, `DB_BAR_SYNC_FUNCTION_NAME`, `RDS_HOST`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME`), and schema areas to edit such as `BAR_TABLE` and `OPEN_HOURS_TABLE`.
- Implement helpers for open-hours normalization (`format_open_hours` / `normalize_open_hours`), polygon filtering (`point_in_polygon`), image handling and S3 key generation, input validation, and error handling for Google API and DB failures.

### Testing

- No automated tests were added or executed for these new modules as part of this change.
- It is recommended to add unit tests for `format_open_hours`, `point_in_polygon`, `insert_new_bars`, and `upsert_open_hours` and integration tests for the end-to-end `sync_neighborhood_bars` flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd9298825083308f9ba251e6914475)