### PR TITLE
Auto-reject generated specials that match prior admin rejections

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -60,7 +60,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     updatingCandidateId: null,
     editingCandidateId: null,
     savingCandidate: false,
-    actionRejectedCandidateId: null,
     actionSpecialId: null,
     detailSpecials: [],
     detailEditing: false,
@@ -88,7 +87,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     state.currentView = 'home';
     state.errorMessage = '';
     state.actionSpecialId = null;
-    state.actionRejectedCandidateId = null;
     state.detailSpecials = [];
     state.detailEditing = false;
     state.actionBarId = null;
@@ -342,7 +340,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         mode: 'remove_rejected_special_candidate',
         special_candidate_id: specialCandidateId
       });
-      state.actionRejectedCandidateId = null;
       await loadRejectedSpecials();
     } catch (err) {
       console.error('Failed to remove rejected special candidate:', err);
@@ -1446,36 +1443,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           </tbody>
         </table>
       </div>
-      ${getRejectedSpecialActionMenuMarkup()}
-    `;
-  }
-
-  function getRejectedSpecialActionMenuMarkup() {
-    const candidateId = Number(state.actionRejectedCandidateId);
-    if (!candidateId) return '';
-    return `
-      <div class="admin-action-menu-backdrop" data-close-rejected-action-menu="true">
-        <div class="admin-action-menu" role="dialog" aria-modal="true" aria-label="Rejected special actions">
-          <h4>Rejected Special Candidate ${candidateId}</h4>
-          <div class="admin-actions-row">
-            <button
-              type="button"
-              class="admin-action-btn reject"
-              data-rejected-special-action="remove-rejected-candidate"
-              data-special-candidate-id="${candidateId}"
-            >
-              Remove Rejected Special Candidate
-            </button>
-            <button
-              type="button"
-              class="admin-secondary-btn"
-              data-close-rejected-action-menu="true"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
     `;
   }
 
@@ -1507,25 +1474,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       }
 
       screenElement.querySelectorAll('[data-rejected-special-candidate-row]').forEach((row) => {
-        row.addEventListener('click', () => {
+        row.addEventListener('click', async () => {
           const specialCandidateId = Number(row.getAttribute('data-rejected-special-candidate-row'));
-          if (!specialCandidateId) return;
-          state.actionRejectedCandidateId = specialCandidateId;
-          render();
-        });
-      });
-
-      screenElement.querySelectorAll('[data-close-rejected-action-menu="true"]').forEach((element) => {
-        element.addEventListener('click', (event) => {
-          if (event.currentTarget !== event.target && !event.target.hasAttribute('data-close-rejected-action-menu')) return;
-          state.actionRejectedCandidateId = null;
-          render();
-        });
-      });
-
-      screenElement.querySelectorAll('[data-rejected-special-action="remove-rejected-candidate"]').forEach((button) => {
-        button.addEventListener('click', async () => {
-          const specialCandidateId = Number(button.getAttribute('data-special-candidate-id'));
           if (!specialCandidateId) return;
           const shouldContinue = window.confirm('Remove rejected special candidate and matching reject records?');
           if (!shouldContinue) return;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1245,7 +1245,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       <section class="admin-home-view" aria-label="Admin tools">
         <h2>Admin tools</h2>
         <button type="button" class="admin-tool-button" data-tool="special-management">Special Management</button>
-        <button type="button" class="admin-tool-button" data-tool="rejected-special-management">Rejected Special Management</button>
+        <button type="button" class="admin-tool-button" data-tool="rejected-special-management">Auto-Rejected Special Management</button>
         <button type="button" class="admin-tool-button" data-tool="bar-management">Bar Management</button>
         <button type="button" class="admin-tool-button" data-tool="specials-to-be-approved">Specials Pending Approval</button>
       </section>
@@ -1348,16 +1348,16 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function renderRejectedSpecialManagementView() {
-    titleElement.textContent = 'Rejected Special Management';
+    titleElement.textContent = 'Auto-Rejected Special Management';
 
     if (state.loadingRejectedSpecials) {
-      screenElement.innerHTML = '<p class="admin-loading">Loading rejected specials...</p>';
+      screenElement.innerHTML = '<p class="admin-loading">Loading auto-rejected specials...</p>';
       return;
     }
 
     screenElement.innerHTML = `
-      <section class="admin-specials-view" aria-label="Rejected special management">
-        <h2>Rejected Special Management</h2>
+      <section class="admin-specials-view" aria-label="Auto-rejected special management">
+        <h2>Auto-Rejected Special Management</h2>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildRejectedSpecialManagementTable()}
       </section>
