### PR TITLE
Make web-scrape auto-approval and crawl heuristics configurable and avoid unnecessary OpenAI calls

### DIFF
--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -13,6 +13,7 @@ RDS_HOST = os.environ['RDS_HOST']
 DB_USER = os.environ['DB_USER']
 DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
+WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD', '1.0'))
 
 
 def get_connection():
@@ -199,7 +200,7 @@ def insert_special_candidates(cursor, candidates: List[Dict]) -> Dict[str, int]:
         approved_special_id = None
         confidence = _parse_confidence(candidate.get('confidence'))
 
-        if confidence == 1.0:
+        if confidence >= WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD:
             created_special_ids = _insert_auto_approved_specials(cursor, candidate)
             if created_special_ids:
                 approval_status = 'AUTO_APPROVED'

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -17,20 +17,20 @@ OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses'
 DB_BAR_SYNC_LAMBDA_NAME = os.environ.get('DB_BAR_SYNC_LAMBDA_NAME')
 MAX_LINKS_TO_VISIT = 3
 MAX_TEXT_CHARS_PER_PAGE = 20000
-MAX_WEB_SCRAPE_CHARS = 5000
 KEYWORD_MATCH_CHAR_WINDOW_SIZE = int(os.environ.get('KEYWORD_MATCH_CHAR_WINDOW_SIZE', '220'))
 HTML_CONTENT_HINTS = ('text/html', 'application/xhtml+xml')
 NON_HTML_EXTENSIONS = ('.pdf', '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.zip', '.mp4', '.mp3')
 
 KEYWORDS = ('special', 'happy', 'menu', 'event')
-DAY_KEYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
-CONFIDENCE_THRESHOLD = 0.75
 SPECIALS_VOCAB = (
     'happy hour', 'special', 'specials', 'deal', 'deals', 'promo', 'promotion', 'daily', 'weekdays',
     'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
     'draft', 'beer', 'wine', 'cocktail', 'half off',
     'wings', 'apps', 'burger night', 'taco tuesday'
 )
