### PR TITLE
Track and surface bar last_special_candidate_run timestamps

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -8,6 +8,23 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   if (!backButton || !homeButton || !titleElement || !screenElement) return;
 
   const DAY_ORDER = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'];
+  const CANDIDATE_DAY_KEYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
+  const CANDIDATE_DAY_ALIASES = {
+    MONDAY: 'MON',
+    TUESDAY: 'TUE',
+    WEDNESDAY: 'WED',
+    THURSDAY: 'THU',
+    FRIDAY: 'FRI',
+    SATURDAY: 'SAT',
+    SUNDAY: 'SUN',
+    MON: 'MON',
+    TUE: 'TUE',
+    WED: 'WED',
+    THU: 'THU',
+    FRI: 'FRI',
+    SAT: 'SAT',
+    SUN: 'SUN'
+  };
   const ADMIN_TIMEZONE = 'America/New_York';
   const ADMIN_DATETIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
     timeZone: ADMIN_TIMEZONE,
@@ -134,6 +151,11 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
   function normalizeDay(day) {
     return String(day || '').trim().toUpperCase();
+  }
+
+  function normalizeCandidateDay(day) {
+    const normalized = normalizeDay(day);
+    return CANDIDATE_DAY_ALIASES[normalized] || '';
   }
 
   function sortDays(days) {
@@ -716,14 +738,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             }
             if (field === 'days_of_week') {
               const selectedDays = Array.isArray(value)
-                ? value.map((day) => normalizeDay(day))
+                ? value.map((day) => normalizeCandidateDay(day)).filter(Boolean)
                 : String(value || '')
                   .split(',')
-                  .map((day) => normalizeDay(day))
+                  .map((day) => normalizeCandidateDay(day))
                   .filter(Boolean);
               return `
                 <span>
-                  ${DAY_ORDER.map((day) => `
+                  ${CANDIDATE_DAY_KEYS.map((day) => `
                     <label>
                       <input
                         type="checkbox"
@@ -731,7 +753,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
                         data-candidate-day="${day}"
                         ${selectedDays.includes(day) ? 'checked' : ''}
                       />
-                      ${day.charAt(0) + day.slice(1).toLowerCase()}
+                      ${day}
                     </label>
                   `).join(' ')}
                 </span>
@@ -741,12 +763,12 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           }
           if (field === 'days_of_week') {
             const resolvedDays = Array.isArray(value)
-              ? value
+              ? value.map((day) => normalizeCandidateDay(day)).filter(Boolean)
               : String(value || '')
                 .split(',')
-                .map((day) => normalizeDay(day))
+                .map((day) => normalizeCandidateDay(day))
                 .filter(Boolean);
-            const displayDays = resolvedDays.map((day) => day.charAt(0) + day.slice(1).toLowerCase()).join(', ');
+            const displayDays = resolvedDays.join(', ');
             return displayDays || fallback;
           }
           return value === '' ? fallback : String(value);

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -714,7 +714,40 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
                 </select>
               `;
             }
+            if (field === 'days_of_week') {
+              const selectedDays = Array.isArray(value)
+                ? value.map((day) => normalizeDay(day))
+                : String(value || '')
+                  .split(',')
+                  .map((day) => normalizeDay(day))
+                  .filter(Boolean);
+              return `
+                <span>
+                  ${DAY_ORDER.map((day) => `
+                    <label>
+                      <input
+                        type="checkbox"
+                        data-candidate-id="${candidateId}"
+                        data-candidate-day="${day}"
+                        ${selectedDays.includes(day) ? 'checked' : ''}
+                      />
+                      ${day.charAt(0) + day.slice(1).toLowerCase()}
+                    </label>
+                  `).join(' ')}
+                </span>
+              `;
+            }
             return `<input class="admin-input" data-candidate-id="${candidateId}" data-candidate-field="${field}" value="${value}" />`;
+          }
+          if (field === 'days_of_week') {
+            const resolvedDays = Array.isArray(value)
+              ? value
+              : String(value || '')
+                .split(',')
+                .map((day) => normalizeDay(day))
+                .filter(Boolean);
+            const displayDays = resolvedDays.map((day) => day.charAt(0) + day.slice(1).toLowerCase()).join(', ');
+            return displayDays || fallback;
           }
           return value === '' ? fallback : String(value);
         };
@@ -727,6 +760,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               </button>
             `}
             <h4>${isEditing ? 'Editing Special Candidate' : (special.description || 'No description')}</h4>