@@ -1374,8 +1374,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     });
 
     if (!rows.length) {
-      if (searchTerm) return '<p class="admin-empty">No rejected specials match that bar or neighborhood.</p>';
-      return '<p class="admin-empty">No rejected specials found.</p>';
+      if (searchTerm) return '<p class="admin-empty">No auto-rejected specials match that bar or neighborhood.</p>';
+      return '<p class="admin-empty">No auto-rejected specials found.</p>';
     }
 
     return `

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -60,6 +60,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     updatingCandidateId: null,
     editingCandidateId: null,
     savingCandidate: false,
+    actionRejectedCandidateId: null,
     actionSpecialId: null,
     detailSpecials: [],
     detailEditing: false,
@@ -86,6 +87,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     if (state.currentView === 'home') return;
     state.currentView = 'home';
     state.errorMessage = '';
+    state.actionRejectedCandidateId = null;
     state.actionSpecialId = null;
     state.detailSpecials = [];
     state.detailEditing = false;
@@ -1378,6 +1380,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         ${buildRejectedSpecialManagementTable()}
       </section>
     `;
+
+    bindRejectedSpecialManagementEvents();
   }
 
   function buildRejectedSpecialManagementTable() {
@@ -1424,7 +1428,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           </thead>
           <tbody>
             ${rows.map((row) => `
-              <tr data-rejected-special-candidate-row="${row.special_candidate_id}">
+              <tr class="admin-special-row" data-rejected-special-candidate-row="${row.special_candidate_id}">
                 <td>${row.neighborhood || '—'}</td>
                 <td>${row.bar_name || '—'}</td>
                 <td>${row.description || '—'}</td>
@@ -1443,7 +1447,64 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           </tbody>
         </table>
       </div>
+      ${getRejectedSpecialActionMenuMarkup()}
     `;
+  }
+
+  function getRejectedSpecialActionMenuMarkup() {
+    if (!state.actionRejectedCandidateId) return '';
+    return `
+      <div class="admin-modal-backdrop" data-close-rejected-action-menu="true">
+        <div class="admin-modal" role="dialog" aria-label="Rejected special actions">
+          <h3>Rejected Special Actions</h3>
+          <button
+            type="button"
+            class="admin-tool-button"
+            data-rejected-special-action="remove-rejected-candidate"
+            data-special-candidate-id="${state.actionRejectedCandidateId}"
+          >
+            Remove Rejected Special Candidate
+          </button>
+          <button type="button" class="admin-secondary-btn" data-close-rejected-action-menu="true">Close</button>
+        </div>
+      </div>
+    `;
+  }
+
+  function bindRejectedSpecialManagementEvents() {
+    const searchInput = screenElement.querySelector('[data-rejected-special-search-input]');
+    if (searchInput) {
+      searchInput.addEventListener('input', (event) => {
+        state.specialSearchTerm = event.target.value;
+        render();
+      });
+    }
+
+    screenElement.querySelectorAll('[data-rejected-special-candidate-row]').forEach((row) => {
+      row.addEventListener('click', () => {
+        const specialCandidateId = Number(row.getAttribute('data-rejected-special-candidate-row'));
+        if (!specialCandidateId) return;
+        state.actionRejectedCandidateId = specialCandidateId;
+        render();
+      });
+    });
+
+    screenElement.querySelectorAll('[data-close-rejected-action-menu="true"]').forEach((element) => {
+      element.addEventListener('click', (event) => {
+        if (event.currentTarget !== event.target) return;
+        state.actionRejectedCandidateId = null;
+        render();
+      });
+    });
+
+    screenElement.querySelectorAll('[data-rejected-special-action="remove-rejected-candidate"]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const specialCandidateId = Number(button.getAttribute('data-special-candidate-id'));
+        if (!specialCandidateId) return;
+        state.actionRejectedCandidateId = null;
+        await removeRejectedSpecialCandidate(specialCandidateId);
+      });
+    });
   }
 
   function render() {
@@ -1465,23 +1526,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
     if (state.currentView === 'rejected-special-management') {
       renderRejectedSpecialManagementView();
-      const rejectedSearch = screenElement.querySelector('[data-rejected-special-search-input]');
-      if (rejectedSearch) {
-        rejectedSearch.addEventListener('input', (event) => {
-          state.specialSearchTerm = event.target.value;
-          render();
-        });
-      }
-
-      screenElement.querySelectorAll('[data-rejected-special-candidate-row]').forEach((row) => {
-        row.addEventListener('click', async () => {
-          const specialCandidateId = Number(row.getAttribute('data-rejected-special-candidate-row'));
-          if (!specialCandidateId) return;
-          const shouldContinue = window.confirm('Remove rejected special candidate and matching reject records?');
-          if (!shouldContinue) return;
-          await removeRejectedSpecialCandidate(specialCandidateId);
-        });
-      });
       return;
     }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -60,6 +60,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     updatingCandidateId: null,
     editingCandidateId: null,
     savingCandidate: false,
+    actionRejectedCandidateId: null,
     actionSpecialId: null,
     detailSpecials: [],
     detailEditing: false,
@@ -87,6 +88,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     state.currentView = 'home';
     state.errorMessage = '';
     state.actionSpecialId = null;
+    state.actionRejectedCandidateId = null;
     state.detailSpecials = [];
     state.detailEditing = false;
     state.actionBarId = null;
@@ -340,6 +342,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         mode: 'remove_rejected_special_candidate',
         special_candidate_id: specialCandidateId
       });
