### PR TITLE
Admin: show Bar ID, use pencil edit icon, and render source as links in pending specials

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -122,6 +122,10 @@ body {
   padding: 12px;
 }
 
+.admin-candidate-card {
+  position: relative;
+}
+
 .admin-run-card {
   display: flex;
   flex-direction: column;
@@ -158,6 +162,35 @@ body {
   display: flex;
   gap: 8px;
   margin-top: 8px;
+}
+
+.admin-icon-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border: 1px solid #c8d8ff;
+  border-radius: 999px;
+  background: #fff;
+  color: #2f6fd1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.admin-icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.admin-source-link {
+  color: #2458b8;
+  text-decoration: underline;
+  word-break: break-word;
 }
 
 .admin-action-btn {

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -168,18 +168,16 @@ body {
   position: absolute;
   top: 8px;
   right: 8px;
-  width: 28px;
-  height: 28px;
-  border: 1px solid #c8d8ff;
-  border-radius: 999px;
-  background: #fff;
+  border: none;
+  background: transparent;
   color: #2f6fd1;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 15px;
+  font-size: 22px;
   line-height: 1;
   cursor: pointer;
+  padding: 0 4px;
 }
 
 .admin-icon-btn:disabled {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -99,6 +99,15 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     return String(value).slice(0, 5);
   }
 
+  function getSourceMarkup(source) {
+    if (!source) return '—';
+    const sourceValue = String(source);
+    if (/^https?:\/\//i.test(sourceValue)) {
+      return `<a class="admin-source-link" href="${sourceValue}" target="_blank" rel="noopener noreferrer">${sourceValue}</a>`;
+    }
+    return sourceValue;
+  }
+
   function normalizeDay(day) {
     return String(day || '').trim().toUpperCase();
   }
@@ -424,7 +433,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
                       <td>${candidate.confidence ?? '—'}</td>
                       <td>${candidate.fetch_method || '—'}</td>
                       <td>${candidate.notes || '—'}</td>
-                      <td>${candidate.source || '—'}</td>
+                      <td>${getSourceMarkup(candidate.source)}</td>
                       <td>${candidate.approval_status || '—'}</td>
                       <td>${formatDateTime(candidate.insert_date)}</td>
                       <td>${formatDateTime(candidate.approval_date)}</td>
@@ -480,6 +489,11 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
+            ${isEditing ? '' : `
+              <button class="admin-icon-btn" type="button" aria-label="Edit special candidate" title="Edit" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>
+                &#9998;
+              </button>
+            `}
             <h4>${isEditing ? 'Editing Special Candidate' : (special.description || 'No description')}</h4>
             <p><strong>Description:</strong> ${editableValue('description')}</p>
             <p><strong>Type:</strong> ${editableValue('type')}</p>
@@ -489,14 +503,13 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             <p><strong>End Time:</strong> ${editableValue('end_time')}</p>
             <p><strong>Confidence:</strong> ${confidence}</p>
             <p><strong>Method:</strong> ${special.fetch_method || '—'}</p>
-            <p><strong>Source:</strong> ${special.source || '—'}</p>
+            <p><strong>Source:</strong> ${getSourceMarkup(special.source)}</p>
             <p><strong>Notes:</strong> ${special.notes || '—'}</p>
             <div class="admin-actions-row">
               ${isEditing
                 ? `<button class="admin-action-btn approve" type="button" data-candidate-action="save-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Save</button>
                    <button class="admin-secondary-btn" type="button" data-candidate-action="cancel-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Cancel</button>`
-                : `<button class="admin-action-btn edit" type="button" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Edit</button>
-                   <button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
+                : `<button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
                    <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>`}
             </div>
           </article>
@@ -507,6 +520,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         <section class="admin-run-card">
           <h3>Run ${run.run_id} — ${run.bar_name || 'Unknown bar'}</h3>
           <p><strong>Neighborhood:</strong> ${run.neighborhood || '—'}</p>
+          <p><strong>Bar ID:</strong> ${run.bar_id ?? '—'}</p>
           <p><strong>Total candidates:</strong> ${run.total_candidates ?? '—'}</p>
           <p><strong>Auto Approved Candidates:</strong> ${run.auto_approved_candidates ?? '—'}</p>
           <p><strong>Started:</strong> ${formatDateTime(run.started_at)}</p>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -500,7 +500,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
             ${isEditing ? '' : `
               <button class="admin-icon-btn" type="button" aria-label="Edit special candidate" title="Edit" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>
-                &#9998;
+                &#8943;
               </button>
             `}
             <h4>${isEditing ? 'Editing Special Candidate' : (special.description || 'No description')}</h4>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -477,11 +477,20 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         const candidateId = Number(special.special_candidate_id);
         const isUpdating = state.updatingCandidateId === candidateId;
         const isEditing = state.editingCandidateId === candidateId;
-        const days = Array.isArray(special.days_of_week) ? special.days_of_week.join(', ') : '';
         const confidence = special.confidence === null || special.confidence === undefined ? '—' : String(special.confidence);
         const editableValue = (field, fallback = '—') => {
           const value = special[field] ?? '';
           if (isEditing) {
+            if (field === 'type') {
+              const normalizedType = String(value || '').trim().toLowerCase();
+              return `
+                <select class="admin-input" data-candidate-id="${candidateId}" data-candidate-field="type">
+                  <option value="food" ${normalizedType === 'food' ? 'selected' : ''}>food</option>
+                  <option value="drink" ${normalizedType === 'drink' ? 'selected' : ''}>drink</option>
+                  <option value="combo" ${normalizedType === 'combo' ? 'selected' : ''}>combo</option>
+                </select>
+              `;
+            }
             return `<input class="admin-input" data-candidate-id="${candidateId}" data-candidate-field="${field}" value="${value}" />`;
           }
           return value === '' ? fallback : String(value);


### PR DESCRIPTION
### Motivation
- Make the Specials Pending Approval UI more useful to moderators by surfacing the `bar_id` with run metadata, improving the edit affordance, and turning source values into clickable links when they are URLs.

### Description
- Added a helper `getSourceMarkup` to render `http(s)` sources as clickable links and used it in candidate cards and in the candidate-history table in the detail modal (`admin/admin.js`).
- Inserted a `Bar ID` line under each run’s metadata block in the Specials Pending Approval view (`admin/admin.js`).
- Replaced the text `Edit` action on candidate cards with a top-right pencil icon button that appears in non-edit mode and preserves the existing inline edit flow (`admin/admin.js` and `admin/admin.css`).
- Added CSS for the new icon button and for link styling (`admin/admin.css`) and made candidate cards `position: relative` so the icon can be absolutely positioned.

### Testing
- Ran the test suite with `node --test tests/app.test.js`, which passed most tests but reported one failing assertion unrelated to these admin UI changes (a different endpoint expectation in `submitSpecialReport`).
- No UI browser tests were run in this environment; changes are limited to `admin/admin.js` and `admin/admin.css` and are unit-test safe.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb460560c8330bd4b08908fd1045f)