### PR TITLE
Add 'combo' special type with UI icons and filter support

### DIFF
--- a/css/screen-bar-detail.css
+++ b/css/screen-bar-detail.css
@@ -207,7 +207,10 @@
 }
 
 #detail-screen .type-icon {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   vertical-align: middle;
   margin-left: auto;
   margin-right: 10px;

--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -140,6 +140,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   width: 40px;
   height: 40px;
   flex-shrink: 0;
@@ -153,7 +154,8 @@
 }
 
 .type-icon.food,
-.type-icon.drink {
+.type-icon.drink,
+.type-icon.combo {
   stroke: #8e8e93;
   stroke-width: 1.2;
 }

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -656,7 +656,8 @@ def normalize_item(item, default_source):
         days = []
 
     normalized_days = [day for day in days if day in DAY_KEYS]
-    item_type = item.get('type') if item.get('type') in ('food', 'drink', 'unknown') else 'unknown'
+    raw_item_type = str(item.get('type') or '').strip().lower()
+    item_type = raw_item_type if raw_item_type in ('food', 'drink', 'combo', 'unknown') else 'unknown'
     text_blob = f"{item.get('description') or ''} {item.get('notes') or ''}"
     parsed_date = _parse_date_from_text(text_blob)
     if parsed_date and parsed_date < date.today():
@@ -703,7 +704,7 @@ def _contains_money_signal(text):
 
 
 def _mentions_food_or_drink(item):
-    if item.get('type') in ('food', 'drink'):
+    if item.get('type') in ('food', 'drink', 'combo'):
         return True
     blob = f"{item.get('description', '')} {item.get('notes', '')}".lower()
     return any(term in blob for term in FOOD_DRINK_CLUES)

--- a/js/app.js
+++ b/js/app.js
@@ -94,7 +94,7 @@ function updateFilterSectionVisibility() {
 function getFilteredFavorites() {
   return getFavoriteSpecialEntries().filter((item) => {
     const specialType = item.special.special_type || item.special.type;
-    const typePass = activeFilters.types.length === 0 || activeFilters.types.includes(specialType);
+    const typePass = specialMatchesTypeFilters(specialType, activeFilters.types);
     const neighborhoodPass = activeFilters.neighborhoods.length === 0 || activeFilters.neighborhoods.includes(item.bar.neighborhood);
     const favoritesPass = !activeFilters.favoritesOnly || item.special.favorite === true || item.bar.favorite === true;
     return typePass && neighborhoodPass && favoritesPass;

--- a/js/render-home.js
+++ b/js/render-home.js
@@ -33,7 +33,7 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
 
   groupedSpecials.forEach((special) => {
     const specialType = special.special_type || special.type;
-    const typePass = activeFilters.types.length === 0 || activeFilters.types.includes(specialType);
+    const typePass = specialMatchesTypeFilters(specialType, activeFilters.types);
     const favoritesPass = !activeFilters.favoritesOnly || special.favorite === true || isBarFavorite;
     if (!typePass || !favoritesPass) return;
 

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -237,7 +237,7 @@ function renderMapTab() {
     return specialIds.some((specialId) => {
       const special = startupPayload?.specials?.[String(specialId)];
       const specialType = special?.special_type || special?.type;
-      return Boolean(specialType && activeFilters.types.includes(specialType));
+      return specialMatchesTypeFilters(specialType, activeFilters.types);
     });
   });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -134,6 +134,25 @@ function groupSpecialsForUI(specials) {
   });
 }
 
+function normalizeSpecialType(type) {
+  return String(type || '').trim().toLowerCase();
+}
+
+function specialMatchesTypeFilters(specialType, selectedTypes = []) {
+  if (!Array.isArray(selectedTypes) || selectedTypes.length === 0) return true;
+
+  const normalizedSpecialType = normalizeSpecialType(specialType);
+  const normalizedSelectedTypes = selectedTypes.map((type) => normalizeSpecialType(type));
+
+  if (normalizedSpecialType === 'combo') {
+    return normalizedSelectedTypes.includes('combo')
+      || normalizedSelectedTypes.includes('food')
+      || normalizedSelectedTypes.includes('drink');
+  }
+
+  return normalizedSelectedTypes.includes(normalizedSpecialType);
+}
+
 function buildSpecialItem(special, { isToday = false, clickable = false, onClick = null, neutralTimeBadgeStyle = false } = {}) {
   const item = document.createElement('div');
   item.className = 'special-item';
@@ -161,11 +180,20 @@ function buildSpecialItem(special, { isToday = false, clickable = false, onClick
     item.classList.add('live');
   }
 
-  const specialType = special.special_type || special.type || '';
+  const specialType = normalizeSpecialType(special.special_type || special.type || '');
   const typeIcon = document.createElement('span');
   typeIcon.className = `type-icon ${specialType}`;
-  if (specialType === 'food') typeIcon.setAttribute('data-lucide', 'utensils');
-  else if (specialType === 'drink') typeIcon.setAttribute('data-lucide', 'beer');
+
+  const icons = specialType === 'combo'
+    ? ['utensils', 'beer']
+    : (specialType === 'food' ? ['utensils'] : (specialType === 'drink' ? ['beer'] : []));
+
+  icons.forEach((iconName) => {
+    const icon = document.createElement('span');
+    icon.className = 'type-icon-glyph';
+    icon.setAttribute('data-lucide', iconName);
+    typeIcon.appendChild(icon);
+  });
 
   const desc = document.createElement('span');
   desc.className = 'special-description';

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -687,6 +687,27 @@ test('buildSpecialItem clickable rows stop parent click handling and navigate to
   assert.equal(onClickCalled, true, 'clickable specials still execute their own navigation handler');
 });
 
+test('combo specials render both icons and pass food/drink type filters', () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  const comboItem = ctx.buildSpecialItem({
+    description: 'Burger + Beer',
+    special_type: 'combo',
+    all_day: true
+  });
+
+  const iconGlyphs = comboItem.querySelectorAll('.type-icon-glyph');
+  assert.equal(iconGlyphs.length, 2, 'combo specials render two type icons');
+  assert.equal(iconGlyphs[0].getAttribute('data-lucide'), 'utensils');
+  assert.equal(iconGlyphs[1].getAttribute('data-lucide'), 'beer');
+
+  assert.equal(ctx.specialMatchesTypeFilters('combo', ['food']), true);
+  assert.equal(ctx.specialMatchesTypeFilters('combo', ['drink']), true);
+  assert.equal(ctx.specialMatchesTypeFilters('food', ['drink']), false);
+});
+
 
 test('showDetail reuses startup payload details when has_special_this_week is true', async () => {
   const document = new DocumentMock();


### PR DESCRIPTION
### Motivation
- Support specials that combine food and drink as a distinct `combo` type and ensure they render correctly and match existing food/drink filters.

### Description
- Add `combo` handling to normalization and classification in `functions/generateCandidateSpecials/generate_candidate_specials.py` so items with `type` of `combo` are recognized and treated as food/drink content.
- Update CSS (`css/screen-bar-detail.css`, `css/tab-special.css`) to better layout type icons using `inline-flex`/`flex` and `gap` to accommodate multiple glyphs.
- Introduce `normalizeSpecialType` and `specialMatchesTypeFilters` in `js/utils.js` and replace direct type checks in filter logic (`js/app.js`, `js/render-home.js`, `js/render-map.js`) to ensure `combo` matches `food` and `drink` filters as appropriate.
- Render multiple icon glyphs for `combo` specials in `js/render-home.js` / `js/app.js` by adding two glyph spans (`utensils` and `beer`) and normalizing special type handling.

### Testing
- Ran the automated unit test suite via `npm test` which includes the added test `combo specials render both icons and pass food/drink type filters` in `tests/app.test.js`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d116e3448330a7cf4c35a66d572d)