### PR TITLE
Fallback to web AI search when homepage/crawl fails

### DIFF
--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -575,7 +575,14 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
         neighborhood,
         homepage_url
     )
-    homepage_html = fetch_html(homepage_url)
+    try:
+        homepage_html = fetch_html(homepage_url)
+    except requests.RequestException:
+        LOGGER.exception('Failed fetching homepage for crawl; falling back to web_search: %s', homepage_url)
+        return []
+    except Exception:
+        LOGGER.exception('Unexpected homepage crawl error; falling back to web_search: %s', homepage_url)
+        return []
     if not homepage_html:
         LOGGER.info('Homepage was non-HTML or empty; returning empty crawl result')
         return []
@@ -703,7 +710,14 @@ def lambda_handler(event, context):
                 continue
 
             processed_bars += 1
-            specials = generate_from_crawl(homepage_url, bar_name, bar_neighborhood)
+            try:
+                specials = generate_from_crawl(homepage_url, bar_name, bar_neighborhood)
+            except Exception:
+                LOGGER.exception(
+                    'Crawl flow crashed for bar_id=%s; falling back to OpenAI web_search',
+                    bar.get('bar_id')
+                )
+                specials = []
             if not specials:
                 LOGGER.info('No crawl specials found for bar_id=%s; using OpenAI web_search', bar.get('bar_id'))
                 specials = generate_from_search(bar_name, bar_neighborhood)


### PR DESCRIPTION
### Motivation
- Prevent the whole `generateCandidateSpecials` invocation from crashing when a bar homepage fetch or crawl step fails so the system can still try the existing web-enabled AI search fallback.

### Description
- Add try/except around `fetch_html` in `generate_from_crawl` to catch `requests.RequestException` and generic exceptions, log the error, and return an empty crawl result (so callers will fall back to search).
- Add a defensive `try/except` around the per-bar `generate_from_crawl` call in `lambda_handler` to log unexpected crawl crashes and continue by falling back to `generate_from_search` for that bar.
- Changes applied in `functions/generateCandidateSpecials/generate_candidate_specials.py`.

### Testing
- Ran `python -m py_compile functions/generateCandidateSpecials/generate_candidate_specials.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc313eec3083309a1c583cadbad657)