### PR TITLE
Fix combo special icon spacing inside cards

### DIFF
--- a/css/screen-bar-detail.css
+++ b/css/screen-bar-detail.css
@@ -214,7 +214,9 @@
   vertical-align: middle;
   margin-left: auto;
   margin-right: 10px;
-  width: 40px;
+  min-width: 40px;
+  width: auto;
+  padding: 0 6px;
   height: 40px;
   stroke: #8e8e93;
   stroke-width: 1;

--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -141,7 +141,9 @@
   align-items: center;
   justify-content: center;
   gap: 4px;
-  width: 40px;
+  min-width: 40px;
+  width: auto;
+  padding: 0 6px;
   height: 40px;
   flex-shrink: 0;
 }


### PR DESCRIPTION
### Motivation
- Give combo special icons enough horizontal breathing room so the food icon doesn't sit flush against the special card edge.

### Description
- Replace the fixed `width: 40px` on the icon container with `min-width: 40px`, `width: auto`, and `padding: 0 6px` in `css/tab-special.css` and `css/screen-bar-detail.css` to allow combo icons to render side-by-side with proper spacing.

### Testing
- Ran `npm test`, which failed because `package.json` is missing in the repository, so no automated tests were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92e2d7f3c8330b9c6bcf64ab1f534)