### PR TITLE
Add 'combo' special type with dual icons and filter compatibility

### DIFF
--- a/css/screen-bar-detail.css
+++ b/css/screen-bar-detail.css
@@ -227,8 +227,8 @@
 }
 
 #detail-screen .type-icon.combo svg {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
 }
 
 #detail-screen .no-specials-item {

--- a/css/screen-bar-detail.css
+++ b/css/screen-bar-detail.css
@@ -207,7 +207,10 @@
 }
 
 #detail-screen .type-icon {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   vertical-align: middle;
   margin-left: auto;
   margin-right: 10px;
@@ -221,6 +224,11 @@
 #detail-screen .type-icon svg {
   width: 30px;
   height: 30px;
+}
+
+#detail-screen .type-icon.combo svg {
+  width: 16px;
+  height: 16px;
 }
 
 #detail-screen .no-specials-item {

--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -140,6 +140,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   width: 40px;
   height: 40px;
   flex-shrink: 0;
@@ -152,8 +153,14 @@
   flex-shrink: 0;
 }
 
+.type-icon.combo svg {
+  width: 16px;
+  height: 16px;
+}
+
 .type-icon.food,
-.type-icon.drink {
+.type-icon.drink,
+.type-icon.combo {
   stroke: #8e8e93;
   stroke-width: 1.2;
 }

--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -154,8 +154,8 @@
 }
 
 .type-icon.combo svg {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
 }
 
 .type-icon.food,

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -656,7 +656,8 @@ def normalize_item(item, default_source):
         days = []
 
     normalized_days = [day for day in days if day in DAY_KEYS]
-    item_type = item.get('type') if item.get('type') in ('food', 'drink', 'unknown') else 'unknown'
+    raw_item_type = str(item.get('type') or '').strip().lower()
+    item_type = raw_item_type if raw_item_type in ('food', 'drink', 'combo', 'unknown') else 'unknown'
     text_blob = f"{item.get('description') or ''} {item.get('notes') or ''}"
     parsed_date = _parse_date_from_text(text_blob)
     if parsed_date and parsed_date < date.today():
@@ -703,7 +704,7 @@ def _contains_money_signal(text):
 
 
 def _mentions_food_or_drink(item):
-    if item.get('type') in ('food', 'drink'):
+    if item.get('type') in ('food', 'drink', 'combo'):
         return True
     blob = f"{item.get('description', '')} {item.get('notes', '')}".lower()
     return any(term in blob for term in FOOD_DRINK_CLUES)

