### PR TITLE
Improve web crawl extraction, confidence heuristics, and DB insert handling for candidate specials

### DIFF
--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -171,7 +171,6 @@ def _insert_auto_approved_specials(cursor, candidate: Dict) -> List[int]:
             INSERT INTO special
             (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method)
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            RETURNING special_id
             """,
             (
                 candidate['bar_id'],
@@ -184,8 +183,7 @@ def _insert_auto_approved_specials(cursor, candidate: Dict) -> List[int]:
                 'AUTO',
             ),
         )
-        row = cursor.fetchone() or {}
-        special_id = row.get('special_id')
+        special_id = cursor.lastrowid
         if special_id is not None:
             created_special_ids.append(special_id)
 
@@ -212,8 +210,8 @@ def insert_special_candidates(cursor, candidates: List[Dict]) -> Dict[str, int]:
         cursor.execute(
             """
             INSERT INTO special_candidate
-            (bar_id, bar_name, neighborhood, description, type, days_of_week, start_time, end_time, all_day, is_recurring, date, fetch_method, source, confidence, approval_status, approval_date, approved_special_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            (bar_id, bar_name, neighborhood, description, type, days_of_week, start_time, end_time, all_day, is_recurring, date, fetch_method, source, confidence, notes, approval_status, approval_date, approved_special_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 candidate['bar_id'],
@@ -230,6 +228,7 @@ def insert_special_candidates(cursor, candidates: List[Dict]) -> Dict[str, int]:
                 candidate.get('fetch_method'),
                 candidate.get('source') or candidate.get('source_url'),
                 candidate.get('confidence'),
+                candidate.get('notes'),
                 approval_status,
                 approval_date,
                 approved_special_id,

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -17,11 +17,24 @@ OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
 DB_BAR_SYNC_LAMBDA_NAME = os.environ.get('DB_BAR_SYNC_LAMBDA_NAME')
 MAX_LINKS_TO_VISIT = 3
 MAX_TEXT_CHARS_PER_PAGE = 12000
+MAX_WEB_SCRAPE_CHARS = int(os.environ.get('MAX_WEB_SCRAPE_CHARS', '12000'))
+KEYWORD_MATCH_CHAR_WINDOW_SIZE = int(os.environ.get('KEYWORD_MATCH_CHAR_WINDOW_SIZE', '220'))
 HTML_CONTENT_HINTS = ('text/html', 'application/xhtml+xml')
 NON_HTML_EXTENSIONS = ('.pdf', '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.zip', '.mp4', '.mp3')
 
 KEYWORDS = ('special', 'happy', 'menu', 'event')
 DAY_KEYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+CONFIDENCE_THRESHOLD = 0.75
+SPECIALS_VOCAB = (
+    'happy hour', 'special', 'specials', 'deal', 'deals', 'promo', 'promotion', 'daily', 'weekdays',
+    'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
+    'draft', 'beer', 'wine', 'cocktail', 'half off',
+    'wings', 'apps', 'burger night', 'taco tuesday'
+)
+FOOD_DRINK_CLUES = (
+    'food', 'drink', 'beer', 'wine', 'cocktail', 'draft', 'shot', 'margarita',
+    'burger', 'wings', 'taco', 'pizza', 'app', 'appetizer', 'fries', 'nachos'
+)
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -307,7 +320,7 @@ def choose_candidate_links(links):
         scored.append((hits, keyword_in_text_boost, -len(link.get('url', '')), link))
 
     scored.sort(key=lambda row: (row[0], row[1], row[2]), reverse=True)
-    return [item[3].get('url') for item in scored[:MAX_LINKS_TO_VISIT] if item[3].get('url')]
+    return [item[3].get('url') for item in scored if item[3].get('url')]
 
 
 def extract_text(html):
@@ -317,10 +330,46 @@ def extract_text(html):
     return text[:MAX_TEXT_CHARS_PER_PAGE]
 
 
+def _extract_keyword_windows(text):
+    capped_text = (text or '')[:MAX_WEB_SCRAPE_CHARS]
+    lowered = capped_text.lower()
+    if not lowered:
+        return capped_text
+
+    intervals = []
+    for term in SPECIALS_VOCAB:
+        start = 0
+        while True:
+            index = lowered.find(term, start)
+            if index == -1:
+                break
+            interval_start = max(0, index - KEYWORD_MATCH_CHAR_WINDOW_SIZE)
+            interval_end = min(len(capped_text), index + len(term) + KEYWORD_MATCH_CHAR_WINDOW_SIZE)
+            intervals.append((interval_start, interval_end))
+            start = index + len(term)
+
+    if not intervals:
+        return capped_text
+
+    intervals.sort()
+    merged = [intervals[0]]
+    for start, end in intervals[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+
+    snippets = [capped_text[start:end].strip() for start, end in merged if capped_text[start:end].strip()]
+    focused_text = '\n...\n'.join(snippets)
+    return focused_text[:MAX_WEB_SCRAPE_CHARS]
+
+
 def build_crawl_prompt(bar_name, neighborhood, homepage_url, page_payloads):
     pages_blob = []
     for page in page_payloads:
-        pages_blob.append(f"URL: {page['url']}\nTEXT:\n{page['text']}")
+        focused_text = _extract_keyword_windows(page['text'])
+        pages_blob.append(f"URL: {page['url']}\nTEXT:\n{focused_text}")
 
     content = '\n\n'.join(pages_blob)
 
@@ -339,6 +388,8 @@ STRICT RULES:
 - Do NOT guess or invent information
 - If information is missing, leave it null
 - If no specials are present, return an empty array []
+- If an item does not clearly mention food or drink, exclude it.
+- Confidence scoring rule: set confidence to 1.0 ONLY when the item has a clear time window and clear money-saving signal (for example "$", "half off", "% off", or "off").
 
 Extraction strategy (important):
 - Prioritize sections/headings that contain words like: specials, weekly specials, happy hour, deals, promotions.
@@ -573,6 +624,52 @@ def normalize_item(item, default_source):
     }
 
 
+def _contains_time_signal(text):
+    blob = (text or '').lower()
+    return bool(
+        re.search(
+            r'\b(\d{1,2}(:\d{2})?\s?(am|pm)|\d{1,2}\s?-\s?\d{1,2}\s?(am|pm)|\d{1,2}:\d{2})\b',
+            blob
+        )
+    )
+
+
+def _contains_money_signal(text):
+    blob = (text or '').lower()
+    if re.search(r'\$\s*\d+(\.\d{1,2})?', blob):
+        return True
+    if re.search(r'\b\d+(\.\d{1,2})?\s*(usd|dollars?|bucks?)\b', blob):
+        return True
+    if re.search(r'\b(half off|\d+\s*[%]?\s*off|off)\b', blob):
+        return True
+    if re.search(r'\bfor\s+\$?\d+(\.\d{1,2})?\b', blob):
+        return True
+    return False
+
+
+def _mentions_food_or_drink(item):
+    if item.get('type') in ('food', 'drink'):
+        return True
+    blob = f"{item.get('description', '')} {item.get('notes', '')}".lower()
+    return any(term in blob for term in FOOD_DRINK_CLUES)
+
+
+def _apply_crawl_quality_rules(items):
+    filtered = []
+    for item in items:
+        if not _mentions_food_or_drink(item):
+            continue
+
+        blob = f"{item.get('description', '')} {item.get('notes', '')}"
+        has_time = _contains_time_signal(blob)
+        has_money = _contains_money_signal(blob)
+        if has_time and has_money:
+            item['confidence'] = 1.0
+        filtered.append(item)
+
+    return filtered
+
+
 def generate_from_crawl(homepage_url, bar_name, neighborhood):
     started_at = time.perf_counter()
     LOGGER.info(
@@ -595,12 +692,13 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
     links = extract_links(homepage_url, homepage_html)
     LOGGER.info('Extracted %d same-domain links from homepage', len(links))
     top_links = choose_candidate_links(links)
-    top_links = [homepage_url] + [url for url in top_links if url != homepage_url]
-    top_links = top_links[:MAX_LINKS_TO_VISIT]
-    LOGGER.info('Selected %d candidate links for crawl', len(top_links))
+    candidate_links = [homepage_url] + [url for url in top_links if url != homepage_url]
+    LOGGER.info('Selected %d initial candidate links for crawl', len(candidate_links))
 
     page_payloads = []
-    for link in top_links:
+    for link in candidate_links:
+        if len(page_payloads) >= MAX_LINKS_TO_VISIT:
+            break
         candidate_url = link if isinstance(link, str) else None
         if not candidate_url:
             LOGGER.info('Skipping malformed candidate link entry: %s', link)
@@ -645,6 +743,8 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
                 normalized_item['source_url'] = homepage_url
             normalized_item['fetch_method'] = 'website_crawl'
             normalized.append(normalized_item)
+
+    normalized = _apply_crawl_quality_rules(normalized)
 
     elapsed = time.perf_counter() - started_at
     LOGGER.info(
@@ -696,6 +796,8 @@ def lambda_handler(event, context):
         response_neighborhood = parsed_event.get('neighborhood')
         total_candidates = []
         processed_bars = 0
+        crawl_specials_count = 0
+        web_ai_search_specials_count = 0
 
         if parsed_event['mode'] == 'bars':
             bars = parsed_event['bars']
@@ -723,11 +825,19 @@ def lambda_handler(event, context):
                     bar.get('bar_id')
                 )
                 specials = []
-            if not specials:
+            has_high_confidence = any(
+                isinstance(special.get('confidence'), (int, float)) and special.get('confidence', 0) >= CONFIDENCE_THRESHOLD
+                for special in specials
+            )
+            if not specials or not has_high_confidence:
                 LOGGER.info('No crawl specials found for bar_id=%s; using OpenAI web_search', bar.get('bar_id'))
                 specials = generate_from_search(bar_name, bar_neighborhood)
 
             for special in specials:
+                if special.get('fetch_method') == 'website_crawl':
+                    crawl_specials_count += 1
+                elif special.get('fetch_method') == 'web_ai_search':
+                    web_ai_search_specials_count += 1
                 total_candidates.append({
                     'bar_id': bar['bar_id'],
                     'bar_name': bar_name,
@@ -737,6 +847,7 @@ def lambda_handler(event, context):
 
         insert_result = invoke_db_bar_sync({'mode': 'insert_special_candidates', 'candidates': total_candidates})
         inserted_count = int(insert_result.get('inserted_count', 0))
+        auto_approved_count = int(insert_result.get('auto_approved_count', 0))
 
         elapsed = time.perf_counter() - started_at
         LOGGER.info(
@@ -752,7 +863,10 @@ def lambda_handler(event, context):
                 'neighborhood': response_neighborhood,
                 'processed_bars': processed_bars,
                 'candidate_specials_found': len(total_candidates),
-                'candidate_specials_inserted': inserted_count
+                'candidate_specials_inserted': inserted_count,
+                'auto_approved_specials': auto_approved_count,
+                'website_crawl_specials': crawl_specials_count,
+                'web_ai_search_specials': web_ai_search_specials_count
             })
         }
     except ValueError as exc:


### PR DESCRIPTION
### Motivation
- Reduce false positives from website crawls by focusing scraped text around specialty-related keywords and applying simple quality rules. 
- Ensure auto-approved `special` inserts work reliably across DB drivers and persist `notes` from candidate extraction. 
- Improve telemetry to understand source of candidate specials and surface auto-approvals.

### Description
- Added focused text extraction with `_extract_keyword_windows` and new config constants (`MAX_WEB_SCRAPE_CHARS`, `KEYWORD_MATCH_CHAR_WINDOW_SIZE`, `SPECIALS_VOCAB`, `FOOD_DRINK_CLUES`, `CONFIDENCE_THRESHOLD`) to limit and prioritize crawl content in `generate_candidate_specials.py`.
- Updated `build_crawl_prompt` to use the focused page snippets and tightened extraction rules (exclude non-food/drink items and guidance for confidence scoring).
- Implemented heuristics `_contains_time_signal`, `_contains_money_signal`, `_mentions_food_or_drink`, and `_apply_crawl_quality_rules` to filter crawl results and set high-confidence items to `confidence=1.0` when both time and money signals exist.
- Changed link selection and page capture flow so the homepage plus best candidate links are considered and only up to `MAX_LINKS_TO_VISIT` pages are used; also retained all scored links earlier in the flow to allow selective truncation later.
- In the lambda orchestration, added fallback logic that runs `web_search` if crawl results are empty or lack any item meeting `CONFIDENCE_THRESHOLD`, and added counters for `website_crawl` vs `web_ai_search` items plus `auto_approved_specials` in the response.
- In `db_bar_sync.py`, switched to using `cursor.lastrowid` to obtain the inserted `special` id instead of relying on `RETURNING special_id` and `fetchone()`, and added the `notes` column into the `special_candidate` insert values.

### Testing
- Ran the existing unit test suite for candidate generation and DB sync functions, and all tests passed. 
- Performed a local invocation of the crawl + insert flow against a staging DB and sample homepages to validate focused extraction, confidence assignment, and that `notes` persist; the run completed without errors and counters were reported. 
- Executed static checks (`flake8`/`pyflakes`) and found no new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd714d7aa88330bcb40977db4803bb)