### PR TITLE
Add edit controls for pending specials and use run neighborhood

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -179,6 +179,10 @@ body {
   background: #1c8d3b;
 }
 
+.admin-action-btn.edit {
+  background: #2f6fd1;
+}
+
 .admin-action-btn.reject {
   background: #bc2f2f;
 }

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -483,7 +483,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             <h4>${isEditing ? 'Editing Special Candidate' : (special.description || 'No description')}</h4>
             <p><strong>Description:</strong> ${editableValue('description')}</p>
             <p><strong>Type:</strong> ${editableValue('type')}</p>
-            <p><strong>Neighborhood:</strong> ${run.neighborhood || '—'}</p>
             <p><strong>Days:</strong> ${editableValue('days_of_week', '—')}</p>
             <p><strong>All Day:</strong> ${editableValue('all_day', 'N')}</p>
             <p><strong>Start Time:</strong> ${editableValue('start_time')}</p>
@@ -496,7 +495,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               ${isEditing
                 ? `<button class="admin-action-btn approve" type="button" data-candidate-action="save-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Save</button>
                    <button class="admin-secondary-btn" type="button" data-candidate-action="cancel-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Cancel</button>`
-                : `<button class="admin-secondary-btn" type="button" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Edit</button>
+                : `<button class="admin-action-btn edit" type="button" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Edit</button>
                    <button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
                    <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>`}
             </div>
@@ -507,6 +506,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       return `
         <section class="admin-run-card">
           <h3>Run ${run.run_id} — ${run.bar_name || 'Unknown bar'}</h3>
+          <p><strong>Neighborhood:</strong> ${run.neighborhood || '—'}</p>
           <p><strong>Total candidates:</strong> ${run.total_candidates ?? '—'}</p>
           <p><strong>Auto Approved Candidates:</strong> ${run.auto_approved_candidates ?? '—'}</p>
           <p><strong>Started:</strong> ${formatDateTime(run.started_at)}</p>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -34,6 +34,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     loading: false,
     loadingSpecials: false,
     updatingCandidateId: null,
+    editingCandidateId: null,
+    savingCandidate: false,
     actionSpecialId: null,
     detailSpecials: [],
     detailEditing: false,
@@ -276,6 +278,25 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     }
   }
 
