### PR TITLE
Re-enable OpenAI web search fallback and add WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `DB_USER`
   - `DB_PASSWORD`
   - `DB_NAME`
+  - `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
+  - `WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
 
 - **`insertUserReport`**  
   Used on the special details view. When a user marks a special for review, this function is called to insert a report record in the database.

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -14,6 +14,7 @@ DB_USER = os.environ['DB_USER']
 DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD', '1.0'))
+WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD', '1.0'))
 
 
 def get_connection():
@@ -200,7 +201,13 @@ def insert_special_candidates(cursor, candidates: List[Dict]) -> Dict[str, int]:
         approved_special_id = None
         confidence = _parse_confidence(candidate.get('confidence'))
 
-        if confidence >= WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD:
+        fetch_method = (candidate.get('fetch_method') or '').strip()
+        if fetch_method == 'web_ai_search':
+            auto_approval_threshold = WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD
+        else:
+            auto_approval_threshold = WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD
+
+        if confidence >= auto_approval_threshold:
             created_special_ids = _insert_auto_approved_specials(cursor, candidate)
             if created_special_ids:
                 approval_status = 'AUTO_APPROVED'

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -891,12 +891,11 @@ def lambda_handler(event, context):
             )
             if not specials or not has_fallback_confidence:
                 LOGGER.info(
-                    'No crawl specials met fallback threshold %.2f for bar_name=%s; OpenAI web_search fallback is temporarily disabled',
+                    'No crawl specials met fallback threshold %.2f for bar_name=%s; using OpenAI web_search fallback',
                     WEB_SCRAPE_FALLBACK_THRESHOLD,
                     bar_name
                 )
-                # Temporarily disabled for crawler-only testing:
-                # specials = generate_from_search(bar_name, bar_neighborhood)
+                specials = generate_from_search(bar_name, bar_neighborhood)
 
             for special in specials:
                 if special.get('fetch_method') == 'website_crawl':


### PR DESCRIPTION
### Motivation
- The crawl-first flow had OpenAI `web_search` fallback temporarily disabled, which prevents finding specials when site crawl is empty or low-confidence. 
- Web-derived candidates should be able to auto-approve under a separate, configurable threshold from site-crawl candidates. 

### Description
- Re-enabled the web AI fallback by calling `generate_from_search(...)` when crawl results are empty or do not meet `WEB_SCRAPE_FALLBACK_THRESHOLD` in `functions/generateCandidateSpecials/generate_candidate_specials.py`. 
- Added a new environment variable `WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD` and parsed it in `functions/dbBarSync/db_bar_sync.py`. 
- Updated `insert_special_candidates` to select the auto-approval threshold based on `fetch_method` (uses `WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD` for `web_ai_search`, otherwise `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD`). 
- Documented both optional auto-approval environment variables in `README.md`. 

### Testing
- Ran `node --test tests/app.test.js` which completed successfully (all tests passed). 
- Ran `python -m py_compile functions/generateCandidateSpecials/generate_candidate_specials.py functions/dbBarSync/db_bar_sync.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea48a34488330a1c10e8dddcf58d8)