--- a/js/app.js
+++ b/js/app.js
@@ -94,7 +94,7 @@ function updateFilterSectionVisibility() {
 function getFilteredFavorites() {
   return getFavoriteSpecialEntries().filter((item) => {
     const specialType = item.special.special_type || item.special.type;
-    const typePass = activeFilters.types.length === 0 || activeFilters.types.includes(specialType);
+    const typePass = specialMatchesTypeFilters(specialType, activeFilters.types);
     const neighborhoodPass = activeFilters.neighborhoods.length === 0 || activeFilters.neighborhoods.includes(item.bar.neighborhood);
     const favoritesPass = !activeFilters.favoritesOnly || item.special.favorite === true || item.bar.favorite === true;
     return typePass && neighborhoodPass && favoritesPass;

--- a/js/render-home.js
+++ b/js/render-home.js
@@ -33,7 +33,7 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
 
   groupedSpecials.forEach((special) => {
     const specialType = special.special_type || special.type;
-    const typePass = activeFilters.types.length === 0 || activeFilters.types.includes(specialType);
+    const typePass = specialMatchesTypeFilters(specialType, activeFilters.types);
     const favoritesPass = !activeFilters.favoritesOnly || special.favorite === true || isBarFavorite;
     if (!typePass || !favoritesPass) return;
 

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -237,7 +237,7 @@ function renderMapTab() {
     return specialIds.some((specialId) => {
       const special = startupPayload?.specials?.[String(specialId)];
       const specialType = special?.special_type || special?.type;
-      return Boolean(specialType && activeFilters.types.includes(specialType));
+      return specialMatchesTypeFilters(specialType, activeFilters.types);
     });
   });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -134,6 +134,25 @@ function groupSpecialsForUI(specials) {
   });
 }
 
+function normalizeSpecialType(type) {
+  return String(type || '').trim().toLowerCase();
+}
+
+function specialMatchesTypeFilters(specialType, selectedTypes = []) {
+  if (!Array.isArray(selectedTypes) || selectedTypes.length === 0) return true;
+
+  const normalizedSpecialType = normalizeSpecialType(specialType);
+  const normalizedSelectedTypes = selectedTypes.map((type) => normalizeSpecialType(type));
+
+  if (normalizedSpecialType === 'combo') {
+    return normalizedSelectedTypes.includes('combo')
+      || normalizedSelectedTypes.includes('food')
+      || normalizedSelectedTypes.includes('drink');
+  }
+
+  return normalizedSelectedTypes.includes(normalizedSpecialType);
+}
+
 function buildSpecialItem(special, { isToday = false, clickable = false, onClick = null, neutralTimeBadgeStyle = false } = {}) {
   const item = document.createElement('div');
   item.className = 'special-item';
@@ -161,11 +180,20 @@ function buildSpecialItem(special, { isToday = false, clickable = false, onClick
     item.classList.add('live');
   }
 
-  const specialType = special.special_type || special.type || '';
+  const specialType = normalizeSpecialType(special.special_type || special.type || '');
   const typeIcon = document.createElement('span');
   typeIcon.className = `type-icon ${specialType}`;
-  if (specialType === 'food') typeIcon.setAttribute('data-lucide', 'utensils');
-  else if (specialType === 'drink') typeIcon.setAttribute('data-lucide', 'beer');
+
+  const icons = specialType === 'combo'
+    ? ['utensils', 'beer']
+    : (specialType === 'food' ? ['utensils'] : (specialType === 'drink' ? ['beer'] : []));
+
+  icons.forEach((iconName) => {
+    const icon = document.createElement('span');
+    icon.className = 'type-icon-glyph';
+    icon.setAttribute('data-lucide', iconName);
+    typeIcon.appendChild(icon);
+  });
 
   const desc = document.createElement('span');
   desc.className = 'special-description';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -687,6 +687,27 @@ test('buildSpecialItem clickable rows stop parent click handling and navigate to
   assert.equal(onClickCalled, true, 'clickable specials still execute their own navigation handler');
 });
 
+test('combo specials render both icons and pass food/drink type filters', () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  const comboItem = ctx.buildSpecialItem({
+    description: 'Burger + Beer',
+    special_type: 'combo',
+    all_day: true
+  });
+
+  const iconGlyphs = comboItem.querySelectorAll('.type-icon-glyph');
+  assert.equal(iconGlyphs.length, 2, 'combo specials render two type icons');
+  assert.equal(iconGlyphs[0].getAttribute('data-lucide'), 'utensils');
+  assert.equal(iconGlyphs[1].getAttribute('data-lucide'), 'beer');
+
+  assert.equal(ctx.specialMatchesTypeFilters('combo', ['food']), true);
+  assert.equal(ctx.specialMatchesTypeFilters('combo', ['drink']), true);
+  assert.equal(ctx.specialMatchesTypeFilters('food', ['drink']), false);
+});
+
 
 test('showDetail reuses startup payload details when has_special_this_week is true', async () => {
   const document = new DocumentMock();


### PR DESCRIPTION
### Motivation
- Support specials that represent a combination of food and drink (e.g., "Burger + Beer") as a first-class `combo` type in data and UI.
- Ensure combo specials are displayed with both food and drink icons and that type filters treat `combo` as matching `food` and `drink` selections.
- Improve icon layout in several UI areas so multiple glyphs render and size correctly.

### Description
- Add `combo` handling in the crawl normalization by accepting `type` values of `combo` in `normalize_item` and treating `combo` as a food/drink mention in `_mentions_food_or_drink` in `generate_candidate_specials.py`.
- Introduce `normalizeSpecialType` and `specialMatchesTypeFilters` helper functions in `js/utils.js` and update filter checks in `js/app.js`, `js/render-home.js`, and `js/render-map.js` to use the new matching logic.
- Update `buildSpecialItem` in `js/utils.js` to render two icon glyphs for `combo` specials (`utensils` and `beer`) and to normalize special type usage when building the element.
- Adjust CSS in `css/tab-special.css` and `css/screen-bar-detail.css` to support flex layout and spacing for multiple icons and add a smaller size for `.type-icon.combo svg`.
- Add a unit test `combo specials render both icons and pass food/drink type filters` in `tests/app.test.js` to verify rendering and filter matching.

### Testing
- Ran the JavaScript unit test suite via `npm test` which includes the new `combo` test in `tests/app.test.js`, and the suite passed.
- Verified the new unit test asserts that combo items render two `.type-icon-glyph` elements and that `specialMatchesTypeFilters('combo', ['food'])` and `specialMatchesTypeFilters('combo', ['drink'])` return `true`.
- Existing tests that exercise `buildSpecialItem` still pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d116e3448330a7cf4c35a66d572d)