### PR TITLE
Admin: add back navigation, route home to app root, and show run metadata in approvals

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -139,6 +139,15 @@ body {
   font-size: 13px;
 }
 
+.admin-run-sublist {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
 .admin-candidate-list {
   display: flex;
   flex-direction: column;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -187,7 +187,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     screenElement.innerHTML = `
       <section class="admin-home-view" aria-label="Admin tools">
         <h2>Admin tools</h2>
-        <button type="button" class="admin-tool-button" data-tool="specials-to-be-approved">Specials to be Approved</button>
+        <button type="button" class="admin-tool-button" data-tool="specials-to-be-approved">Specials Pending Approval</button>
       </section>
     `;
     bindToolButtons();
@@ -203,7 +203,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
     screenElement.innerHTML = `
       <section class="admin-specials-view" aria-label="Special approvals">
-        <h2>Specials to be Approved</h2>
+        <h2>Specials Pending Approval</h2>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildRunsMarkup()}
       </section>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,10 +1,11 @@
 const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/dbAdminSync';
 
 (function initAdminPage() {
+  const backButton = document.getElementById('admin-back-button');
   const homeButton = document.getElementById('admin-home-button');
   const titleElement = document.getElementById('admin-title');
   const screenElement = document.getElementById('admin-screen');
-  if (!homeButton || !titleElement || !screenElement) return;
+  if (!backButton || !homeButton || !titleElement || !screenElement) return;
 
   const state = {
     currentView: 'home',
@@ -14,14 +15,20 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     errorMessage: ''
   };
 
-  homeButton.addEventListener('click', () => {
-    if (state.currentView === 'home') {
-      window.location.assign('/');
-      return;
-    }
+  function updateToolbarButtons() {
+    const isHomeView = state.currentView === 'home';
+    backButton.classList.toggle('is-hidden', isHomeView);
+  }
+
+  backButton.addEventListener('click', () => {
+    if (state.currentView === 'home') return;
     state.currentView = 'home';
     state.errorMessage = '';
     render();
+  });
+
+  homeButton.addEventListener('click', () => {
+    window.location.assign('/');
   });
 
   async function callAdminSync(payload) {
@@ -130,6 +137,19 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         <section class="admin-run-card">
           <h3>Run ${run.run_id} — ${run.bar_name || 'Unknown bar'}</h3>
           <p><strong>Total candidates:</strong> ${run.total_candidates ?? '—'}</p>
+          <p><strong>Auto Approved Candidates:</strong> ${run.auto_approved_candidates ?? '—'}</p>
+          <p><strong>Web Crawl:</strong></p>
+          <ul class="admin-run-sublist">
+            <li><strong>AI Parse Attempted:</strong> ${run.web_crawl_ai_parse_attempted ?? '—'}</li>
+            <li><strong>Candidates:</strong> ${run.web_crawl_candidates ?? '—'}</li>
+            <li><strong>Candidate Links:</strong> ${run.web_crawl_candidate_links ?? '—'}</li>
+            <li><strong>Keyword Matches:</strong> ${run.web_crawl_keyword_matches ?? '—'}</li>
+          </ul>
+          <p><strong>Web AI Search:</strong></p>
+          <ul class="admin-run-sublist">
+            <li><strong>Attempted:</strong> ${run.web_ai_search_attempted ?? '—'}</li>
+            <li><strong>Candidates:</strong> ${run.web_ai_search_candidates ?? '—'}</li>
+          </ul>
           <p><strong>Started:</strong> ${formatDateTime(run.started_at)}</p>
           <p><strong>Completed:</strong> ${formatDateTime(run.completed_at)}</p>
           <div class="admin-candidate-list">${specialsMarkup}</div>
@@ -193,6 +213,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function render() {
+    updateToolbarButtons();
     if (state.currentView === 'specials') {
       renderSpecialsView();
       return;


### PR DESCRIPTION
### Motivation
- Make the admin toolbar behave like a normal app: provide a back control for nested admin tool pages while keeping the main admin menu clean, and ensure the home action returns to the app home page instead of the admin index. 
- Surface more run-level metadata in the "Specials to be Approved" queue so reviewers can see crawl/AI run diagnostics when evaluating candidates.

### Description
- Wire up the admin back button by querying `#admin-back-button`, adding a `back` click handler that returns the UI to the admin home view, and toggle the back button visibility based on `state.currentView` via `updateToolbarButtons()`; call `updateToolbarButtons()` from `render()` so the toolbar updates when views change (file: `admin/admin.js`).
- Change the admin home button to always navigate to the app root with `window.location.assign('/')` (file: `admin/admin.js`).
- Expand the run card markup in the specials approval view to include `auto_approved_candidates`, a Web Crawl block (AI parse attempted, candidates, candidate links, keyword matches), and Web AI Search info (attempted and candidates) (file: `admin/admin.js`).
- Add `.admin-run-sublist` CSS to style nested run metadata lists so new fields are readable (file: `admin/admin.css`).

### Testing
- Ran `node --check admin/admin.js` to validate the modified admin script and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd121b34fc83309ccb2d205645ec4e)