### PR TITLE
Group candidate specials by day/time before DB insert

### DIFF
--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -725,6 +725,65 @@ def _apply_crawl_quality_rules(items):
     return filtered
 
 
+def _dedupe_preserve_order(values):
+    seen = set()
+    result = []
+    for value in values:
+        normalized = (value or '').strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _group_specials_for_insert(items):
+    grouped = {}
+    ordered_keys = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+
+        days = tuple(sorted(day for day in (item.get('days_of_week') or []) if day in DAY_KEYS))
+        key = (
+            days,
+            item.get('start_time') or None,
+            item.get('end_time') or None,
+            'Y' if item.get('all_day') == 'Y' else 'N',
+            item.get('type') or 'unknown',
+            item.get('is_recurring') or 'Y',
+            item.get('date') or None,
+        )
+
+        if key not in grouped:
+            grouped[key] = {
+                **item,
+                'days_of_week': list(days),
+                '_descriptions': _dedupe_preserve_order([item.get('description')]),
+                '_notes': _dedupe_preserve_order([item.get('notes')]),
+            }
+            ordered_keys.append(key)
+            continue
+
+        target = grouped[key]
+        target['_descriptions'] = _dedupe_preserve_order(target['_descriptions'] + [item.get('description')])
+        target['_notes'] = _dedupe_preserve_order(target['_notes'] + [item.get('notes')])
+        target['confidence'] = max(
+            float(target.get('confidence') or 0.0),
+            float(item.get('confidence') or 0.0)
+        )
+
+    merged = []
+    for key in ordered_keys:
+        item = grouped[key]
+        item['description'] = '; '.join(item.pop('_descriptions'))
+        item['notes'] = ' | '.join(item.pop('_notes'))
+        merged.append(item)
+
+    return merged
+
+
 def generate_from_crawl(homepage_url, bar_name, neighborhood):
     started_at = time.perf_counter()
     LOGGER.info(
@@ -900,6 +959,7 @@ def lambda_handler(event, context):
                     bar_name
                 )
                 specials = generate_from_search(bar_name, bar_neighborhood)
+            specials = _group_specials_for_insert(specials)
 
             bar_candidates = []
             bar_crawl_specials_count = 0


### PR DESCRIPTION
### Motivation
- Prevent duplicate same-time/same-day drink deals from being inserted as separate `special_candidate` rows by merging candidate specials that represent the same schedule window.

### Description
- Added `_group_specials_for_insert` to coalesce specials that share the same `days_of_week`, `start_time`, `end_time`, `all_day`, `type`, `is_recurring`, and `date` into a single candidate record in `functions/generateCandidateSpecials/generate_candidate_specials.py`.
- Added `_dedupe_preserve_order` and used it to merge and deduplicate `description` and `notes` while preserving the original order; merged descriptions are joined with `;` and notes with ` | `, and the highest `confidence` is preserved.
- Wired grouping into the main flow by calling `specials = _group_specials_for_insert(specials)` before building candidate payloads so only grouped records are inserted into `special_candidate`.

### Testing
- Ran `python -m py_compile functions/generateCandidateSpecials/generate_candidate_specials.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef1b821e88330b387e76ec9e15f34)