### PR TITLE
Add two-Lambda Google bar sync flow: `googleBarSync` and `dbBarSync` with README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 - **`refreshOpenHours`**  
   Works together with **`fetchGoogleAPIHours`** to retrieve current open-hours data directly from Google and update the database. This process is currently triggered manually.
 
+
+- **`googleBarSync`**  
+  This is the only entry point for the new two-Lambda bar sync flow. It accepts only `{ "neighborhood": "downtown" }`, loads the built-in neighborhood config, calls Places API (New) Text Search (`textQuery: "bar"`) using one or more configured rectangle `locationRestriction` search windows per neighborhood, dedupes results across all rectangles/pages, filters candidates to the configured polygon, formats open hours using the same structure as `fetchGoogleAPIHours`, asks `dbBarSync` which bars are new vs existing, fetches Google photos only for new bars using Place Photos (New), uploads those images to S3, and then calls `dbBarSync` again to save the results. It no longer makes Place Details calls during the sync.
+
+  Required environment variables:
+  - `GOOGLE_API_KEY`
+  - `S3_BUCKET_NAME`
+  - `BAR_IMAGE_FOLDER`
+  - `DB_BAR_SYNC_LAMBDA_NAME`
+
+- **`dbBarSync`**  
+  This Lambda is invoked only by `googleBarSync`. On the first invocation it categorizes bars into `new_bars` and `existing_bars` by `google_place_id`. On the second invocation it inserts new bar records into `bar`, upserts all open-hours rows into `open_hours`, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive. It uses the same RDS connection variable pattern as the existing database Lambdas.
+
+  Required environment variables:
+  - `RDS_HOST`
+  - `DB_USER`
+  - `DB_PASSWORD`
+  - `DB_NAME`
+
 - **`insertUserReport`**  
   Used on the special details view. When a user marks a special for review, this function is called to insert a report record in the database.
 
@@ -169,3 +188,26 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 - Favorites are now persisted in the background whenever a user favorites/unfavorites a special.
 - Endpoint used by the web app:
   - `https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/updateDeviceFavorite`
