### PR TITLE
Add North Shore neighborhood config to googleBarSync

### DIFF
--- a/functions/googleBarSync/google_bar_sync.py
+++ b/functions/googleBarSync/google_bar_sync.py
@@ -63,7 +63,24 @@ NEIGHBORHOOD_CONFIGS = {
             {'lat': 40.434590, 'lng': -79.996123},
             {'lat': 40.442357, 'lng': -80.015060},
         ],
-    }
+    },
+    'north shore': {
+        'neighborhood_name': 'North Shore',
+        'search_rectangles': [
+            {
+                'low': {'lat': 40.4450, 'lng': -80.0240},
+                'high': {'lat': 40.4568, 'lng': -80.0005},
+            },
+        ],
+        'polygon': [
+            {'lat': 40.451900, 'lng': -80.024900},
+            {'lat': 40.456800, 'lng': -80.015000},
+            {'lat': 40.454900, 'lng': -80.000500},
+            {'lat': 40.446700, 'lng': -79.999300},
+            {'lat': 40.445000, 'lng': -80.017800},
+            {'lat': 40.451900, 'lng': -80.024900},
+        ],
+    },
 }
 
 lambda_client = boto3.client('lambda')
@@ -76,7 +93,7 @@ class GoogleBarSyncError(Exception):
 
 
 def get_neighborhood_config(neighborhood: Optional[str]) -> Dict:
-    neighborhood_key = (neighborhood or '').strip().lower()
+    neighborhood_key = (neighborhood or '').strip().lower().replace('_', ' ').replace('-', ' ')
     if not neighborhood_key:
         raise GoogleBarSyncError('Event field "neighborhood" is required.')
 


### PR DESCRIPTION
### Motivation
- Enable `googleBarSync` to discover and filter bars in the North Shore neighborhood by adding a built-in neighborhood config. 
- Accept common neighborhood input variants like `north_shore` and `north-shore` so invocations are more forgiving.

### Description
- Added a new `"north shore"` entry to `NEIGHBORHOOD_CONFIGS` in `functions/googleBarSync/google_bar_sync.py` with a `search_rectangles` list and a `polygon` for spatial filtering. 
- Normalized neighborhood input in `get_neighborhood_config` by replacing underscores and hyphens with spaces before lowercasing and lookup (`.replace('_', ' ').replace('-', ' ')`).
- No other functional behavior of the sync or DB invocation was changed.

### Testing
- Ran `python -m py_compile functions/googleBarSync/google_bar_sync.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc349da5908330b91ce47fa1366806)