### PR TITLE
Fix special_candidate_run crawl/search telemetry population

### DIFF
--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -210,6 +210,7 @@ def insert_special_candidate_run(cursor, run: Dict) -> int:
             web_crawl_candidate_links,
             web_crawl_keyword_matches,
             web_crawl_prompt_char_count,
+            web_ai_search_prompt_char_count,
             web_crawl_ai_parse_attempted,
             web_ai_search_attempted,
             auto_publish,
@@ -217,7 +218,7 @@ def insert_special_candidate_run(cursor, run: Dict) -> int:
             completed_at,
             published_at
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """,
         (
             run['bar_id'],
@@ -228,6 +229,7 @@ def insert_special_candidate_run(cursor, run: Dict) -> int:
             run.get('web_crawl_candidate_links', 0),
             run.get('web_crawl_keyword_matches', 0),
             run.get('web_crawl_prompt_char_count', 0),
+            run.get('web_ai_search_prompt_char_count', 0),
             'Y' if run.get('web_crawl_ai_parse_attempted') == 'Y' else 'N',
             'Y' if run.get('web_ai_search_attempted') == 'Y' else 'N',
             'N',

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -785,6 +785,12 @@ def _group_specials_for_insert(items):
 
 
 def generate_from_crawl(homepage_url, bar_name, neighborhood):
+    stats = {
+        'web_crawl_candidate_links': 0,
+        'web_crawl_keyword_matches': 0,
+        'web_crawl_prompt_char_count': 0,
+        'web_crawl_ai_parse_attempted': 'N',
+    }
     started_at = time.perf_counter()
     LOGGER.info(
         'Starting crawl flow bar_name=%s neighborhood=%s homepage_url=%s',
@@ -796,16 +802,17 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
         homepage_html = fetch_html(homepage_url)
     except requests.RequestException:
         LOGGER.exception('Failed fetching homepage for crawl; falling back to web_search: %s', homepage_url)
-        return []
+        return [], stats
     except Exception:
         LOGGER.exception('Unexpected homepage crawl error; falling back to web_search: %s', homepage_url)
-        return []
+        return [], stats
     if not homepage_html:
         LOGGER.info('Homepage was non-HTML or empty; returning empty crawl result')
-        return []
+        return [], stats
     links = extract_links(homepage_url, homepage_html)
     LOGGER.info('Extracted %d same-domain links from homepage', len(links))
     top_links = choose_candidate_links(links)
+    stats['web_crawl_candidate_links'] = len(top_links)
     candidate_links = [homepage_url] + [url for url in top_links if url != homepage_url]
     LOGGER.info('Selected %d initial candidate links for crawl', len(candidate_links))
 
@@ -837,17 +844,24 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
 
     if not page_payloads:
         LOGGER.info('No crawl text payloads available; returning empty list')
-        return []
+        return [], stats
+
+    stats['web_crawl_keyword_matches'] = sum(
+        _get_keyword_hit_stats(page.get('text')).get('total_hits', 0)
+        for page in page_payloads
+    )
 
     prompt = build_crawl_prompt(bar_name, neighborhood, homepage_url, page_payloads)
     if not prompt:
         LOGGER.info('No keyword-matching crawl page content found; skipping OpenAI crawl call')
-        return []
+        return [], stats
+    stats['web_crawl_prompt_char_count'] = len(prompt)
     payload = {
         'model': OPENAI_MODEL,
         'input': prompt,
         'temperature': 0
     }
+    stats['web_crawl_ai_parse_attempted'] = 'Y'
     raw_response = call_openai(payload)
     raw_text = extract_output_text(raw_response)
     items = parse_json_array(raw_text)
@@ -869,19 +883,25 @@ def generate_from_crawl(homepage_url, bar_name, neighborhood):
         elapsed,
         len(normalized)
     )
-    return normalized
+    return normalized, stats
 
 
 def generate_from_search(bar_name, neighborhood):
+    stats = {
+        'web_ai_search_prompt_char_count': 0,
+        'web_ai_search_attempted': 'N',
+    }
     started_at = time.perf_counter()
     LOGGER.info('Starting direct web_search flow bar_name=%s neighborhood=%s', bar_name, neighborhood)
     prompt = build_search_prompt(bar_name, neighborhood)
+    stats['web_ai_search_prompt_char_count'] = len(prompt)
     payload = {
         'model': OPENAI_MODEL,
         'tools': [{'type': 'web_search'}],
         'input': prompt,
         'temperature': 0
     }
+    stats['web_ai_search_attempted'] = 'Y'
     raw_response = call_openai(payload)
     raw_text = extract_output_text(raw_response)
     items = parse_json_array(raw_text)
@@ -902,7 +922,7 @@ def generate_from_search(bar_name, neighborhood):
         elapsed,
         len(normalized)
     )
-    return normalized
+    return normalized, stats
 
 
 def lambda_handler(event, context):
@@ -940,13 +960,19 @@ def lambda_handler(event, context):
 
             processed_bars += 1
             try:
-                specials = generate_from_crawl(homepage_url, bar_name, bar_neighborhood)
+                specials, crawl_stats = generate_from_crawl(homepage_url, bar_name, bar_neighborhood)
             except Exception:
                 LOGGER.exception(
                     'Crawl flow crashed for bar_name=%s; falling back to OpenAI web_search',
                     bar.get('bar_name')
                 )
                 specials = []
+                crawl_stats = {
+                    'web_crawl_candidate_links': 0,
+                    'web_crawl_keyword_matches': 0,
+                    'web_crawl_prompt_char_count': 0,
+                    'web_crawl_ai_parse_attempted': 'N',
+                }
             has_fallback_confidence = any(
                 isinstance(special.get('confidence'), (int, float))
                 and special.get('confidence', 0) >= WEB_SCRAPE_FALLBACK_THRESHOLD
@@ -958,7 +984,12 @@ def lambda_handler(event, context):
                     WEB_SCRAPE_FALLBACK_THRESHOLD,
                     bar_name
                 )
-                specials = generate_from_search(bar_name, bar_neighborhood)
+                specials, search_stats = generate_from_search(bar_name, bar_neighborhood)
+            else:
+                search_stats = {
+                    'web_ai_search_prompt_char_count': 0,
+                    'web_ai_search_attempted': 'N',
+                }
             specials = _group_specials_for_insert(specials)
 
             bar_candidates = []
@@ -985,11 +1016,12 @@ def lambda_handler(event, context):
                 'total_candidates': len(bar_candidates),
                 'web_crawl_candidates': bar_crawl_specials_count,
                 'web_ai_search_candidates': bar_web_ai_search_specials_count,
-                'web_crawl_candidate_links': 0,
-                'web_crawl_keyword_matches': 0,
-                'web_crawl_prompt_char_count': 0,
-                'web_crawl_ai_parse_attempted': 'Y' if bar_crawl_specials_count > 0 else 'N',
-                'web_ai_search_attempted': 'Y' if bar_web_ai_search_specials_count > 0 else 'N',
+                'web_crawl_candidate_links': crawl_stats.get('web_crawl_candidate_links', 0),
+                'web_crawl_keyword_matches': crawl_stats.get('web_crawl_keyword_matches', 0),
+                'web_crawl_prompt_char_count': crawl_stats.get('web_crawl_prompt_char_count', 0),
+                'web_ai_search_prompt_char_count': search_stats.get('web_ai_search_prompt_char_count', 0),
+                'web_crawl_ai_parse_attempted': crawl_stats.get('web_crawl_ai_parse_attempted', 'N'),
+                'web_ai_search_attempted': search_stats.get('web_ai_search_attempted', 'N'),
                 'started_at': run_started_at,
                 'completed_at': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
             }


### PR DESCRIPTION
### Motivation
- Telemetry columns in `special_candidate_run` were being written as zeros or derived from candidate counts, causing incorrect values when prompts were sent but produced no candidates.
- The goal is to record actual crawl/search behavior (links tested, keyword hits, prompt sizes, and whether AI calls were attempted) so runs can be audited and monitored accurately.

### Description
- `generate_from_crawl` now computes and returns a `stats` dict containing `web_crawl_candidate_links`, `web_crawl_keyword_matches`, `web_crawl_prompt_char_count`, and `web_crawl_ai_parse_attempted`, and only marks parse attempted when the crawl prompt is sent; changes are in `functions/generateCandidateSpecials/generate_candidate_specials.py`.
- `generate_from_search` now computes and returns a `stats` dict containing `web_ai_search_prompt_char_count` and `web_ai_search_attempted`; changes are in `functions/generateCandidateSpecials/generate_candidate_specials.py`.
- `lambda_handler` was updated to consume the returned `crawl_stats` and `search_stats` and populate `run_payload` fields (`web_crawl_candidate_links`, `web_crawl_keyword_matches`, `web_crawl_prompt_char_count`, `web_ai_search_prompt_char_count`, `web_crawl_ai_parse_attempted`, `web_ai_search_attempted`) instead of inferring attempted flags from candidate counts; changes are in `functions/generateCandidateSpecials/generate_candidate_specials.py`.
- DB insert logic was updated to persist `web_ai_search_prompt_char_count` (SQL column list, placeholders, and bound values) when inserting into `special_candidate_run`; changes are in `functions/dbBarSync/db_bar_sync.py`.

### Testing
- Ran Python syntax check: `python -m py_compile functions/generateCandidateSpecials/generate_candidate_specials.py functions/dbBarSync/db_bar_sync.py`, which completed successfully.
- Verified the modified files were committed with message `Fix special candidate run crawl/search telemetry fields`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfe7ec7f8083308c6cb6e4d9fc020f)