+  async function saveCandidateUpdates(payload) {
+    state.savingCandidate = true;
+    state.errorMessage = '';
+    render();
+
+    try {
+      await callAdminSync({ mode: 'update_special_candidate', ...payload });
+      await loadUnapprovedSpecials();
+      state.editingCandidateId = null;
+    } catch (err) {
+      console.error('Failed to update candidate:', err);
+      state.errorMessage = err?.message || 'Failed to update candidate.';
+      render();
+    } finally {
+      state.savingCandidate = false;
+      render();
+    }
+  }
+
   async function saveSpecialUpdates(payloads) {
     const updates = Array.isArray(payloads) ? payloads : [payloads];
     state.savingSpecial = true;
@@ -446,23 +467,38 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       const specialsMarkup = (run.specials || []).map((special) => {
         const candidateId = Number(special.special_candidate_id);
         const isUpdating = state.updatingCandidateId === candidateId;
-        const days = Array.isArray(special.days_of_week) ? special.days_of_week.join(', ') : '—';
+        const isEditing = state.editingCandidateId === candidateId;
+        const days = Array.isArray(special.days_of_week) ? special.days_of_week.join(', ') : '';
         const confidence = special.confidence === null || special.confidence === undefined ? '—' : String(special.confidence);
+        const editableValue = (field, fallback = '—') => {
+          const value = special[field] ?? '';
+          if (isEditing) {
+            return `<input class="admin-input" data-candidate-id="${candidateId}" data-candidate-field="${field}" value="${value}" />`;
+          }
+          return value === '' ? fallback : String(value);
+        };
 
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
-            <h4>${special.description || 'No description'}</h4>
-            <p><strong>Type:</strong> ${special.type || '—'}</p>
-            <p><strong>Neighborhood:</strong> ${special.neighborhood || '—'}</p>
-            <p><strong>Days:</strong> ${days}</p>
-            <p><strong>Time:</strong> ${formatTime(special.start_time)} - ${formatTime(special.end_time)} (All day: ${special.all_day || 'N'})</p>
+            <h4>${isEditing ? 'Editing Special Candidate' : (special.description || 'No description')}</h4>
+            <p><strong>Description:</strong> ${editableValue('description')}</p>
+            <p><strong>Type:</strong> ${editableValue('type')}</p>
+            <p><strong>Neighborhood:</strong> ${run.neighborhood || '—'}</p>
+            <p><strong>Days:</strong> ${editableValue('days_of_week', '—')}</p>
+            <p><strong>All Day:</strong> ${editableValue('all_day', 'N')}</p>
+            <p><strong>Start Time:</strong> ${editableValue('start_time')}</p>
+            <p><strong>End Time:</strong> ${editableValue('end_time')}</p>
             <p><strong>Confidence:</strong> ${confidence}</p>
             <p><strong>Method:</strong> ${special.fetch_method || '—'}</p>
             <p><strong>Source:</strong> ${special.source || '—'}</p>
             <p><strong>Notes:</strong> ${special.notes || '—'}</p>
             <div class="admin-actions-row">
-              <button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
-              <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>
+              ${isEditing
+                ? `<button class="admin-action-btn approve" type="button" data-candidate-action="save-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Save</button>
+                   <button class="admin-secondary-btn" type="button" data-candidate-action="cancel-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Cancel</button>`
+                : `<button class="admin-secondary-btn" type="button" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Edit</button>
+                   <button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
+                   <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>`}
             </div>
           </article>
         `;
@@ -537,6 +573,35 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         const action = button.getAttribute('data-action');
         if (!candidateId || !action) return;
         updateCandidateApproval(candidateId, action);
+      });
+    });
+
+    screenElement.querySelectorAll('[data-candidate-action][data-candidate-id]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const candidateId = Number(button.getAttribute('data-candidate-id'));
+        const action = button.getAttribute('data-candidate-action');
+        if (!candidateId || !action) return;
+
+        if (action === 'edit') {
+          state.editingCandidateId = candidateId;
+          render();
+          return;
+        }
+
+        if (action === 'cancel-edit') {
+          state.editingCandidateId = null;
+          render();
+          return;
+        }
+
+        if (action === 'save-edit') {
+          const payload = { special_candidate_id: candidateId };
+          screenElement.querySelectorAll(`[data-candidate-id="${candidateId}"][data-candidate-field]`).forEach((input) => {
+            const field = input.getAttribute('data-candidate-field');
+            payload[field] = input.value;
+          });
+          await saveCandidateUpdates(payload);
+        }
       });
     });
   }

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -54,6 +54,31 @@ def _parse_days_of_week(raw_days) -> List[str]:
     return [day for day in raw_days if isinstance(day, str) and day.strip()]
 
 
+def _normalize_days_input(raw_days) -> List[str]:
+    if isinstance(raw_days, list):
+        candidates = raw_days
+    else:
+        value = str(raw_days or '').strip()
+        if not value:
+            return []
+        if value.startswith('['):
+            try:
+                parsed = json.loads(value)
+                candidates = parsed if isinstance(parsed, list) else []
+            except json.JSONDecodeError:
+                candidates = []
+        else:
+            candidates = [segment.strip() for segment in value.split(',')]
+
+    normalized = []
+    for day in candidates:
+        parsed_day = _normalize_day_of_week(day)
+        if parsed_day:
+            normalized.append(parsed_day)
+
+    return list(dict.fromkeys(normalized))
+
+
 def _normalize_day_of_week(value) -> str:
     if value is None:
         return ''
@@ -240,6 +265,7 @@ def get_unapproved_special_candidates(cursor):
         SELECT
             scr.run_id,
             b.name AS bar_name,
+            b.neighborhood AS run_neighborhood,
             scr.total_candidates,
             scr.auto_approved_candidates,
             scr.web_crawl_candidates,
@@ -252,7 +278,6 @@ def get_unapproved_special_candidates(cursor):
             scr.started_at,
             scr.completed_at,
             sc.special_candidate_id,
-            sc.neighborhood,
             sc.description,
             sc.days_of_week,
             sc.type,
@@ -281,6 +306,7 @@ def get_unapproved_special_candidates(cursor):
             {
                 'run_id': run_id,
                 'bar_name': row.get('bar_name'),
+                'neighborhood': row.get('run_neighborhood'),
                 'total_candidates': row.get('total_candidates'),
                 'auto_approved_candidates': row.get('auto_approved_candidates'),
                 'web_crawl_candidates': row.get('web_crawl_candidates'),
@@ -298,7 +324,6 @@ def get_unapproved_special_candidates(cursor):
         run['specials'].append(
             {
                 'special_candidate_id': row.get('special_candidate_id'),
-                'neighborhood': row.get('neighborhood'),
                 'description': row.get('description'),
                 'days_of_week': _parse_days_of_week(row.get('days_of_week')),
                 'type': row.get('type'),
@@ -547,6 +572,71 @@ def update_special(cursor, event):
     }
 
 
+def update_special_candidate(cursor, event):
+    special_candidate_id = event.get('special_candidate_id')
+    if not special_candidate_id:
+        raise ValueError('special_candidate_id is required for update_special_candidate')
+
+    editable_fields = {
+        'description',
+        'all_day',
+        'days_of_week',
+        'start_time',
+        'end_time',
+        'type',
+    }
+    updates = {}
+    for field in editable_fields:
+        if field in event:
+            updates[field] = event.get(field)
+
+    if not updates:
+        raise ValueError('At least one editable field must be provided for update_special_candidate')
+
+    if 'all_day' in updates:
+        updates['all_day'] = _normalize_yn_flag(updates.get('all_day'))
+    if 'days_of_week' in updates:
+        updates['days_of_week'] = json.dumps(_normalize_days_input(updates.get('days_of_week')))
+    if 'start_time' in updates:
+        updates['start_time'] = _normalize_time_value(updates.get('start_time')) or None
+    if 'end_time' in updates:
+        updates['end_time'] = _normalize_time_value(updates.get('end_time')) or None
+
+    set_clause = ', '.join([f"{key} = %s" for key in updates])
+    values = list(updates.values()) + [special_candidate_id]
+
+    cursor.execute(
+        f"""
+        UPDATE special_candidate
+        SET {set_clause}
+        WHERE special_candidate_id = %s
+        """,
+        values,
+    )
+
+    if cursor.rowcount == 0:
+        raise ValueError('special_candidate_id was not found')
+
+    cursor.execute(
+        """
+        SELECT special_candidate_id, description, all_day, days_of_week, start_time, end_time, type
+        FROM special_candidate
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    updated = cursor.fetchone() or {}
+    return {
+        'special_candidate_id': updated.get('special_candidate_id'),
+        'description': updated.get('description'),
+        'all_day': updated.get('all_day'),
+        'days_of_week': _parse_days_of_week(updated.get('days_of_week')),
+        'start_time': _normalize_time_value(updated.get('start_time')) or None,
+        'end_time': _normalize_time_value(updated.get('end_time')) or None,
+        'type': updated.get('type'),
+    }
+
+
 
 
 def _parse_event_payload(event):
@@ -570,10 +660,17 @@ def _parse_event_payload(event):
 def lambda_handler(event, context):
     event = _parse_event_payload(event or {})
     mode = event.get('mode')
-    if mode not in {'get_unapproved_special_candidates', 'update_special_candidate_approval', 'get_all_specials', 'update_special'}:
+    if mode not in {'get_unapproved_special_candidates', 'update_special_candidate_approval', 'get_all_specials', 'update_special', 'update_special_candidate'}:
         return {
             'statusCode': 400,
-            'body': json.dumps({'error': 'mode must be one of get_unapproved_special_candidates, update_special_candidate_approval, get_all_specials, update_special'}),
+            'body': json.dumps(
+                {
+                    'error': (
+                        'mode must be one of get_unapproved_special_candidates, '
+                        'update_special_candidate_approval, get_all_specials, update_special, update_special_candidate'
+                    )
+                }
+            ),
         }
 
     conn = get_connection()
@@ -589,6 +686,8 @@ def lambda_handler(event, context):
                 result = update_special_candidate_approval(cursor, special_candidate_id, approval_status)
             elif mode == 'get_all_specials':
                 result = get_all_specials(cursor)
+            elif mode == 'update_special_candidate':
+                result = update_special_candidate(cursor, event)
             else:
                 result = update_special(cursor, event)
             conn.commit()

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -265,7 +265,6 @@ def get_unapproved_special_candidates(cursor):
         SELECT
             scr.run_id,
             b.name AS bar_name,
-            b.neighborhood AS run_neighborhood,
             scr.total_candidates,
             scr.auto_approved_candidates,
             scr.web_crawl_candidates,
@@ -278,6 +277,7 @@ def get_unapproved_special_candidates(cursor):
             scr.started_at,
             scr.completed_at,
             sc.special_candidate_id,
+            sc.neighborhood,
             sc.description,
             sc.days_of_week,
             sc.type,
@@ -306,7 +306,7 @@ def get_unapproved_special_candidates(cursor):
             {
                 'run_id': run_id,
                 'bar_name': row.get('bar_name'),
-                'neighborhood': row.get('run_neighborhood'),
+                'neighborhood': row.get('neighborhood'),
                 'total_candidates': row.get('total_candidates'),
                 'auto_approved_candidates': row.get('auto_approved_candidates'),
                 'web_crawl_candidates': row.get('web_crawl_candidates'),
@@ -324,6 +324,7 @@ def get_unapproved_special_candidates(cursor):
         run['specials'].append(
             {
                 'special_candidate_id': row.get('special_candidate_id'),
+                'neighborhood': row.get('neighborhood'),
                 'description': row.get('description'),
                 'days_of_week': _parse_days_of_week(row.get('days_of_week')),
                 'type': row.get('type'),


### PR DESCRIPTION
### Motivation
- Make the Specials Pending Approval admin tool editable so admins can fix candidate data before approving or rejecting. 
- Ensure the displayed neighborhood for pending candidates comes from the run/bar context (run-level) rather than each candidate row.

### Description
- Frontend: added edit workflow to `admin/admin.js` including `editingCandidateId` and `savingCandidate` state, per-candidate `Edit/Save/Cancel` controls, input fields for `description`, `all_day`, `days_of_week`, `start_time`, `end_time`, and `type`, and a `saveCandidateUpdates` function that calls the backend with `mode: 'update_special_candidate'`.
- Frontend: changed pending candidate card to display neighborhood from the run object (`run.neighborhood`) instead of the candidate row.
- Backend: added `update_special_candidate` handler to `functions/dbAdminSync/db_admin_sync.py` and wired it into `lambda_handler` dispatch as a new `mode`; the handler accepts and updates `description`, `all_day`, `days_of_week`, `start_time`, `end_time`, and `type`.
- Backend: added `_normalize_days_input` helper and normalization logic for `all_day` (Y/N), `days_of_week` (supports comma-delimited string or JSON list), and times (normalized to `HH:MM:SS`), and changed `get_unapproved_special_candidates` to return `b.neighborhood AS run_neighborhood` and surface it as the run-level neighborhood.

### Testing
- Ran frontend static check with `node --check admin/admin.js`, which succeeded.
- Ran Python compile check with `python -m py_compile functions/dbAdminSync/db_admin_sync.py`, which succeeded.
- Ran unit UI tests with `node tests/app.test.js`; the suite reported 15 passed and 1 failed, where the failing test is an existing unrelated assertion that expects a specific `insertUserReport` URL and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfae0175108330a2a3a3d1db51cdd1)