+      state.actionRejectedCandidateId = null;
       await loadRejectedSpecials();
     } catch (err) {
       console.error('Failed to remove rejected special candidate:', err);
@@ -1417,16 +1420,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               <th>Type</th>
               <th>Method</th>
               <th>Source</th>
-              <th>Status</th>
               <th>Web AI Search Matches</th>
               <th>Web Crawl Matches</th>
               <th>Insert Date</th>
-              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             ${rows.map((row) => `
-              <tr>
+              <tr data-rejected-special-candidate-row="${row.special_candidate_id}">
                 <td>${row.neighborhood || '—'}</td>
                 <td>${row.bar_name || '—'}</td>
                 <td>${row.description || '—'}</td>
@@ -1437,23 +1438,43 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
                 <td>${row.type || '—'}</td>
                 <td>${row.fetch_method || '—'}</td>
                 <td>${getSourceMarkup(row.source)}</td>
-                <td>${row.approval_status || '—'}</td>
                 <td>${row.web_ai_search_matches ?? 0}</td>
                 <td>${row.web_crawl_matches ?? 0}</td>
                 <td>${formatDateTime(row.insert_date)}</td>
-                <td>
-                  <button
-                    type="button"
-                    class="admin-action-btn reject"
-                    data-remove-rejected-candidate-id="${row.special_candidate_id}"
-                  >
-                    Remove Rejected Special Candidate
-                  </button>
-                </td>
               </tr>
             `).join('')}
           </tbody>
         </table>
+      </div>
+      ${getRejectedSpecialActionMenuMarkup()}
+    `;
+  }
+
+  function getRejectedSpecialActionMenuMarkup() {
+    const candidateId = Number(state.actionRejectedCandidateId);
+    if (!candidateId) return '';
+    return `
+      <div class="admin-action-menu-backdrop" data-close-rejected-action-menu="true">
+        <div class="admin-action-menu" role="dialog" aria-modal="true" aria-label="Rejected special actions">
+          <h4>Rejected Special Candidate ${candidateId}</h4>
+          <div class="admin-actions-row">
+            <button
+              type="button"
+              class="admin-action-btn reject"
+              data-rejected-special-action="remove-rejected-candidate"
+              data-special-candidate-id="${candidateId}"
+            >
+              Remove Rejected Special Candidate
+            </button>
+            <button
+              type="button"
+              class="admin-secondary-btn"
+              data-close-rejected-action-menu="true"
+            >
+              Close
+            </button>
+          </div>
+        </div>
       </div>
     `;
   }
@@ -1484,9 +1505,27 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           render();
         });
       }
-      screenElement.querySelectorAll('[data-remove-rejected-candidate-id]').forEach((button) => {
+
+      screenElement.querySelectorAll('[data-rejected-special-candidate-row]').forEach((row) => {
+        row.addEventListener('click', () => {
+          const specialCandidateId = Number(row.getAttribute('data-rejected-special-candidate-row'));
+          if (!specialCandidateId) return;
+          state.actionRejectedCandidateId = specialCandidateId;
+          render();
+        });
+      });
+
+      screenElement.querySelectorAll('[data-close-rejected-action-menu="true"]').forEach((element) => {
+        element.addEventListener('click', (event) => {
+          if (event.currentTarget !== event.target && !event.target.hasAttribute('data-close-rejected-action-menu')) return;
+          state.actionRejectedCandidateId = null;
+          render();
+        });
+      });
+
+      screenElement.querySelectorAll('[data-rejected-special-action="remove-rejected-candidate"]').forEach((button) => {
         button.addEventListener('click', async () => {
-          const specialCandidateId = Number(button.getAttribute('data-remove-rejected-candidate-id'));
+          const specialCandidateId = Number(button.getAttribute('data-special-candidate-id'));
           if (!specialCandidateId) return;
           const shouldContinue = window.confirm('Remove rejected special candidate and matching reject records?');
           if (!shouldContinue) return;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -332,6 +332,22 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     }
   }
 
+  async function removeRejectedSpecialCandidate(specialCandidateId) {
+    state.errorMessage = '';
+    render();
+    try {
+      await callAdminSync({
+        mode: 'remove_rejected_special_candidate',
+        special_candidate_id: specialCandidateId
+      });
+      await loadRejectedSpecials();
+    } catch (err) {
+      console.error('Failed to remove rejected special candidate:', err);
+      state.errorMessage = err?.message || 'Failed to remove rejected special candidate.';
+      render();
+    }
+  }
+
   async function loadAllBars() {
     state.loadingBars = true;
     state.errorMessage = '';
@@ -1245,7 +1261,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       <section class="admin-home-view" aria-label="Admin tools">
         <h2>Admin tools</h2>
         <button type="button" class="admin-tool-button" data-tool="special-management">Special Management</button>
-        <button type="button" class="admin-tool-button" data-tool="rejected-special-management">Auto-Rejected Special Management</button>
+        <button type="button" class="admin-tool-button" data-tool="rejected-special-management">Rejected Specials</button>
         <button type="button" class="admin-tool-button" data-tool="bar-management">Bar Management</button>
         <button type="button" class="admin-tool-button" data-tool="specials-to-be-approved">Specials Pending Approval</button>
       </section>
@@ -1348,16 +1364,16 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function renderRejectedSpecialManagementView() {
-    titleElement.textContent = 'Auto-Rejected Special Management';
+    titleElement.textContent = 'Rejected Specials';
 
     if (state.loadingRejectedSpecials) {
-      screenElement.innerHTML = '<p class="admin-loading">Loading auto-rejected specials...</p>';
+      screenElement.innerHTML = '<p class="admin-loading">Loading rejected specials...</p>';
       return;
     }
 
     screenElement.innerHTML = `
-      <section class="admin-specials-view" aria-label="Auto-rejected special management">
-        <h2>Auto-Rejected Special Management</h2>
+      <section class="admin-specials-view" aria-label="Rejected specials">
+        <h2>Rejected Specials</h2>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildRejectedSpecialManagementTable()}
       </section>
