### PR TITLE
Reuse inactive specials during auto publish

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -8,6 +8,17 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   if (!backButton || !homeButton || !titleElement || !screenElement) return;
 
   const DAY_ORDER = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'];
+  const ADMIN_TIMEZONE = 'America/New_York';
+  const ADMIN_DATETIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    timeZone: ADMIN_TIMEZONE,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short'
+  });
   const DAY_LABELS = {
     MONDAY: 'Mon',
     TUESDAY: 'Tue',
@@ -78,7 +89,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     if (!value) return '—';
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return String(value);
-    return date.toLocaleString();
+    return ADMIN_DATETIME_FORMATTER.format(date);
   }
 
   function formatTime(value) {

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -256,10 +256,9 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     manual_filter_clause = "AND insert_method <> 'MANUAL'" if IGNORE_MANUAL_SPECIALS_ON_PUBLISH == 'Y' else ''
     cursor.execute(
         f"""
-        SELECT special_id, day_of_week, all_day, start_time, end_time, description
+        SELECT special_id, day_of_week, all_day, start_time, end_time, description, is_active
         FROM special
         WHERE bar_id = %s
-            AND is_active = 'Y'
             {manual_filter_clause}
         """,
         (bar_id,),
@@ -296,10 +295,21 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
 
     for special in existing_specials:
         if special['special_id'] not in matched_special_ids:
+            if special.get('is_active') == 'Y':
+                cursor.execute(
+                    """
+                    UPDATE special
+                    SET is_active = 'N',
+                        update_date = NOW()
+                    WHERE special_id = %s
+                    """,
+                    (special['special_id'],),
+                )
+        elif special.get('is_active') != 'Y':
             cursor.execute(
                 """
                 UPDATE special
-                SET is_active = 'N',
+                SET is_active = 'Y',
                     update_date = NOW()
                 WHERE special_id = %s
                 """,
@@ -339,7 +349,11 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             (approved_special_id, candidate_id),
         )
 
-    deactivated_special_count = len(existing_specials) - len(matched_special_ids)
+    deactivated_special_count = sum(
+        1
+        for special in existing_specials
+        if special.get('is_active') == 'Y' and special['special_id'] not in matched_special_ids
+    )
     cursor.execute(
         """
         UPDATE special_candidate_run

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -315,6 +315,15 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 """,
                 (special['special_id'],),
             )
+        else:
+            cursor.execute(
+                """
+                UPDATE special
+                SET update_date = NOW()
+                WHERE special_id = %s
+                """,
+                (special['special_id'],),
+            )
 
     inserted_special_count = 0
     for candidate in unmatched_candidates:


### PR DESCRIPTION
### Motivation
- Prevent duplicate special rows when an automated scrape rediscovers a previously deactivated special by allowing reuse of existing records.
- Reduce database bloat by reactivating matching inactive specials instead of inserting new ones.
- Preserve current deactivation behavior for unmatched active specials while counting only those that were actually active.

### Description
- `publish_special_candidate_run` now loads all specials for the bar (removed the `is_active = 'Y'` restriction) and includes the `is_active` column in the query.
- When a candidate matches an existing special that is inactive, the code sets `is_active = 'Y'` and updates `update_date = NOW()` to reactivate the row.
- Unmatched specials are only deactivated if they were active prior to publish; the code checks `is_active == 'Y'` before updating to `'N'`.
- `deactivated_special_count` calculation was adjusted to count only previously active specials that were deactivated.

### Testing
- Ran `python -m py_compile functions/dbSpecialSync/db_special_sync.py` and it completed successfully.
- No additional automated tests were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd557d078c8330b6170d3183db3a5f)