+            <p><strong>Special Candidate ID:</strong> ${special.special_candidate_id ?? '—'}</p>
             <p><strong>Description:</strong> ${editableValue('description')}</p>
             <p><strong>Type:</strong> ${editableValue('type')}</p>
             <p><strong>Days:</strong> ${editableValue('days_of_week', '—')}</p>
@@ -918,6 +952,9 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             const field = input.getAttribute('data-candidate-field');
             payload[field] = input.value;
           });
+          payload.days_of_week = Array.from(
+            screenElement.querySelectorAll(`[data-candidate-id="${candidateId}"][data-candidate-day]:checked`)
+          ).map((checkbox) => checkbox.getAttribute('data-candidate-day'));
           await saveCandidateUpdates(payload);
         }
       });

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -651,6 +651,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               ${renderBarField('latitude', 'Latitude')}
               ${renderBarField('longitude', 'Longitude')}
               ${renderBarField('is_active', 'Is Active')}
+              <p><strong>Last Candidate Run:</strong> ${formatDateTime(bar.last_special_candidate_run)}</p>
               <p><strong>Insert Date:</strong> ${formatDateTime(bar.insert_date)}</p>
               <p><strong>Update Date:</strong> ${formatDateTime(bar.update_date)}</p>
             </div>
@@ -856,6 +857,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         <td>${bar.name || '—'}</td>
         <td>${bar.neighborhood || '—'}</td>
         <td>${bar.is_active || '—'}</td>
+        <td>${formatDateTime(bar.last_special_candidate_run)}</td>
         <td>${formatDateTime(bar.insert_date)}</td>
         <td>${formatDateTime(bar.update_date)}</td>
       </tr>
@@ -869,6 +871,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               <th>Name</th>
               <th>Neighborhood</th>
               <th>Is Active</th>
+              <th>Last Candidate Run</th>
               <th>Insert Date</th>
               <th>Update Date</th>
             </tr>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -529,6 +529,7 @@ def get_all_bars(cursor):
             name,
             neighborhood,
             is_active,
+            last_special_candidate_run,
             insert_date,
             update_date
         FROM bar
@@ -544,6 +545,7 @@ def get_all_bars(cursor):
                 'name': row.get('name'),
                 'neighborhood': row.get('neighborhood'),
                 'is_active': row.get('is_active'),
+                'last_special_candidate_run': row.get('last_special_candidate_run').isoformat() if row.get('last_special_candidate_run') else None,
                 'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
                 'update_date': row.get('update_date').isoformat() if row.get('update_date') else None,
             }
@@ -564,6 +566,7 @@ def get_bar_details(cursor, bar_id: int):
             latitude,
             longitude,
             is_active,
+            last_special_candidate_run,
             insert_date,
             update_date
         FROM bar
@@ -603,6 +606,7 @@ def get_bar_details(cursor, bar_id: int):
             'latitude': _to_json_safe_number(bar_row.get('latitude')),
             'longitude': _to_json_safe_number(bar_row.get('longitude')),
             'is_active': bar_row.get('is_active'),
