### PR TITLE
Add admin UI and tap-to-enter shortcut; ensure bottom taskbar visibility

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,0 +1,53 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+  background: #fff;
+}
+
+.admin-toolbar {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background-color: #007bff;
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.admin-toolbar-inner {
+  height: 48px;
+  max-width: 480px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.admin-title {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.admin-home-button {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+
+.admin-screen {
+  max-width: 480px;
+  margin: 48px auto 0;
+  min-height: calc(100vh - 48px);
+  min-height: calc(100dvh - 48px);
+}

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,8 @@
+(function initAdminPage() {
+  const homeButton = document.getElementById('admin-home-button');
+  if (!homeButton) return;
+
+  homeButton.addEventListener('click', () => {
+    window.location.assign('/');
+  });
+}());

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Admin</title>
+<link rel="stylesheet" href="/admin/admin.css">
+</head>
+<body>
+<div class="admin-toolbar">
+  <div class="admin-toolbar-inner">
+    <span class="admin-title">admin</span>
+    <button id="admin-home-button" class="admin-home-button" type="button" aria-label="Go home">
+      <span data-lucide="house"></span>
+    </button>
+  </div>
+</div>
+<main class="admin-screen" aria-label="Admin screen"></main>
+
+<script src="https://cdn.jsdelivr.net/npm/lucide@0.575.0/dist/umd/lucide.js"></script>
+<script>lucide.createIcons();</script>
+<script src="/admin/admin.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,10 @@
 function setScreenLayout(isHome) {
   const toolbar = document.querySelector('.home-toolbar');
   const appContainer = document.querySelector('.app-container');
+  const bottomTaskbar = document.querySelector('.bottom-taskbar');
 
   if (toolbar) toolbar.style.display = isHome ? 'block' : 'none';
+  if (bottomTaskbar) bottomTaskbar.style.display = 'flex';
   if (appContainer) appContainer.classList.toggle('detail-mode', !isHome);
 }
 
@@ -149,6 +151,30 @@ function initBarsSearch() {
   });
 }
 
+function initAdminTitleTapEntry() {
+  const appTitle = document.querySelector('.app-title');
+  const tapThreshold = 5;
+  const tapResetMs = 1200;
+  let tapCount = 0;
+  let tapTimer = null;
+
+  if (!appTitle) return;
+
+  appTitle.addEventListener('click', () => {
+    tapCount += 1;
+    if (tapTimer) clearTimeout(tapTimer);
+    tapTimer = setTimeout(() => {
+      tapCount = 0;
+    }, tapResetMs);
+
+    if (tapCount >= tapThreshold) {
+      tapCount = 0;
+      if (tapTimer) clearTimeout(tapTimer);
+      window.location.assign('/admin');
+    }
+  });
+}
+
 function initHomeScrollCapture() {
   document.addEventListener('wheel', (event) => {
     const homeScreen = document.getElementById('home-screen');
@@ -258,6 +284,7 @@ function hideInitialLoadingOverlay() {
 initSidebarFilters();
 initTaskbar();
 initBarsSearch();
+initAdminTitleTapEntry();
 initHomeScrollCapture();
 if (typeof initMapDayController === 'function') {
   initMapDayController();
@@ -265,6 +292,7 @@ if (typeof initMapDayController === 'function') {
 initSpecialReport();
 initBarReport();
 initSpecialFavoriteButton();
+
 showTab(currentTab);
 setScreenLayout(true);
 loadBars();


### PR DESCRIPTION
### Motivation

- Provide a lightweight admin page and a hidden entry point for developers/operators without adding visible navigation to the main UI.
- Ensure the bottom taskbar is shown consistently when switching screen layout.

### Description

- Add `admin/index.html`, `admin/admin.css`, and `admin/admin.js` to provide a simple fixed admin toolbar, home button, and Lucide icon integration.
- Implement `initAdminTitleTapEntry()` in `js/app.js` which navigates to `/admin` after the app title is clicked `5` times within `1200ms`, and wire it into initialization by calling `initAdminTitleTapEntry()`.
- Update `setScreenLayout()` in `js/app.js` to select `.bottom-taskbar` and set its `display` to `flex` when toggling layouts.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d932899f1c83308a1a30d65b3b8c30)