+
+
+## Two-Lambda bar sync flow
+
+1. Invoke `googleBarSync` with:
+
+   ```json
+   {
+     "neighborhood": "downtown"
+   }
+   ```
+
+2. `googleBarSync` loads the built-in neighborhood config (polygon + one or more search rectangles), runs Places Text Search for each rectangle with pagination, dedupes results, filters candidates to the polygon, and builds a bar list with formatted hours.
+3. `googleBarSync` invokes `dbBarSync` to split candidates into `new_bars` and `existing_bars` using `google_place_id`.
+4. `googleBarSync` leaves `existing_bars` alone, fetches and uploads images only for `new_bars`, and assigns each one an `image_file`.
+5. `googleBarSync` invokes `dbBarSync` a second time.
+6. `dbBarSync` inserts new bars and updates open hours for both new and existing bars.
+
+Design rules:
+- `googleBarSync` is the only public entry point.
+- `googleBarSync` invokes `dbBarSync`.
+- `dbBarSync` never invokes `googleBarSync`.
+- There is no third orchestrator Lambda.

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -1,0 +1,165 @@
+import json
+import logging
+import os
+from typing import Dict, List
+
+import pymysql
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+RDS_HOST = os.environ['RDS_HOST']
+DB_USER = os.environ['DB_USER']
+DB_PASSWORD = os.environ['DB_PASSWORD']
+DB_NAME = os.environ['DB_NAME']
+
+
+def get_connection():
+    return pymysql.connect(
+        host=RDS_HOST,
+        user=DB_USER,
+        passwd=DB_PASSWORD,
+        db=DB_NAME,
+        connect_timeout=5,
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=False,
+    )
+
+
+def categorize_bars(cursor, bars: List[Dict]) -> Dict[str, List[Dict]]:
+    if not bars:
+        return {'new_bars': [], 'existing_bars': []}
+
+    place_ids = [bar['google_place_id'] for bar in bars if bar.get('google_place_id')]
+    if not place_ids:
+        return {'new_bars': [], 'existing_bars': []}
+
+    placeholders = ', '.join(['%s'] * len(place_ids))
+    cursor.execute(
+        f"SELECT bar_id, google_place_id FROM bar WHERE google_place_id IN ({placeholders})",
+        tuple(place_ids),
+    )
+    existing_rows = {row['google_place_id']: row for row in cursor.fetchall()}
+
+    new_bars = []
+    existing_bars = []
+    for bar in bars:
+        existing_row = existing_rows.get(bar['google_place_id'])
+        if existing_row:
+            existing_bars.append({**bar, 'bar_id': existing_row['bar_id']})
+        else:
+            new_bars.append(bar)
+
+    return {'new_bars': new_bars, 'existing_bars': existing_bars}
+
+
+def is_bar_operational(bar: Dict) -> bool:
+    return bar.get('business_status') == 'OPERATIONAL'
+
+
+def insert_new_bars(cursor, new_bars: List[Dict]) -> Dict[str, int]:
+    inserted_count = 0
+    for bar in new_bars:
+        cursor.execute(
+            """
+            INSERT INTO bar (name, google_place_id, address, neighborhood, image_file, is_active)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            (
+                bar['name'],
+                bar['google_place_id'],
+                bar['address'],
+                bar['neighborhood'],
+                bar.get('image_file'),
+                'Y' if is_bar_operational(bar) else 'N',
+            ),
+        )
+        bar['bar_id'] = cursor.lastrowid
+        inserted_count += 1
+    return {'inserted_bars': inserted_count}
+
+
+def upsert_open_hours(cursor, bars: List[Dict]) -> int:
+    updated_rows = 0
+    for bar in bars:
+        bar_id = bar.get('bar_id')
+        if not bar_id:
+            raise ValueError(f"Missing bar_id for {bar.get('google_place_id')}")
+
+        cursor.execute(
+            """
+            UPDATE bar
+            SET is_active = %s,
+                update_date = NOW()
+            WHERE bar_id = %s
+            """,
+            ('Y' if is_bar_operational(bar) else 'N', bar_id),
+        )
+
+        hours = bar.get('hours', {})
+        for day_of_week, value in hours.items():
+            if value == 'CLOSED':
+                open_time = None
+                close_time = None
+                is_closed = 'Y'
+            else:
+                open_time, close_time = value
+                is_closed = 'N'
+
+            cursor.execute(
+                """
+                INSERT INTO open_hours (bar_id, day_of_week, open_time, close_time, is_closed)
+                VALUES (%s, %s, %s, %s, %s)
+                ON DUPLICATE KEY UPDATE
+                    open_time = VALUES(open_time),
+                    close_time = VALUES(close_time),
+                    is_closed = VALUES(is_closed),
+                    update_date = NOW()
+                """,
+                (bar_id, day_of_week, open_time, close_time, is_closed),
+            )
+            updated_rows += 1
+    return updated_rows
+
+
+def apply_changes(cursor, new_bars: List[Dict], existing_bars: List[Dict]) -> Dict[str, int]:
+    result = insert_new_bars(cursor, new_bars)
+    all_bars = new_bars + existing_bars
+    result['updated_open_hours_rows'] = upsert_open_hours(cursor, all_bars)
+    result['processed_bar_count'] = len(all_bars)
+    return result
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    mode = event.get('mode')
+    if mode not in {'categorize', 'apply'}:
+        return {
+            'statusCode': 400,
+            'body': json.dumps({'error': 'mode must be either categorize or apply'}),
+        }
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cursor:
+            if mode == 'categorize':
+                result = categorize_bars(cursor, event.get('bars', []))
+                conn.commit()
+            else:
+                result = apply_changes(cursor, event.get('new_bars', []), event.get('existing_bars', []))
+                conn.commit()
+
+        LOGGER.info('dbBarSync %s result=%s', mode, result)
+        return {
+            'statusCode': 200,
+            'body': json.dumps(result),
+        }
+    except Exception as exc:
+        conn.rollback()
+        LOGGER.exception('dbBarSync failed during %s', mode)
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'error': str(exc), 'mode': mode}),
+        }
+    finally:
+        conn.close()

--- a/functions/googleBarSync/google_bar_sync.py
+++ b/functions/googleBarSync/google_bar_sync.py
@@ -1,0 +1,347 @@
+import json
+import logging
+import os
+import re
+import time
+from typing import Dict, List, Optional
+
+import boto3
+import requests
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+GOOGLE_API_KEY = os.environ['GOOGLE_API_KEY']
+S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
+BAR_IMAGE_FOLDER = os.environ['BAR_IMAGE_FOLDER'].strip('/')
+DB_BAR_SYNC_LAMBDA_NAME = os.environ['DB_BAR_SYNC_LAMBDA_NAME']
+
+GOOGLE_TEXT_SEARCH_URL = 'https://places.googleapis.com/v1/places:searchText'
+GOOGLE_PLACE_PHOTO_URL_TEMPLATE = 'https://places.googleapis.com/v1/{photo_name}/media'
+GOOGLE_FIELD_MASK = ','.join([
+    'places.id',
+    'places.displayName',
+    'places.businessStatus',
+    'places.formattedAddress',
+    'places.location',
+    'places.currentOpeningHours',
+    'places.rating',
+    'places.priceLevel',
+    # Required to keep the existing new-bar image flow without any Place Details call.
+    'places.photos',
+])
+
+DAY_MAP = {
+    0: 'SUN',
+    1: 'MON',
+    2: 'TUE',
+    3: 'WED',
+    4: 'THU',
+    5: 'FRI',
+    6: 'SAT',
+}
+ALL_DAYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+
+NEIGHBORHOOD_CONFIGS = {
+    'downtown': {
+        'neighborhood_name': 'Downtown',
+        'search_rectangles': [
+            {
+                'low': {'lat': 40.4325, 'lng': -80.0208},
+                'high': {'lat': 40.4475, 'lng': -79.9870},
+            }
+        ],
+        'polygon': [
+            {'lat': 40.442357, 'lng': -80.015060},
+            {'lat': 40.447582, 'lng': -79.994819},
+            {'lat': 40.443094, 'lng': -79.991779},
+            {'lat': 40.434590, 'lng': -79.996123},
+            {'lat': 40.442357, 'lng': -80.015060},
+        ],
+    }
+}
+
+lambda_client = boto3.client('lambda')
+s3_client = boto3.client('s3')
+http_session = requests.Session()
+
+
+class GoogleBarSyncError(Exception):
+    pass
+
+
+def get_neighborhood_config(neighborhood: Optional[str]) -> Dict:
+    neighborhood_key = (neighborhood or '').strip().lower()
+    if not neighborhood_key:
+        raise GoogleBarSyncError('Event field "neighborhood" is required.')
+
+    config = NEIGHBORHOOD_CONFIGS.get(neighborhood_key)
+    if not config:
+        raise GoogleBarSyncError(
+            f'Unsupported neighborhood "{neighborhood}". Supported neighborhoods: {sorted(NEIGHBORHOOD_CONFIGS)}'
+        )
+
+    rectangles = config.get('search_rectangles') or []
+    if not rectangles:
+        raise GoogleBarSyncError(f'Neighborhood "{neighborhood}" has no configured search rectangles.')
+
+    return config
+
+
+def point_in_polygon(lat: float, lng: float, polygon: List[Dict[str, float]]) -> bool:
+    inside = False
+    previous_index = len(polygon) - 1
+
+    for index, point in enumerate(polygon):
+        yi = point['lat']
+        xi = point['lng']
+        yj = polygon[previous_index]['lat']
+        xj = polygon[previous_index]['lng']
+        intersects = ((yi > lat) != (yj > lat)) and (
+            lng < (xj - xi) * (lat - yi) / ((yj - yi) or 1e-12) + xi
+        )
+        if intersects:
+            inside = not inside
+        previous_index = index
+
+    return inside
+
+
+def search_text_by_rectangle(rectangle: Dict[str, Dict[str, float]]) -> List[Dict]:
+    places = []
+    next_page_token = None
+
+    while True:
+        body = {
+            'textQuery': 'bar',
+            'pageSize': 20,
+            'locationRestriction': {
+                'rectangle': {
+                    'low': {
+                        'latitude': rectangle['low']['lat'],
+                        'longitude': rectangle['low']['lng'],
+                    },
+                    'high': {
+                        'latitude': rectangle['high']['lat'],
+                        'longitude': rectangle['high']['lng'],
+                    },
+                }
+            },
+        }
+        if next_page_token:
+            body['pageToken'] = next_page_token
+
+        response = http_session.post(
+            GOOGLE_TEXT_SEARCH_URL,
+            headers={
+                'Content-Type': 'application/json',
+                'X-Goog-Api-Key': GOOGLE_API_KEY,
+                'X-Goog-FieldMask': GOOGLE_FIELD_MASK,
+            },
+            json=body,
+            timeout=20,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        places.extend(payload.get('places', []))
+        next_page_token = payload.get('nextPageToken')
+        if not next_page_token:
+            break
+
+        LOGGER.info('Fetching next Text Search page for rectangle.')
+        time.sleep(2)
+
+    return places
+
+
+def search_text_places(rectangles: List[Dict[str, Dict[str, float]]]) -> List[Dict]:
+    combined = []
+    for index, rectangle in enumerate(rectangles, start=1):
+        LOGGER.info('Running Text Search rectangle %s/%s', index, len(rectangles))
+        combined.extend(search_text_by_rectangle(rectangle))
+
+    deduped = {}
+    for place in combined:
+        place_id = place.get('id')
+        if place_id:
+            deduped[place_id] = place
+
+    return list(deduped.values())
+
+
+def format_open_hours(periods: List[Dict]) -> Dict[str, object]:
+    hours_map = {day: 'CLOSED' for day in ALL_DAYS}
+
+    for period in periods or []:
+        open_info = period.get('open') or {}
+        close_info = period.get('close') or {}
+        if 'day' not in open_info or 'hour' not in open_info or 'minute' not in open_info:
+            continue
+
+        open_day = DAY_MAP.get(open_info['day'])
+        if not open_day:
+            continue
+
+        formatted_open = f"{int(open_info['hour']):02d}:{int(open_info.get('minute', 0)):02d}:00"
+
+        if close_info and 'hour' in close_info and 'minute' in close_info:
+            formatted_close = f"{int(close_info['hour']):02d}:{int(close_info.get('minute', 0)):02d}:00"
+        else:
+            formatted_close = None
+
+        hours_map[open_day] = [formatted_open, formatted_close]
+
+    return hours_map
+
+
+def build_candidate_bar(place: Dict, neighborhood_name: str) -> Optional[Dict]:
+    place_id = place.get('id')
+    name = (place.get('displayName') or {}).get('text', '').strip()
+    address = (place.get('formattedAddress') or '').strip()
+    location = place.get('location') or {}
+    lat = location.get('latitude')
+    lng = location.get('longitude')
+
+    if not place_id or not name or not address or lat is None or lng is None:
+        return None
+
+    opening_hours = place.get('currentOpeningHours') or {}
+    photos = place.get('photos') or []
+    photo_name = (photos[0] or {}).get('name') if photos else None
+
+    return {
+        'google_place_id': place_id,
+        'name': name,
+        'address': address,
+        'neighborhood': neighborhood_name,
+        'business_status': place.get('businessStatus'),
+        'hours': format_open_hours(opening_hours.get('periods', [])),
+        'photo_name': photo_name,
+        'rating': place.get('rating'),
+        'price_level': place.get('priceLevel'),
+    }
+
+
+def invoke_db_lambda(payload: Dict) -> Dict:
+    response = lambda_client.invoke(
+        FunctionName=DB_BAR_SYNC_LAMBDA_NAME,
+        InvocationType='RequestResponse',
+        Payload=json.dumps(payload).encode('utf-8'),
+    )
+    if response.get('FunctionError'):
+        raise GoogleBarSyncError(f"DB lambda invocation failed: {response['FunctionError']}")
+
+    response_payload = json.loads(response['Payload'].read())
+    status_code = response_payload.get('statusCode', 500)
+    body = response_payload.get('body')
+    parsed_body = json.loads(body) if isinstance(body, str) else body
+    if status_code >= 400:
+        raise GoogleBarSyncError(f'DB lambda returned {status_code}: {parsed_body}')
+    return parsed_body
+
+
+def infer_extension(content_type: str) -> str:
+    normalized = (content_type or '').split(';', 1)[0].strip().lower()
+    mapping = {
+        'image/jpeg': '.jpg',
+        'image/jpg': '.jpg',
+        'image/png': '.png',
+        'image/webp': '.webp',
+        'image/gif': '.gif',
+    }
+    return mapping.get(normalized, '.jpg')
+
+
+def slugify_bar_name(name: str) -> str:
+    slug = re.sub(r'[^a-z0-9]+', '_', name.lower()).strip('_')
+    return slug or 'bar'
+
+
+def fetch_and_store_bar_image(bar: Dict) -> Optional[str]:
+    photo_name = bar.get('photo_name')
+    if not photo_name:
+        LOGGER.info('No Google photo available for %s (%s)', bar['name'], bar['google_place_id'])
+        return None
+
+    response = http_session.get(
+        GOOGLE_PLACE_PHOTO_URL_TEMPLATE.format(photo_name=photo_name),
+        headers={
+            'X-Goog-Api-Key': GOOGLE_API_KEY,
+        },
+        params={
+            'maxWidthPx': 1200,
+        },
+        timeout=20,
+        allow_redirects=True,
+    )
+    response.raise_for_status()
+
+    extension = infer_extension(response.headers.get('Content-Type', ''))
+    image_file = f"{slugify_bar_name(bar['name'])}_{bar['google_place_id']}{extension}"
+    s3_key = f'{BAR_IMAGE_FOLDER}/{image_file}' if BAR_IMAGE_FOLDER else image_file
+
+    s3_client.put_object(
+        Bucket=S3_BUCKET_NAME,
+        Key=s3_key,
+        Body=response.content,
+        ContentType=response.headers.get('Content-Type', 'application/octet-stream'),
+    )
+    return image_file
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    try:
+        config = get_neighborhood_config(event.get('neighborhood'))
+        neighborhood_name = config['neighborhood_name']
+        rectangles = config['search_rectangles']
+        LOGGER.info('Starting Google bar sync for neighborhood=%s with %s search rectangle(s)', neighborhood_name, len(rectangles))
+
+        places = search_text_places(rectangles)
+        LOGGER.info('Fetched %s deduped raw places from Places API (New) Text Search', len(places))
+
+        candidate_bars = []
+        for place in places:
+            location = place.get('location') or {}
+            lat = location.get('latitude')
+            lng = location.get('longitude')
+            if lat is None or lng is None or not point_in_polygon(lat, lng, config['polygon']):
+                continue
+
+            candidate_bar = build_candidate_bar(place, neighborhood_name)
+            if candidate_bar:
+                candidate_bars.append(candidate_bar)
+
+        LOGGER.info('Built %s polygon-filtered candidate bars', len(candidate_bars))
+
+        categorized = invoke_db_lambda({'mode': 'categorize', 'bars': candidate_bars})
+        new_bars = categorized.get('new_bars', [])
+        existing_bars = categorized.get('existing_bars', [])
+        LOGGER.info('Categorized bars: %s new, %s existing', len(new_bars), len(existing_bars))
+
+        for bar in new_bars:
+            bar['image_file'] = fetch_and_store_bar_image(bar)
+
+        apply_result = invoke_db_lambda({
+            'mode': 'apply',
+            'new_bars': new_bars,
+            'existing_bars': existing_bars,
+        })
+
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                'neighborhood': event.get('neighborhood'),
+                'candidate_count': len(candidate_bars),
+                'new_bar_count': len(new_bars),
+                'existing_bar_count': len(existing_bars),
+                'db_result': apply_result,
+            }),
+        }
+    except Exception as exc:
+        LOGGER.exception('googleBarSync failed')
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'error': str(exc)}),
+        }


### PR DESCRIPTION
### Motivation
- Introduce a two-Lambda sync flow to import bars from the new Places API Text Search and avoid per-place Details calls by separating discovery/image work from DB persistence.
- Ensure new-bar images are fetched and uploaded to S3 only for bars that do not already exist in the database and to provide a polygon-filtered, deduped candidate set with formatted open-hours.

### Description
- Add `functions/googleBarSync/google_bar_sync.py` which performs Places Text Search across configured rectangle windows, handles pagination and deduplication, filters results to a neighborhood polygon, formats open hours, fetches photos for new bars, uploads images to S3, and invokes `dbBarSync` via Lambda calls; it requires `GOOGLE_API_KEY`, `S3_BUCKET_NAME`, `BAR_IMAGE_FOLDER`, and `DB_BAR_SYNC_LAMBDA_NAME` environment variables.
- Add `functions/dbBarSync/db_bar_sync.py` which implements `categorize` and `apply` modes to split candidates into `new_bars` and `existing_bars` by `google_place_id`, insert new `bar` rows, upsert `open_hours`, and mark non-`OPERATIONAL` bars inactive; it uses RDS env vars `RDS_HOST`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME`.
- Update `README.md` with an overview of the new two-Lambda flow, required environment variables, and operational notes describing invocation and design rules.
- Maintain existing behavior and data shapes by formatting hours to the same structure used by `fetchGoogleAPIHours` and by preserving existing `image_file` and `is_active` semantics during DB writes.

### Testing
- No automated tests were added or executed for these changes as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1544c9f208330bb9671cffc70a1fd)