@@ -1374,8 +1390,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     });
 
     if (!rows.length) {
-      if (searchTerm) return '<p class="admin-empty">No auto-rejected specials match that bar or neighborhood.</p>';
-      return '<p class="admin-empty">No auto-rejected specials found.</p>';
+      if (searchTerm) return '<p class="admin-empty">No rejected specials match that bar or neighborhood.</p>';
+      return '<p class="admin-empty">No rejected specials found.</p>';
     }
 
     return `
@@ -1405,6 +1421,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
               <th>Web AI Search Matches</th>
               <th>Web Crawl Matches</th>
               <th>Insert Date</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -1424,6 +1441,15 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
                 <td>${row.web_ai_search_matches ?? 0}</td>
                 <td>${row.web_crawl_matches ?? 0}</td>
                 <td>${formatDateTime(row.insert_date)}</td>
+                <td>
+                  <button
+                    type="button"
+                    class="admin-action-btn reject"
+                    data-remove-rejected-candidate-id="${row.special_candidate_id}"
+                  >
+                    Remove Rejected Special Candidate
+                  </button>
+                </td>
               </tr>
             `).join('')}
           </tbody>
@@ -1458,6 +1484,15 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           render();
         });
       }
+      screenElement.querySelectorAll('[data-remove-rejected-candidate-id]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const specialCandidateId = Number(button.getAttribute('data-remove-rejected-candidate-id'));
+          if (!specialCandidateId) return;
+          const shouldContinue = window.confirm('Remove rejected special candidate and matching reject records?');
+          if (!shouldContinue) return;
+          await removeRejectedSpecialCandidate(specialCandidateId);
+        });
+      });
       return;
     }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -50,6 +50,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     currentView: 'home',
     loading: false,
     loadingSpecials: false,
+    loadingRejectedSpecials: false,
     loadingBars: false,
     specialSearchTerm: '',
     specialFilterActive: 'all',
@@ -70,6 +71,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     detailBarEditing: false,
     savingBar: false,
     runs: [],
+    rejectedSpecials: [],
     allSpecials: [],
     groupedSpecials: [],
     errorMessage: ''
@@ -309,6 +311,23 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       state.errorMessage = err?.message || 'Failed to load specials.';
     } finally {
       state.loadingSpecials = false;
+      render();
+    }
+  }
+
+  async function loadRejectedSpecials() {
+    state.loadingRejectedSpecials = true;
+    state.errorMessage = '';
+    render();
+
+    try {
+      const result = await callAdminSync({ mode: 'get_rejected_special_candidates' });
+      state.rejectedSpecials = Array.isArray(result?.specials) ? result.specials : [];
+    } catch (err) {
+      console.error('Failed to load rejected specials:', err);
+      state.errorMessage = err?.message || 'Failed to load rejected specials.';
+    } finally {
+      state.loadingRejectedSpecials = false;
       render();
     }
   }
@@ -1210,6 +1229,12 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           render();
           await loadAllBars();
         }
+
+        if (tool === 'rejected-special-management') {
+          state.currentView = 'rejected-special-management';
+          render();
+          await loadRejectedSpecials();
+        }
       });
     });
   }
@@ -1220,6 +1245,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       <section class="admin-home-view" aria-label="Admin tools">
         <h2>Admin tools</h2>
         <button type="button" class="admin-tool-button" data-tool="special-management">Special Management</button>