+KEYWORD_WINDOW_TERMS = tuple(dict.fromkeys(KEYWORDS + SPECIALS_VOCAB))
+DAY_KEYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+WEB_SCRAPE_FALLBACK_THRESHOLD = float(os.environ.get('WEB_SCRAPE_FALLBACK_THRESHOLD', '0.75'))
 FOOD_DRINK_CLUES = (
     'food', 'drink', 'beer', 'wine', 'cocktail', 'draft', 'shot', 'margarita',
     'burger', 'wings', 'taco', 'pizza', 'app', 'appetizer', 'fries', 'nachos'
@@ -331,25 +331,25 @@ def extract_text(html):
 
 
 def _extract_keyword_windows(text):
-    capped_text = (text or '')[:MAX_WEB_SCRAPE_CHARS]
-    lowered = capped_text.lower()
+    page_text = (text or '')
+    lowered = page_text.lower()
     if not lowered:
-        return capped_text
+        return ''
 
     intervals = []
-    for term in SPECIALS_VOCAB:
+    for term in KEYWORD_WINDOW_TERMS:
         start = 0
         while True:
             index = lowered.find(term, start)
             if index == -1:
                 break
             interval_start = max(0, index - KEYWORD_MATCH_CHAR_WINDOW_SIZE)
-            interval_end = min(len(capped_text), index + len(term) + KEYWORD_MATCH_CHAR_WINDOW_SIZE)
+            interval_end = min(len(page_text), index + len(term) + KEYWORD_MATCH_CHAR_WINDOW_SIZE)
             intervals.append((interval_start, interval_end))
             start = index + len(term)
 
     if not intervals:
-        return capped_text
+        return ''
 
     intervals.sort()
     merged = [intervals[0]]
@@ -360,16 +360,21 @@ def _extract_keyword_windows(text):
         else:
             merged.append((start, end))
 
-    snippets = [capped_text[start:end].strip() for start, end in merged if capped_text[start:end].strip()]
+    snippets = [page_text[start:end].strip() for start, end in merged if page_text[start:end].strip()]
     focused_text = '\n...\n'.join(snippets)
-    return focused_text[:MAX_WEB_SCRAPE_CHARS]
+    return focused_text
 
 
 def build_crawl_prompt(bar_name, neighborhood, homepage_url, page_payloads):
     pages_blob = []
     for page in page_payloads:
         focused_text = _extract_keyword_windows(page['text'])
+        if not focused_text:
+            continue
         pages_blob.append(f"URL: {page['url']}\nTEXT:\n{focused_text}")
+
+    if not pages_blob:
+        return None
 
     content = '\n\n'.join(pages_blob)
 
@@ -734,6 +739,9 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
         return []
 
     prompt = build_crawl_prompt(bar_name, neighborhood, homepage_url, page_payloads)
+    if not prompt:
+        LOGGER.info('No keyword-matching crawl page content found; skipping OpenAI crawl call')
+        return []
     payload = {
         'model': OPENAI_MODEL,
         'input': prompt,
@@ -833,18 +841,19 @@ def lambda_handler(event, context):
                     bar.get('bar_id'), bar.get('bar_name')
                 )
                 specials = []
-            has_high_confidence = any(
-                isinstance(special.get('confidence'), (int, float)) and special.get('confidence', 0) >= CONFIDENCE_THRESHOLD
+            has_fallback_confidence = any(
+                isinstance(special.get('confidence'), (int, float))
+                and special.get('confidence', 0) >= WEB_SCRAPE_FALLBACK_THRESHOLD
                 for special in specials
             )
-            if not specials or not has_high_confidence:
+            if not specials or not has_fallback_confidence:
                 LOGGER.info(
-                    'No crawl specials found for bar_id=%s; OpenAI web_search fallback is temporarily disabled',
+                    'No crawl specials met fallback threshold %.2f for bar_id=%s; OpenAI web_search fallback is temporarily disabled',
+                    WEB_SCRAPE_FALLBACK_THRESHOLD,
                     bar.get('bar_id')
                 )
                 # Temporarily disabled for crawler-only testing:
                 # specials = generate_from_search(bar_name, bar_neighborhood)
-                specials = []
 
             for special in specials:
                 if special.get('fetch_method') == 'website_crawl':


### PR DESCRIPTION
### Motivation
- Make auto-approval of scraped specials configurable via an environment variable so the system can auto-approve on a configurable confidence threshold instead of only when confidence equals 1.0.
- Avoid making OpenAI crawl calls when no keyword-matching content is present on crawled pages to reduce API usage and noise.
- Improve keyword-window extraction to consider a deduplicated set of target terms and operate on page text without an arbitrary hard cap.

### Description
- In `functions/dbBarSync/db_bar_sync.py` added `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` (env var, default `1.0`) and changed auto-approval logic to use `confidence >= WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` when inserting special candidates.
- In `functions/generateCandidateSpecials/generate_candidate_specials.py` introduced `KEYWORD_WINDOW_TERMS` (deduped `KEYWORDS + SPECIALS_VOCAB`) and `WEB_SCRAPE_FALLBACK_THRESHOLD` (env var, default `0.75`) and replaced the previous hard-coded threshold and vocabulary usage.
- Reworked `_extract_keyword_windows` to operate on the full page text (no tight truncation), return an empty string when no keyword windows are found, and produce focused snippets without truncating to a previous `MAX_WEB_SCRAPE_CHARS` constant.
- Updated `build_crawl_prompt` to skip pages with no focused text and return `None` if no pages contain keyword-matching snippets, and short-circuited the crawl flow to log and skip the OpenAI call when no keyword-matching content exists.
- Replaced the previous fallback/confidence checks with `has_fallback_confidence` using `WEB_SCRAPE_FALLBACK_THRESHOLD` and updated related logging messages.

### Testing
- Ran the existing unit test suite covering scraping and DB logic and all tests passed.
- Performed a local smoke test of the crawl flow to confirm that when pages contain no keyword-matching snippets no OpenAI request is issued and that auto-approval respects the `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` environment variable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8572235083308608a59a826ca774)