### PR TITLE
Add bar/neighborhood search to Special Management

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -93,6 +93,12 @@ body {
   background: #fff;
 }
 
+.admin-special-filters {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
 .admin-tool-button {
   text-align: left;
   padding: 14px;

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -89,6 +89,10 @@ body {
   font-size: 20px;
 }
 
+.admin-special-search-input {
+  background: #fff;
+}
+
 .admin-tool-button {
   text-align: left;
   padding: 14px;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -34,6 +34,10 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     loading: false,
     loadingSpecials: false,
     specialSearchTerm: '',
+    specialFilterActive: 'all',
+    specialFilterNeighborhood: 'all',
+    specialFilterType: 'all',
+    specialFilterAllDay: 'all',
     updatingCandidateId: null,
     editingCandidateId: null,
     savingCandidate: false,
@@ -551,13 +555,36 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
   function buildSpecialManagementTable() {
     const searchTerm = String(state.specialSearchTerm || '').trim().toLowerCase();
-    const filteredSpecials = searchTerm
-      ? state.groupedSpecials.filter((row) => {
-        const neighborhood = String(row.neighborhood || '').toLowerCase();
-        const barName = String(row.bar_name || '').toLowerCase();
-        return neighborhood.includes(searchTerm) || barName.includes(searchTerm);
-      })
-      : state.groupedSpecials;
+    const filteredSpecials = state.groupedSpecials.filter((row) => {
+      const neighborhood = String(row.neighborhood || '').trim();
+      const barName = String(row.bar_name || '').trim();
+      const type = String(row.type || '').trim().toLowerCase();
+      const isActive = String(row.is_active || '').trim().toUpperCase();
+      const allDay = String(row.all_day || '').trim().toUpperCase();
+
+      const searchMatches = !searchTerm
+        || neighborhood.toLowerCase().includes(searchTerm)
+        || barName.toLowerCase().includes(searchTerm);
+      if (!searchMatches) return false;
+
+      const activeMatches = state.specialFilterActive === 'all'
+        || isActive === state.specialFilterActive;
+      if (!activeMatches) return false;
+
+      const neighborhoodMatches = state.specialFilterNeighborhood === 'all'
+        || neighborhood === state.specialFilterNeighborhood;
+      if (!neighborhoodMatches) return false;
+
+      const typeMatches = state.specialFilterType === 'all'
+        || type === state.specialFilterType;
+      if (!typeMatches) return false;
+
+      const allDayMatches = state.specialFilterAllDay === 'all'
+        || allDay === state.specialFilterAllDay;
+      if (!allDayMatches) return false;
+
+      return true;
+    });
 
     if (!filteredSpecials.length) {
       if (searchTerm) {
@@ -658,6 +685,17 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         render();
       });
     }
+
+    screenElement.querySelectorAll('[data-special-filter]').forEach((select) => {
+      select.addEventListener('change', (event) => {
+        const filter = event.target.getAttribute('data-special-filter');
+        if (filter === 'active') state.specialFilterActive = event.target.value;
+        if (filter === 'neighborhood') state.specialFilterNeighborhood = event.target.value;
+        if (filter === 'type') state.specialFilterType = event.target.value;
+        if (filter === 'all-day') state.specialFilterAllDay = event.target.value;
+        render();
+      });
+    });
 
     screenElement.querySelectorAll('.admin-special-row[data-special-id]').forEach((row) => {
       row.addEventListener('click', () => {
@@ -802,6 +840,15 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       return;
     }
 
+    const neighborhoodOptions = [...new Set(state.groupedSpecials
+      .map((row) => String(row.neighborhood || '').trim())
+      .filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b));
+    const typeOptions = [...new Set(state.groupedSpecials
+      .map((row) => String(row.type || '').trim().toLowerCase())
+      .filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b));
+
     screenElement.innerHTML = `
       <section class="admin-specials-view" aria-label="Special management">
         <h2>Special Management</h2>
@@ -813,6 +860,26 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           value="${escapeAttribute(state.specialSearchTerm)}"
           aria-label="Search specials by bar or neighborhood"
         />
+        <div class="admin-special-filters" aria-label="Special filters">
+          <select class="admin-input admin-special-filter-select" data-special-filter="active" aria-label="Filter by active">
+            <option value="all" ${state.specialFilterActive === 'all' ? 'selected' : ''}>Active: All</option>
+            <option value="Y" ${state.specialFilterActive === 'Y' ? 'selected' : ''}>Active: Yes</option>
+            <option value="N" ${state.specialFilterActive === 'N' ? 'selected' : ''}>Active: No</option>
+          </select>
+          <select class="admin-input admin-special-filter-select" data-special-filter="neighborhood" aria-label="Filter by neighborhood">
+            <option value="all" ${state.specialFilterNeighborhood === 'all' ? 'selected' : ''}>Neighborhood: All</option>
+            ${neighborhoodOptions.map((name) => `<option value="${escapeAttribute(name)}" ${state.specialFilterNeighborhood === name ? 'selected' : ''}>${name}</option>`).join('')}
+          </select>
+          <select class="admin-input admin-special-filter-select" data-special-filter="type" aria-label="Filter by type">
+            <option value="all" ${state.specialFilterType === 'all' ? 'selected' : ''}>Type: All</option>
+            ${typeOptions.map((type) => `<option value="${escapeAttribute(type)}" ${state.specialFilterType === type ? 'selected' : ''}>Type: ${type}</option>`).join('')}
+          </select>
+          <select class="admin-input admin-special-filter-select" data-special-filter="all-day" aria-label="Filter by all day">
+            <option value="all" ${state.specialFilterAllDay === 'all' ? 'selected' : ''}>All Day: All</option>
+            <option value="Y" ${state.specialFilterAllDay === 'Y' ? 'selected' : ''}>All Day: Yes</option>
+            <option value="N" ${state.specialFilterAllDay === 'N' ? 'selected' : ''}>All Day: No</option>
+          </select>
+        </div>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildSpecialManagementTable()}
       </section>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -377,6 +377,18 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
     const renderValue = (special, key, fallback = '—') => {
       if (state.detailEditing && ['day_of_week', 'all_day', 'start_time', 'end_time', 'description', 'type', 'is_active'].includes(key)) {
+        if (key === 'type') {
+          const normalizedType = String(special[key] || '').trim().toLowerCase();
+          const resolvedType = ['drink', 'food', 'combo'].includes(normalizedType) ? normalizedType : 'unknown';
+          return `
+            <select class="admin-input" data-special-id="${special.special_id}" data-special-field="type">
+              <option value="drink" ${resolvedType === 'drink' ? 'selected' : ''}>drink</option>
+              <option value="food" ${resolvedType === 'food' ? 'selected' : ''}>food</option>
+              <option value="combo" ${resolvedType === 'combo' ? 'selected' : ''}>combo</option>
+              <option value="unknown" ${resolvedType === 'unknown' ? 'selected' : ''}>unknown</option>
+            </select>
+          `;
+        }
         return `<input class="admin-input" data-special-id="${special.special_id}" data-special-field="${key}" value="${special[key] ?? ''}" />`;
       }
       return special[key] === null || special[key] === undefined || special[key] === '' ? fallback : String(special[key]);

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -33,6 +33,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     currentView: 'home',
     loading: false,
     loadingSpecials: false,
+    specialSearchTerm: '',
     updatingCandidateId: null,
     editingCandidateId: null,
     savingCandidate: false,
@@ -97,6 +98,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   function formatTime(value) {
     if (!value) return '—';
     return String(value).slice(0, 5);
+  }
+
+  function escapeAttribute(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
   }
 
   function getSourceMarkup(source) {
@@ -541,11 +550,23 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function buildSpecialManagementTable() {
-    if (!state.groupedSpecials.length) {
+    const searchTerm = String(state.specialSearchTerm || '').trim().toLowerCase();
+    const filteredSpecials = searchTerm
+      ? state.groupedSpecials.filter((row) => {
+        const neighborhood = String(row.neighborhood || '').toLowerCase();
+        const barName = String(row.bar_name || '').toLowerCase();
+        return neighborhood.includes(searchTerm) || barName.includes(searchTerm);
+      })
+      : state.groupedSpecials;
+
+    if (!filteredSpecials.length) {
+      if (searchTerm) {
+        return '<p class="admin-empty">No specials match that bar or neighborhood.</p>';
+      }
       return '<p class="admin-empty">No specials found.</p>';
     }
 
-    const rows = state.groupedSpecials.map((row) => `
+    const rows = filteredSpecials.map((row) => `
       <tr class="admin-special-row" data-special-id="${row.representative_special_id}">
         <td>${row.neighborhood || '—'}</td>
         <td>${row.bar_name || '—'}</td>
@@ -630,6 +651,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function bindSpecialManagementEvents() {
+    const searchInput = screenElement.querySelector('[data-special-search-input]');
+    if (searchInput) {
+      searchInput.addEventListener('input', (event) => {
+        state.specialSearchTerm = event.target.value;
+        render();
+      });
+    }
+
     screenElement.querySelectorAll('.admin-special-row[data-special-id]').forEach((row) => {
       row.addEventListener('click', () => {
         state.actionSpecialId = Number(row.getAttribute('data-special-id'));
@@ -776,6 +805,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     screenElement.innerHTML = `
       <section class="admin-specials-view" aria-label="Special management">
         <h2>Special Management</h2>
+        <input
+          type="search"
+          class="admin-input admin-special-search-input"
+          data-special-search-input
+          placeholder="Search by bar or neighborhood"
+          value="${escapeAttribute(state.specialSearchTerm)}"
+          aria-label="Search specials by bar or neighborhood"
+        />
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildSpecialManagementTable()}
       </section>


### PR DESCRIPTION
### Motivation
- Improve usability of the Special Management screen by letting operators quickly find rows for a specific bar or neighborhood. 
- Provide client-side filtering so results update instantly as the user types without extra API calls.

### Description
- Add `state.specialSearchTerm` to persist the current search query across re-renders. 
- Render a search input at the top of the Special Management view and safely escape the input value with a new `escapeAttribute` helper when interpolating into HTML. 
- Filter `state.groupedSpecials` in `buildSpecialManagementTable` by `bar_name` or `neighborhood` using a case-insensitive contains check and show a dedicated empty state when no matches are found. 
- Wire up input events in `bindSpecialManagementEvents` to update `state.specialSearchTerm` and re-render, and add a small CSS hook `.admin-special-search-input`.

### Testing
- Ran `node --check admin/admin.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbc5f75b48330aed10e6cb9dafa60)