+        <button type="button" class="admin-tool-button" data-tool="rejected-special-management">Rejected Special Management</button>
         <button type="button" class="admin-tool-button" data-tool="bar-management">Bar Management</button>
         <button type="button" class="admin-tool-button" data-tool="specials-to-be-approved">Specials Pending Approval</button>
       </section>
@@ -1321,6 +1347,91 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     bindBarManagementEvents();
   }
 
+  function renderRejectedSpecialManagementView() {
+    titleElement.textContent = 'Rejected Special Management';
+
+    if (state.loadingRejectedSpecials) {
+      screenElement.innerHTML = '<p class="admin-loading">Loading rejected specials...</p>';
+      return;
+    }
+
+    screenElement.innerHTML = `
+      <section class="admin-specials-view" aria-label="Rejected special management">
+        <h2>Rejected Special Management</h2>
+        ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
+        ${buildRejectedSpecialManagementTable()}
+      </section>
+    `;
+  }
+
+  function buildRejectedSpecialManagementTable() {
+    const searchTerm = String(state.specialSearchTerm || '').trim().toLowerCase();
+    const rows = state.rejectedSpecials.filter((row) => {
+      const neighborhood = String(row.neighborhood || '').trim().toLowerCase();
+      const barName = String(row.bar_name || '').trim().toLowerCase();
+      if (!searchTerm) return true;
+      return neighborhood.includes(searchTerm) || barName.includes(searchTerm);
+    });
+
+    if (!rows.length) {
+      if (searchTerm) return '<p class="admin-empty">No rejected specials match that bar or neighborhood.</p>';
+      return '<p class="admin-empty">No rejected specials found.</p>';
+    }
+
+    return `
+      <input
+        type="search"
+        class="admin-input admin-special-search-input"
+        data-rejected-special-search-input
+        placeholder="Search by bar or neighborhood"
+        value="${escapeAttribute(state.specialSearchTerm)}"
+        aria-label="Search rejected specials by bar or neighborhood"
+      />
+      <div class="admin-table-wrap">
+        <table class="admin-special-table">
+          <thead>
+            <tr>
+              <th>Neighborhood</th>
+              <th>Bar Name</th>
+              <th>Description</th>
+              <th>Days of Week</th>
+              <th>All Day</th>
+              <th>Start Time</th>
+              <th>End Time</th>
+              <th>Type</th>
+              <th>Method</th>
+              <th>Source</th>
+              <th>Status</th>
+              <th>Web AI Search Matches</th>
+              <th>Web Crawl Matches</th>
+              <th>Insert Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map((row) => `
+              <tr>
+                <td>${row.neighborhood || '—'}</td>
+                <td>${row.bar_name || '—'}</td>
+                <td>${row.description || '—'}</td>
+                <td>${formatDayGroup(row.days_of_week || [])}</td>
+                <td>${row.all_day || '—'}</td>
+                <td>${formatTime(row.start_time)}</td>
+                <td>${formatTime(row.end_time)}</td>
+                <td>${row.type || '—'}</td>
+                <td>${row.fetch_method || '—'}</td>
+                <td>${getSourceMarkup(row.source)}</td>
+                <td>${row.approval_status || '—'}</td>
+                <td>${row.web_ai_search_matches ?? 0}</td>
+                <td>${row.web_crawl_matches ?? 0}</td>
+                <td>${formatDateTime(row.insert_date)}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
   function render() {
     updateToolbarButtons();
     if (state.currentView === 'specials') {
@@ -1335,6 +1446,18 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
     if (state.currentView === 'bar-management') {
       renderBarManagementView();
+      return;
+    }
+
+    if (state.currentView === 'rejected-special-management') {
+      renderRejectedSpecialManagementView();
+      const rejectedSearch = screenElement.querySelector('[data-rejected-special-search-input]');
+      if (rejectedSearch) {
+        rejectedSearch.addEventListener('input', (event) => {
+          state.specialSearchTerm = event.target.value;
+          render();
+        });
+      }
       return;
     }
 

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -394,7 +394,10 @@ def get_rejected_special_candidates(cursor):
             sc.source,
             sc.approval_status,
             sc.insert_date
-        ORDER BY sc.insert_date DESC, sc.special_candidate_id DESC
+        ORDER BY
+            sc.neighborhood ASC,
+            b.name ASC,
+            sc.special_candidate_id DESC
         """
     )
     rows = cursor.fetchall()

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -376,7 +376,7 @@ def get_rejected_special_candidates(cursor):
         JOIN bar b ON b.bar_id = sc.bar_id
         LEFT JOIN special_candidate_reject_join scrj ON scrj.special_candidate_id = sc.special_candidate_id
         LEFT JOIN special_candidate_reject scr ON scr.reject_id = scrj.reject_id
-        WHERE sc.approval_status IN ('REJECTED', 'AUTO_REJECTED')
+        WHERE sc.approval_status = 'AUTO_REJECTED'
         GROUP BY
             sc.special_candidate_id,
             sc.bar_id,

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -350,6 +350,81 @@ def get_unapproved_special_candidates(cursor):
     return {'runs': runs, 'run_count': len(runs), 'special_count': len(rows)}
 
 
+def get_rejected_special_candidates(cursor):
+    cursor.execute(
+        """
+        SELECT
+            sc.special_candidate_id,
+            sc.bar_id,
+            b.name AS bar_name,
+            sc.neighborhood,
+            sc.description,
+            sc.days_of_week,
+            sc.type,
+            sc.start_time,
+            sc.end_time,
+            sc.all_day,
+            sc.is_recurring,
+            sc.date,
+            sc.fetch_method,
+            sc.source,
+            sc.approval_status,
+            sc.insert_date,
+            COALESCE(SUM(CASE WHEN scr.fetch_method = 'web_ai_search' THEN 1 ELSE 0 END), 0) AS web_ai_search_matches,
+            COALESCE(SUM(CASE WHEN scr.fetch_method = 'web_crawl' THEN 1 ELSE 0 END), 0) AS web_crawl_matches
+        FROM special_candidate sc
+        JOIN bar b ON b.bar_id = sc.bar_id
+        LEFT JOIN special_candidate_reject_join scrj ON scrj.special_candidate_id = sc.special_candidate_id
+        LEFT JOIN special_candidate_reject scr ON scr.reject_id = scrj.reject_id
+        WHERE sc.approval_status IN ('REJECTED', 'AUTO_REJECTED')
+        GROUP BY
+            sc.special_candidate_id,
+            sc.bar_id,
+            b.name,
+            sc.neighborhood,
+            sc.description,
+            sc.days_of_week,
+            sc.type,
+            sc.start_time,
+            sc.end_time,
+            sc.all_day,
+            sc.is_recurring,
+            sc.date,
+            sc.fetch_method,
+            sc.source,
+            sc.approval_status,
+            sc.insert_date
+        ORDER BY sc.insert_date DESC, sc.special_candidate_id DESC
+        """
+    )
+    rows = cursor.fetchall()
+    specials = []
+    for row in rows:
+        specials.append(
+            {
+                'special_candidate_id': row.get('special_candidate_id'),
+                'bar_id': row.get('bar_id'),
+                'bar_name': row.get('bar_name'),
+                'neighborhood': row.get('neighborhood'),
+                'description': row.get('description'),
+                'days_of_week': _parse_days_of_week(row.get('days_of_week')),
+                'type': row.get('type'),
+                'start_time': _normalize_time_value(row.get('start_time')) or None,
+                'end_time': _normalize_time_value(row.get('end_time')) or None,
+                'all_day': row.get('all_day'),
+                'is_recurring': row.get('is_recurring'),
+                'date': row.get('date').isoformat() if hasattr(row.get('date'), 'isoformat') and row.get('date') else row.get('date'),
+                'fetch_method': row.get('fetch_method'),
+                'source': row.get('source'),
+                'approval_status': row.get('approval_status'),
+                'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
+                'web_ai_search_matches': int(row.get('web_ai_search_matches') or 0),
+                'web_crawl_matches': int(row.get('web_crawl_matches') or 0),
+            }
+        )
+    return {'specials': specials, 'special_count': len(specials)}
+
+
 def update_special_candidate_approval(cursor, special_candidate_id: int, approval_status: str):
     normalized_status = str(approval_status or '').strip().upper()
     if normalized_status not in {'APPROVED', 'REJECTED'}:
@@ -913,6 +988,7 @@ def lambda_handler(event, context):
     mode = event.get('mode')
     if mode not in {
         'get_unapproved_special_candidates',
+        'get_rejected_special_candidates',
         'update_special_candidate_approval',
         'get_all_specials',
         'update_special',
@@ -928,6 +1004,7 @@ def lambda_handler(event, context):
                 {
                     'error': (
                         'mode must be one of get_unapproved_special_candidates, '
+                        'get_rejected_special_candidates, '
                         'update_special_candidate_approval, get_all_specials, update_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
@@ -940,6 +1017,8 @@ def lambda_handler(event, context):
         with conn.cursor() as cursor:
             if mode == 'get_unapproved_special_candidates':
                 result = get_unapproved_special_candidates(cursor)
+            elif mode == 'get_rejected_special_candidates':
+                result = get_rejected_special_candidates(cursor)
             elif mode == 'update_special_candidate_approval':
                 special_candidate_id = event.get('special_candidate_id')
                 approval_status = event.get('approval_status')

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -376,7 +376,7 @@ def get_rejected_special_candidates(cursor):
         JOIN bar b ON b.bar_id = sc.bar_id
         LEFT JOIN special_candidate_reject_join scrj ON scrj.special_candidate_id = sc.special_candidate_id
         LEFT JOIN special_candidate_reject scr ON scr.reject_id = scrj.reject_id
-        WHERE sc.approval_status = 'AUTO_REJECTED'
+        WHERE sc.approval_status = 'REJECTED'
         GROUP BY
             sc.special_candidate_id,
             sc.bar_id,
@@ -423,6 +423,49 @@ def get_rejected_special_candidates(cursor):
             }
         )
     return {'specials': specials, 'special_count': len(specials)}
+
+
+def remove_rejected_special_candidate(cursor, special_candidate_id: int):
+    cursor.execute(
+        """
+        SELECT reject_id
+        FROM special_candidate_reject_join
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    reject_ids = [row.get('reject_id') for row in cursor.fetchall() if row.get('reject_id')]
+
+    cursor.execute(
+        """
+        DELETE FROM special_candidate_reject_join
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    deleted_join_rows = cursor.rowcount
+
+    deleted_reject_rows = 0
+    if reject_ids:
+        placeholders = ', '.join(['%s'] * len(reject_ids))
+        cursor.execute(
+            f"""
+            DELETE FROM special_candidate_reject
+            WHERE reject_id IN ({placeholders})
+              AND reject_id NOT IN (
+                    SELECT reject_id
+                    FROM special_candidate_reject_join
+                )
+            """,
+            tuple(reject_ids),
+        )
+        deleted_reject_rows = cursor.rowcount
+
+    return {
+        'special_candidate_id': special_candidate_id,
+        'deleted_join_rows': deleted_join_rows,
+        'deleted_reject_rows': deleted_reject_rows,
+    }
 
 
 def update_special_candidate_approval(cursor, special_candidate_id: int, approval_status: str):
@@ -989,6 +1032,7 @@ def lambda_handler(event, context):
     if mode not in {
         'get_unapproved_special_candidates',
         'get_rejected_special_candidates',
+        'remove_rejected_special_candidate',
         'update_special_candidate_approval',
         'get_all_specials',
         'update_special',
@@ -1005,6 +1049,7 @@ def lambda_handler(event, context):
                     'error': (
                         'mode must be one of get_unapproved_special_candidates, '
                         'get_rejected_special_candidates, '
+                        'remove_rejected_special_candidate, '
                         'update_special_candidate_approval, get_all_specials, update_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
@@ -1025,6 +1070,11 @@ def lambda_handler(event, context):
                 if not special_candidate_id:
                     raise ValueError('special_candidate_id is required for update_special_candidate_approval')
                 result = update_special_candidate_approval(cursor, special_candidate_id, approval_status)
+            elif mode == 'remove_rejected_special_candidate':
+                special_candidate_id = event.get('special_candidate_id')
+                if not special_candidate_id:
+                    raise ValueError('special_candidate_id is required for remove_rejected_special_candidate')
+                result = remove_rejected_special_candidate(cursor, special_candidate_id)
             elif mode == 'get_all_specials':
                 result = get_all_specials(cursor)
             elif mode == 'get_all_bars':

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -73,6 +73,10 @@ def _normalize_day_of_week(value) -> str:
     return str(value).strip().upper()
 
 
+def _normalize_days_of_week_value(value) -> tuple:
+    return tuple(sorted(_normalize_day_of_week(day) for day in _parse_days_of_week(value)))
+
+
 def _normalize_yn_flag(value) -> str:
     if value in {'Y', 'N'}:
         return value
@@ -102,6 +106,18 @@ def _normalize_time_value(value) -> str:
     return normalized
 
 
+def _normalize_date_value(value) -> str:
+    if value is None:
+        return ''
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    return str(value).strip()
+
+
+def _normalize_text_value(value) -> str:
+    return str(value or '').strip()
+
+
 def _is_candidate_same_as_special(candidate_row: Dict, special_row: Dict) -> bool:
     return (
         _normalize_day_of_week(candidate_row.get('day_of_week')) == _normalize_day_of_week(special_row.get('day_of_week'))
@@ -109,6 +125,21 @@ def _is_candidate_same_as_special(candidate_row: Dict, special_row: Dict) -> boo
         and _normalize_time_value(candidate_row.get('start_time')) == _normalize_time_value(special_row.get('start_time'))
         and _normalize_time_value(candidate_row.get('end_time')) == _normalize_time_value(special_row.get('end_time'))
         and _descriptions_match(candidate_row.get('description'), special_row.get('description'))
+    )
+
+
+def _is_candidate_same_as_reject(candidate_row: Dict, reject_row: Dict) -> bool:
+    return (
+        str(candidate_row.get('bar_id')) == str(reject_row.get('bar_id'))
+        and _normalize_days_of_week_value(candidate_row.get('days_of_week')) == _normalize_days_of_week_value(reject_row.get('days_of_week'))
+        and _normalize_time_value(candidate_row.get('start_time')) == _normalize_time_value(reject_row.get('start_time'))
+        and _normalize_time_value(candidate_row.get('end_time')) == _normalize_time_value(reject_row.get('end_time'))
+        and _normalize_yn_flag(candidate_row.get('all_day')) == _normalize_yn_flag(reject_row.get('all_day'))
+        and _normalize_yn_flag(candidate_row.get('is_recurring')) == _normalize_yn_flag(reject_row.get('is_recurring'))
+        and _normalize_date_value(candidate_row.get('date')) == _normalize_date_value(reject_row.get('date'))
+        and _normalize_text_value(candidate_row.get('fetch_method')) == _normalize_text_value(reject_row.get('fetch_method'))
+        and _normalize_text_value(candidate_row.get('source') or candidate_row.get('source_url')) == _normalize_text_value(reject_row.get('source'))
+        and _descriptions_match(candidate_row.get('description'), reject_row.get('description'))
     )
 
 
@@ -174,18 +205,45 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
     run_id = insert_special_candidate_run(cursor, run)
     inserted_count = 0
     auto_approved_count = 0
+
+    cursor.execute(
+        """
+        SELECT
+            bar_id,
+            description,
+            days_of_week,
+            start_time,
+            end_time,
+            all_day,
+            is_recurring,
+            date,
+            fetch_method,
+            source
+        FROM special_candidate_reject
+        WHERE bar_id = %s
+        """,
+        (run['bar_id'],),
+    )
+    rejected_candidates = cursor.fetchall()
+
     for candidate in candidates:
         approval_status = 'NOT_APPROVED'
         approval_date = None
         approved_special_id = None
         confidence = _parse_confidence(candidate.get('confidence'))
 
-        fetch_method = (candidate.get('fetch_method') or '').strip()
-        auto_approval_threshold = WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD if fetch_method == 'web_ai_search' else WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD
-        if confidence >= auto_approval_threshold:
-            approval_status = 'AUTO_APPROVED'
+        is_rejected_candidate = any(_is_candidate_same_as_reject(candidate, rejected_candidate) for rejected_candidate in rejected_candidates)
+
+        if is_rejected_candidate:
+            approval_status = 'AUTO_REJECTED'
             approval_date = datetime.utcnow()
-            auto_approved_count += 1
+        else:
+            fetch_method = (candidate.get('fetch_method') or '').strip()
+            auto_approval_threshold = WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD if fetch_method == 'web_ai_search' else WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD
+            if confidence >= auto_approval_threshold:
+                approval_status = 'AUTO_APPROVED'
+                approval_date = datetime.utcnow()
+                auto_approved_count += 1
 
         cursor.execute(
             """

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -209,6 +209,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
     cursor.execute(
         """
         SELECT
+            reject_id,
             bar_id,
             description,
             days_of_week,
@@ -232,7 +233,13 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         approved_special_id = None
         confidence = _parse_confidence(candidate.get('confidence'))
 
-        is_rejected_candidate = any(_is_candidate_same_as_reject(candidate, rejected_candidate) for rejected_candidate in rejected_candidates)
+        matched_reject_ids = [
+            rejected_candidate.get('reject_id')
+            for rejected_candidate in rejected_candidates
+            if _is_candidate_same_as_reject(candidate, rejected_candidate)
+            and rejected_candidate.get('reject_id')
+        ]
+        is_rejected_candidate = bool(matched_reject_ids)
 
         if is_rejected_candidate:
             approval_status = 'AUTO_REJECTED'
@@ -273,6 +280,16 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                 approved_special_id,
             ),
         )
+        candidate_id = cursor.lastrowid
+        if is_rejected_candidate:
+            for reject_id in matched_reject_ids:
+                cursor.execute(
+                    """
+                    INSERT INTO special_candidate_reject_join (reject_id, special_candidate_id)
+                    VALUES (%s, %s)
+                    """,
+                    (reject_id, candidate_id),
+                )
         inserted_count += 1
 
     cursor.execute(


### PR DESCRIPTION
### Motivation
- Prevent previously rejected special candidates from being re-introduced by the candidate generation pipeline by automatically rejecting matches found during generation.
- Use a precise matching policy: descriptions are compared with the existing fuzzy matcher while other fields require exact (normalized) equality per the requested criteria.

### Description
- Added normalization helpers `
_normalize_days_of_week_value`, `
_normalize_date_value`, and `
_normalize_text_value` to support stable comparisons across representations.
- Implemented `_is_candidate_same_as_reject` which enforces exact (normalized) matches on `bar_id`, `days_of_week`, `start_time`, `end_time`, `all_day`, `is_recurring`, `date`, `fetch_method`, and `source` plus a fuzzy description match via the existing `_descriptions_match`.
- In `insert_special_candidate` the code now preloads `special_candidate_reject` rows for the bar and marks any incoming candidate that matches a reject row as `AUTO_REJECTED` with an `approval_date` instead of leaving it `NOT_APPROVED` or auto-approving by confidence.
- Retained existing confidence-based auto-approval behavior for candidates that do not match a rejection record.

### Testing
- Ran `python -m py_compile functions/dbSpecialSync/db_special_sync.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f0ea7d888330bffcaf33ace3140e)