+            'last_special_candidate_run': bar_row.get('last_special_candidate_run').isoformat() if bar_row.get('last_special_candidate_run') else None,
             'insert_date': bar_row.get('insert_date').isoformat() if bar_row.get('insert_date') else None,
             'update_date': bar_row.get('update_date').isoformat() if bar_row.get('update_date') else None,
         },

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -357,7 +357,19 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
 
     cursor.execute(
         """
-        SELECT special_candidate_id, run_id, bar_id
+        SELECT
+            special_candidate_id,
+            run_id,
+            bar_id,
+            description,
+            days_of_week,
+            start_time,
+            end_time,
+            all_day,
+            is_recurring,
+            date,
+            fetch_method,
+            source
         FROM special_candidate
         WHERE special_candidate_id = %s
         """,
@@ -369,6 +381,46 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
 
     run_id = target['run_id']
     bar_id = target['bar_id']
+
+    if normalized_status == 'REJECTED':
+        cursor.execute(
+            """
+            INSERT INTO special_candidate_reject
+            (
+                bar_id,
+                description,
+                days_of_week,
+                start_time,
+                end_time,
+                all_day,
+                is_recurring,
+                date,
+                fetch_method,
+                source
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                bar_id,
+                target.get('description'),
+                target.get('days_of_week'),
+                target.get('start_time'),
+                target.get('end_time'),
+                target.get('all_day'),
+                target.get('is_recurring'),
+                target.get('date'),
+                target.get('fetch_method'),
+                target.get('source'),
+            ),
+        )
+        reject_id = cursor.lastrowid
+        cursor.execute(
+            """
+            INSERT INTO special_candidate_reject_join (reject_id, special_candidate_id)
+            VALUES (%s, %s)
+            """,
+            (reject_id, special_candidate_id),
+        )
 
     cursor.execute(
         """

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -151,6 +151,7 @@ def get_bars_by_neighborhood(cursor, neighborhood: str) -> Dict[str, List[Dict]]
         SELECT bar_id, name AS bar_name, neighborhood, website_url
         FROM bar
         WHERE neighborhood = %s
+        ORDER BY last_special_candidate_run ASC, bar_id ASC
         """,
         (neighborhood,),
     )

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -113,6 +113,7 @@ def _is_candidate_same_as_special(candidate_row: Dict, special_row: Dict) -> boo
 
 
 def insert_special_candidate_run(cursor, run: Dict) -> int:
+    completed_at = run.get('completed_at') or datetime.utcnow()
     cursor.execute(
         """
         INSERT INTO special_candidate_run
@@ -151,11 +152,22 @@ def insert_special_candidate_run(cursor, run: Dict) -> int:
             'N',
             'N',
             run.get('started_at') or datetime.utcnow(),
-            run.get('completed_at') or datetime.utcnow(),
+            completed_at,
             None,
         ),
     )
-    return cursor.lastrowid
+    run_id = cursor.lastrowid
+    cursor.execute(
+        """
+        UPDATE bar
+        SET last_special_candidate_run = %s
+        WHERE bar_id = %s
+        """,
+        (completed_at, run['bar_id']),
+    )
+    if cursor.rowcount == 0:
+        raise ValueError('run.bar_id was not found while updating bar.last_special_candidate_run')
+    return run_id
 
 
 def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[str, int]:


### PR DESCRIPTION
### Motivation
- Ensure each candidate-special generation run records when it completed on the associated bar row so operators can see recent activity. 
- Surface the new timestamp in admin APIs and the Bar Management UI so it’s visible in the bar list and bar detail modal.

### Description
- Updated `insert_special_candidate_run` in `functions/dbSpecialSync/db_special_sync.py` to compute a `completed_at` timestamp and use it for the inserted run, then update `bar.last_special_candidate_run` for the given `bar_id`, and raise a clear error if the bar row was not found.
- Extended `get_all_bars` and `get_bar_details` in `functions/dbAdminSync/db_admin_sync.py` to select and return `last_special_candidate_run` (ISO serialized) in the bar list and bar detail payloads.
- Updated `admin/admin.js` to add a `Last Candidate Run` column in the Bar Management table and to show `Last Candidate Run` inside the Bar Details modal using `formatDateTime(bar.last_special_candidate_run)`.

### Testing
- Ran Python syntax check: `python -m py_compile functions/dbSpecialSync/db_special_sync.py functions/dbAdminSync/db_admin_sync.py` and it succeeded. 
- Validated admin JS syntax: `node --check admin/admin.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e282f00ff48330996bb5978b09ef99)