### PR TITLE
Add manual special creation and day-checkbox editing in Special Management

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -168,6 +168,19 @@ body {
   gap: 8px;
 }
 
+.admin-day-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.admin-day-checkboxes label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .admin-actions-row {
   display: flex;
   gap: 8px;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -78,6 +78,18 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     specialManagementSort: { key: 'neighborhood', direction: 'asc' },
     barManagementSort: { key: 'name', direction: 'asc' },
     rejectedSpecialSort: { key: 'neighborhood', direction: 'asc' },
+    creatingSpecial: false,
+    savingNewSpecial: false,
+    newSpecialForm: {
+      neighborhood: '',
+      bar_id: '',
+      description: '',
+      type: 'food',
+      days_of_week: [...CANDIDATE_DAY_KEYS],
+      all_day: 'Y',
+      start_time: '',
+      end_time: ''
+    },
     errorMessage: ''
   };
 
@@ -104,6 +116,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     state.detailBar = null;
     state.detailOpenHours = [];
     state.detailBarEditing = false;
+    state.creatingSpecial = false;
     render();
   });
 
@@ -520,6 +533,34 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     }
   }
 
+  async function createSpecial(payload) {
+    state.savingNewSpecial = true;
+    state.errorMessage = '';
+    render();
+
+    try {
+      await callAdminSync({ mode: 'insert_special', ...payload });
+      await loadAllSpecials();
+      state.creatingSpecial = false;
+      state.newSpecialForm = {
+        neighborhood: '',
+        bar_id: '',
+        description: '',
+        type: 'food',
+        days_of_week: [...CANDIDATE_DAY_KEYS],
+        all_day: 'Y',
+        start_time: '',
+        end_time: ''
+      };
+    } catch (err) {
+      console.error('Failed to create special:', err);
+      state.errorMessage = err?.message || 'Failed to create special.';
+    } finally {
+      state.savingNewSpecial = false;
+      render();
+    }
+  }
+
   async function saveBarUpdates(barPayload, openHoursRows) {
     state.savingBar = true;
     state.errorMessage = '';
@@ -596,6 +637,19 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
     const renderValue = (special, key, fallback = '—') => {
       if (state.detailEditing && ['day_of_week', 'all_day', 'start_time', 'end_time', 'description', 'type', 'is_active'].includes(key)) {
+        if (key === 'day_of_week') {
+          const selectedDays = [...new Set(state.detailSpecials.map((row) => normalizeDay(row.day_of_week)).filter(Boolean))];
+          return `
+            <span class="admin-day-checkboxes">
+              ${DAY_ORDER.map((day) => `
+                <label>
+                  <input type="checkbox" data-detail-day="${day}" ${selectedDays.includes(day) ? 'checked' : ''} />
+                  ${CANDIDATE_DAY_ALIASES[day] || day}
+                </label>
+              `).join(' ')}
+            </span>
+          `;
+        }
         if (key === 'type') {
           const normalizedType = String(special[key] || '').trim().toLowerCase();
           const resolvedType = ['drink', 'food', 'combo'].includes(normalizedType) ? normalizedType : 'unknown';
@@ -613,7 +667,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       return special[key] === null || special[key] === undefined || special[key] === '' ? fallback : String(special[key]);
     };
 
-    const detailsMarkup = specials.map((special) => {
+    const detailsMarkup = specials.map((special, index) => {
       return `
         <section class="admin-special-detail-card">
           <h4>${DAY_LABELS[normalizeDay(special.day_of_week)] || special.day_of_week || 'Unknown Day'} — Special ${special.special_id}</h4>
@@ -622,7 +676,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             <p><strong>Neighborhood:</strong> ${special.neighborhood || '—'}</p>
             <p><strong>Bar Name:</strong> ${special.bar_name || '—'}</p>
             <p><strong>Description:</strong> ${renderValue(special, 'description')}</p>
-            <p><strong>Day of Week:</strong> ${renderValue(special, 'day_of_week')}</p>
+            <p><strong>Day of Week:</strong> ${state.detailEditing && index > 0 ? (special.day_of_week || '—') : renderValue(special, 'day_of_week')}</p>
             <p><strong>All Day:</strong> ${renderValue(special, 'all_day')}</p>
             <p><strong>Start Time:</strong> ${renderValue(special, 'start_time')}</p>
             <p><strong>End Time:</strong> ${renderValue(special, 'end_time')}</p>
@@ -1099,6 +1153,16 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
   function bindSpecialManagementEvents() {
     bindSortableColumnHeaders();
+    const defaultNewSpecialForm = () => ({
+      neighborhood: '',
+      bar_id: '',
+      description: '',
+      type: 'food',
+      days_of_week: [...CANDIDATE_DAY_KEYS],
+      all_day: 'Y',
+      start_time: '',
+      end_time: ''
+    });
 
     const searchInput = screenElement.querySelector('[data-special-search-input]');
     if (searchInput) {
@@ -1118,6 +1182,58 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         render();
       });
     });
+
+    const createToggle = screenElement.querySelector('[data-special-create-toggle]');
+    if (createToggle) {
+      createToggle.addEventListener('click', () => {
+        state.creatingSpecial = !state.creatingSpecial;
+        if (!state.creatingSpecial) {
+          state.newSpecialForm = defaultNewSpecialForm();
+        }
+        render();
+      });
+    }
+
+    screenElement.querySelectorAll('[data-new-special-field]').forEach((input) => {
+      input.addEventListener('change', (event) => {
+        const field = event.target.getAttribute('data-new-special-field');
+        if (!field) return;
+        state.newSpecialForm[field] = event.target.value;
+        if (field === 'neighborhood') {
+          state.newSpecialForm.bar_id = '';
+        }
+        render();
+      });
+    });
+
+    screenElement.querySelectorAll('[data-new-special-day]').forEach((checkbox) => {
+      checkbox.addEventListener('change', () => {
+        state.newSpecialForm.days_of_week = Array.from(
+          screenElement.querySelectorAll('[data-new-special-day]:checked')
+        ).map((input) => input.getAttribute('data-new-special-day'));
+      });
+    });
+
+    const saveNewSpecialButton = screenElement.querySelector('[data-new-special-save]');
+    if (saveNewSpecialButton) {
+      saveNewSpecialButton.addEventListener('click', async () => {
+        const payload = {
+          bar_id: Number(state.newSpecialForm.bar_id),
+          description: String(state.newSpecialForm.description || '').trim(),
+          type: String(state.newSpecialForm.type || '').trim().toLowerCase(),
+          days_of_week: state.newSpecialForm.days_of_week,
+          all_day: String(state.newSpecialForm.all_day || 'Y').trim().toUpperCase(),
+          start_time: String(state.newSpecialForm.start_time || '').trim(),
+          end_time: String(state.newSpecialForm.end_time || '').trim()
+        };
+        if (!payload.bar_id || !payload.description || !payload.days_of_week.length) {
+          state.errorMessage = 'Neighborhood, bar, description, and at least one day are required.';
+          render();
+          return;
+        }
+        await createSpecial(payload);
+      });
+    }
 
     screenElement.querySelectorAll('.admin-special-row[data-special-id]').forEach((row) => {
       row.addEventListener('click', () => {
@@ -1198,7 +1314,37 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             }
             payloadBySpecialId.get(specialId)[field] = input.value;
           });
-          await saveSpecialUpdates([...payloadBySpecialId.values()]);
+          const updates = [...payloadBySpecialId.values()];
+          const selectedDays = [...new Set(Array.from(screenElement.querySelectorAll('[data-detail-day]:checked'))
+            .map((input) => normalizeDay(input.getAttribute('data-detail-day')))
+            .filter(Boolean))];
+          const activeSpecialsByDay = new Map(state.detailSpecials.map((row) => [normalizeDay(row.day_of_week), row]));
+          const selectedDaySet = new Set(selectedDays);
+          updates.forEach((payload) => {
+            const matchingSpecial = state.detailSpecials.find((row) => row.special_id === payload.special_id);
+            if (!matchingSpecial) return;
+            const day = normalizeDay(matchingSpecial.day_of_week);
+            if (!selectedDaySet.has(day)) {
+              payload.is_active = 'N';
+            } else if (!payload.is_active) {
+              payload.is_active = matchingSpecial.is_active || 'Y';
+            }
+          });
+          await saveSpecialUpdates(updates);
+
+          const templateSpecial = state.detailSpecials[0];
+          const missingDays = selectedDays.filter((day) => !activeSpecialsByDay.has(day));
+          for (const day of missingDays) {
+            await createSpecial({
+              bar_id: templateSpecial.bar_id,
+              description: updates[0]?.description ?? templateSpecial.description ?? '',
+              type: updates[0]?.type ?? templateSpecial.type ?? 'food',
+              days_of_week: [day],
+              all_day: updates[0]?.all_day ?? templateSpecial.all_day ?? 'Y',
+              start_time: updates[0]?.start_time ?? templateSpecial.start_time ?? '',
+              end_time: updates[0]?.end_time ?? templateSpecial.end_time ?? ''
+            });
+          }
         }
       });
     });
@@ -1320,6 +1466,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         if (tool === 'special-management') {
           state.currentView = 'special-management';
           render();
+          await loadAllBars();
           await loadAllSpecials();
         }
 
@@ -1379,10 +1526,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       return;
     }
 
-    const neighborhoodOptions = [...new Set(state.groupedSpecials
+    const neighborhoodOptions = [...new Set(state.allBars
       .map((row) => String(row.neighborhood || '').trim())
       .filter(Boolean))]
       .sort((a, b) => a.localeCompare(b));
+    const newSpecialNeighborhood = String(state.newSpecialForm.neighborhood || '');
+    const availableBars = state.allBars
+      .filter((bar) => !newSpecialNeighborhood || String(bar.neighborhood || '') === newSpecialNeighborhood)
+      .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
     const typeOptions = [...new Set(state.groupedSpecials
       .map((row) => String(row.type || '').trim().toLowerCase())
       .filter(Boolean))]
@@ -1419,6 +1570,56 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             <option value="N" ${state.specialFilterAllDay === 'N' ? 'selected' : ''}>All Day: No</option>
           </select>
         </div>
+        <button type="button" class="admin-tool-button" data-special-create-toggle>
+          ${state.creatingSpecial ? 'Cancel New Special' : 'Add New Special'}
+        </button>
+        ${state.creatingSpecial ? `
+          <section class="admin-special-detail-card" aria-label="Create special">
+            <p><strong>Create new special</strong></p>
+            <label>Neighborhood
+              <select class="admin-input" data-new-special-field="neighborhood">
+                <option value="">Select neighborhood</option>
+                ${neighborhoodOptions.map((name) => `<option value="${escapeAttribute(name)}" ${newSpecialNeighborhood === name ? 'selected' : ''}>${name}</option>`).join('')}
+              </select>
+            </label>
+            <label>Bar
+              <select class="admin-input" data-new-special-field="bar_id" ${newSpecialNeighborhood ? '' : 'disabled'}>
+                <option value="">Select bar</option>
+                ${availableBars.map((bar) => `<option value="${bar.bar_id}" ${String(state.newSpecialForm.bar_id) === String(bar.bar_id) ? 'selected' : ''}>${bar.name}</option>`).join('')}
+              </select>
+            </label>
+            <label>Description
+              <input class="admin-input" data-new-special-field="description" value="${escapeAttribute(state.newSpecialForm.description)}" />
+            </label>
+            <label>Type
+              <select class="admin-input" data-new-special-field="type">
+                <option value="food" ${state.newSpecialForm.type === 'food' ? 'selected' : ''}>food</option>
+                <option value="drink" ${state.newSpecialForm.type === 'drink' ? 'selected' : ''}>drink</option>
+                <option value="combo" ${state.newSpecialForm.type === 'combo' ? 'selected' : ''}>combo</option>
+              </select>
+            </label>
+            <div class="admin-day-checkboxes">
+              ${CANDIDATE_DAY_KEYS.map((day) => `
+                <label><input type="checkbox" data-new-special-day="${day}" ${state.newSpecialForm.days_of_week.includes(day) ? 'checked' : ''}/> ${day}</label>
+              `).join('')}
+            </div>
+            <label>All Day
+              <select class="admin-input" data-new-special-field="all_day">
+                <option value="Y" ${state.newSpecialForm.all_day === 'Y' ? 'selected' : ''}>Y</option>
+                <option value="N" ${state.newSpecialForm.all_day === 'N' ? 'selected' : ''}>N</option>
+              </select>
+            </label>
+            <label>Start Time
+              <input class="admin-input" placeholder="HH:MM" data-new-special-field="start_time" value="${escapeAttribute(state.newSpecialForm.start_time)}"/>
+            </label>
+            <label>End Time
+              <input class="admin-input" placeholder="HH:MM" data-new-special-field="end_time" value="${escapeAttribute(state.newSpecialForm.end_time)}"/>
+            </label>
+            <div class="admin-actions-row">
+              <button type="button" class="admin-action-btn approve" data-new-special-save ${state.savingNewSpecial ? 'disabled' : ''}>Save New Special</button>
+            </div>
+          </section>
+        ` : ''}
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildSpecialManagementTable()}
       </section>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -627,6 +627,70 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     `;
   }
 
+  function getCreateSpecialModalMarkup() {
+    if (!state.creatingSpecial) return '';
+
+    const neighborhoodOptions = [...new Set(state.allBars
+      .map((row) => String(row.neighborhood || '').trim())
+      .filter(Boolean))]
+      .sort((a, b) => a.localeCompare(b));
+    const newSpecialNeighborhood = String(state.newSpecialForm.neighborhood || '');
+    const availableBars = state.allBars
+      .filter((bar) => !newSpecialNeighborhood || String(bar.neighborhood || '') === newSpecialNeighborhood)
+      .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
+
+    return `
+      <div class="admin-modal-backdrop" data-close-create-special-modal="true">
+        <div class="admin-modal" role="dialog" aria-label="Create special">
+          <h3>Create New Special</h3>
+          <label>Neighborhood
+            <select class="admin-input" data-new-special-field="neighborhood">
+              <option value="">Select neighborhood</option>
+              ${neighborhoodOptions.map((name) => `<option value="${escapeAttribute(name)}" ${newSpecialNeighborhood === name ? 'selected' : ''}>${name}</option>`).join('')}
+            </select>
+          </label>
+          <label>Bar
+            <select class="admin-input" data-new-special-field="bar_id" ${newSpecialNeighborhood ? '' : 'disabled'}>
+              <option value="">Select bar</option>
+              ${availableBars.map((bar) => `<option value="${bar.bar_id}" ${String(state.newSpecialForm.bar_id) === String(bar.bar_id) ? 'selected' : ''}>${bar.name}</option>`).join('')}
+            </select>
+          </label>
+          <label>Description
+            <input class="admin-input" data-new-special-field="description" value="${escapeAttribute(state.newSpecialForm.description)}" />
+          </label>
+          <label>Type
+            <select class="admin-input" data-new-special-field="type">
+              <option value="food" ${state.newSpecialForm.type === 'food' ? 'selected' : ''}>food</option>
+              <option value="drink" ${state.newSpecialForm.type === 'drink' ? 'selected' : ''}>drink</option>
+              <option value="combo" ${state.newSpecialForm.type === 'combo' ? 'selected' : ''}>combo</option>
+            </select>
+          </label>
+          <div class="admin-day-checkboxes">
+            ${CANDIDATE_DAY_KEYS.map((day) => `
+              <label><input type="checkbox" data-new-special-day="${day}" ${state.newSpecialForm.days_of_week.includes(day) ? 'checked' : ''}/> ${day}</label>
+            `).join('')}
+          </div>
+          <label>All Day
+            <select class="admin-input" data-new-special-field="all_day">
+              <option value="Y" ${state.newSpecialForm.all_day === 'Y' ? 'selected' : ''}>Y</option>
+              <option value="N" ${state.newSpecialForm.all_day === 'N' ? 'selected' : ''}>N</option>
+            </select>
+          </label>
+          <label>Start Time
+            <input class="admin-input" placeholder="HH:MM" data-new-special-field="start_time" value="${escapeAttribute(state.newSpecialForm.start_time)}"/>
+          </label>
+          <label>End Time
+            <input class="admin-input" placeholder="HH:MM" data-new-special-field="end_time" value="${escapeAttribute(state.newSpecialForm.end_time)}"/>
+          </label>
+          <div class="admin-actions-row">
+            <button type="button" class="admin-action-btn approve" data-new-special-save ${state.savingNewSpecial ? 'disabled' : ''}>Save New Special</button>
+            <button type="button" class="admin-secondary-btn" data-close-create-special-modal="true" ${state.savingNewSpecial ? 'disabled' : ''}>Cancel</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   function getDetailModalMarkup() {
     if (!state.detailSpecials.length) return '';
     const specials = [...state.detailSpecials].sort((a, b) => {
@@ -1186,13 +1250,19 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     const createToggle = screenElement.querySelector('[data-special-create-toggle]');
     if (createToggle) {
       createToggle.addEventListener('click', () => {
-        state.creatingSpecial = !state.creatingSpecial;
-        if (!state.creatingSpecial) {
-          state.newSpecialForm = defaultNewSpecialForm();
-        }
+        state.creatingSpecial = true;
         render();
       });
     }
+
+    screenElement.querySelectorAll('[data-close-create-special-modal="true"]').forEach((element) => {
+      element.addEventListener('click', (event) => {
+        if (event.currentTarget !== event.target) return;
+        state.creatingSpecial = false;
+        state.newSpecialForm = defaultNewSpecialForm();
+        render();
+      });
+    });
 
     screenElement.querySelectorAll('[data-new-special-field]').forEach((input) => {
       input.addEventListener('change', (event) => {
@@ -1530,10 +1600,6 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       .map((row) => String(row.neighborhood || '').trim())
       .filter(Boolean))]
       .sort((a, b) => a.localeCompare(b));
-    const newSpecialNeighborhood = String(state.newSpecialForm.neighborhood || '');
-    const availableBars = state.allBars
-      .filter((bar) => !newSpecialNeighborhood || String(bar.neighborhood || '') === newSpecialNeighborhood)
-      .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
     const typeOptions = [...new Set(state.groupedSpecials
       .map((row) => String(row.type || '').trim().toLowerCase())
       .filter(Boolean))]
@@ -1570,58 +1636,10 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             <option value="N" ${state.specialFilterAllDay === 'N' ? 'selected' : ''}>All Day: No</option>
           </select>
         </div>
-        <button type="button" class="admin-tool-button" data-special-create-toggle>
-          ${state.creatingSpecial ? 'Cancel New Special' : 'Add New Special'}
-        </button>
-        ${state.creatingSpecial ? `
-          <section class="admin-special-detail-card" aria-label="Create special">
-            <p><strong>Create new special</strong></p>
-            <label>Neighborhood
-              <select class="admin-input" data-new-special-field="neighborhood">
-                <option value="">Select neighborhood</option>
-                ${neighborhoodOptions.map((name) => `<option value="${escapeAttribute(name)}" ${newSpecialNeighborhood === name ? 'selected' : ''}>${name}</option>`).join('')}
-              </select>
-            </label>
-            <label>Bar
-              <select class="admin-input" data-new-special-field="bar_id" ${newSpecialNeighborhood ? '' : 'disabled'}>
-                <option value="">Select bar</option>
-                ${availableBars.map((bar) => `<option value="${bar.bar_id}" ${String(state.newSpecialForm.bar_id) === String(bar.bar_id) ? 'selected' : ''}>${bar.name}</option>`).join('')}
-              </select>
-            </label>
-            <label>Description
-              <input class="admin-input" data-new-special-field="description" value="${escapeAttribute(state.newSpecialForm.description)}" />
-            </label>
-            <label>Type
-              <select class="admin-input" data-new-special-field="type">
-                <option value="food" ${state.newSpecialForm.type === 'food' ? 'selected' : ''}>food</option>
-                <option value="drink" ${state.newSpecialForm.type === 'drink' ? 'selected' : ''}>drink</option>
-                <option value="combo" ${state.newSpecialForm.type === 'combo' ? 'selected' : ''}>combo</option>
-              </select>
-            </label>
-            <div class="admin-day-checkboxes">
-              ${CANDIDATE_DAY_KEYS.map((day) => `
-                <label><input type="checkbox" data-new-special-day="${day}" ${state.newSpecialForm.days_of_week.includes(day) ? 'checked' : ''}/> ${day}</label>
-              `).join('')}
-            </div>
-            <label>All Day
-              <select class="admin-input" data-new-special-field="all_day">
-                <option value="Y" ${state.newSpecialForm.all_day === 'Y' ? 'selected' : ''}>Y</option>
-                <option value="N" ${state.newSpecialForm.all_day === 'N' ? 'selected' : ''}>N</option>
-              </select>
-            </label>
-            <label>Start Time
-              <input class="admin-input" placeholder="HH:MM" data-new-special-field="start_time" value="${escapeAttribute(state.newSpecialForm.start_time)}"/>
-            </label>
-            <label>End Time
-              <input class="admin-input" placeholder="HH:MM" data-new-special-field="end_time" value="${escapeAttribute(state.newSpecialForm.end_time)}"/>
-            </label>
-            <div class="admin-actions-row">
-              <button type="button" class="admin-action-btn approve" data-new-special-save ${state.savingNewSpecial ? 'disabled' : ''}>Save New Special</button>
-            </div>
-          </section>
-        ` : ''}
+        <button type="button" class="admin-tool-button" data-special-create-toggle>Add New Special</button>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildSpecialManagementTable()}
+        ${getCreateSpecialModalMarkup()}
       </section>
     `;
 

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -586,6 +586,7 @@ def get_all_specials(cursor):
         """
         SELECT
             s.special_id,
+            s.bar_id,
             b.name AS bar_name,
             b.neighborhood,
             s.day_of_week,
@@ -662,6 +663,7 @@ def get_all_specials(cursor):
         specials.append(
             {
                 'special_id': special_id,
+                'bar_id': row.get('bar_id'),
                 'bar_name': row.get('bar_name'),
                 'neighborhood': row.get('neighborhood'),
                 'day_of_week': row.get('day_of_week'),
@@ -944,6 +946,49 @@ def update_special(cursor, event):
     }
 
 
+def insert_special(cursor, event):
+    bar_id = event.get('bar_id')
+    if not bar_id:
+        raise ValueError('bar_id is required for insert_special')
+
+    description = str(event.get('description') or '').strip()
+    if not description:
+        raise ValueError('description is required for insert_special')
+
+    special_type = str(event.get('type') or '').strip().lower()
+    if special_type not in {'food', 'drink', 'combo'}:
+        raise ValueError('type must be one of: food, drink, combo')
+
+    days_of_week = _normalize_days_input(event.get('days_of_week'))
+    if not days_of_week:
+        raise ValueError('days_of_week is required for insert_special')
+
+    all_day = _normalize_yn_flag(event.get('all_day') or 'Y')
+    if all_day not in {'Y', 'N'}:
+        raise ValueError('all_day must be Y or N')
+
+    start_time = _normalize_time_value(event.get('start_time')) or None
+    end_time = _normalize_time_value(event.get('end_time')) or None
+
+    inserted_special_ids = []
+    for day_of_week in days_of_week:
+        cursor.execute(
+            """
+            INSERT INTO special
+            (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method, is_active)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, 'MANUAL', 'Y')
+            """,
+            (bar_id, day_of_week, all_day, start_time, end_time, description, special_type),
+        )
+        inserted_special_ids.append(cursor.lastrowid)
+
+    return {
+        'special_ids': inserted_special_ids,
+        'inserted_count': len(inserted_special_ids),
+        'insert_method': 'MANUAL',
+    }
+
+
 def update_special_candidate(cursor, event):
     special_candidate_id = event.get('special_candidate_id')
     if not special_candidate_id:
@@ -1039,6 +1084,7 @@ def lambda_handler(event, context):
         'update_special_candidate_approval',
         'get_all_specials',
         'update_special',
+        'insert_special',
         'update_special_candidate',
         'get_all_bars',
         'get_bar_details',
@@ -1053,7 +1099,7 @@ def lambda_handler(event, context):
                         'mode must be one of get_unapproved_special_candidates, '
                         'get_rejected_special_candidates, '
                         'remove_rejected_special_candidate, '
-                        'update_special_candidate_approval, get_all_specials, update_special, '
+                        'update_special_candidate_approval, get_all_specials, update_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1093,6 +1139,8 @@ def lambda_handler(event, context):
                 result = update_open_hours(cursor, event)
             elif mode == 'update_special_candidate':
                 result = update_special_candidate(cursor, event)
+            elif mode == 'insert_special':
+                result = insert_special(cursor, event)
             else:
                 result = update_special(cursor, event)
             conn.commit()


### PR DESCRIPTION
### Motivation
- Provide admins a way to create specials manually from the Special Management screen with the same fields used elsewhere and ensure those manual inserts are tracked as `MANUAL`.
- Make editing existing specials easier by letting admins toggle days-of-week via checkboxes (matching Pending Approval UI) and support adding/removing day rows consistently.

### Description
- Frontend: Added a new create flow in `admin/admin.js` with a toggleable "Add New Special" form containing a neighborhood dropdown, a bar dropdown filtered by the selected neighborhood, `description` input, `type` select (`food`/`drink`/`combo`), day-of-week checkboxes, `all_day` select (default `Y`), and `start_time`/`end_time` inputs, plus a save handler that calls `mode: 'insert_special'`.
- Frontend: Added create form state (`newSpecialForm`), handlers, and rendering, and updated the special detail edit modal to render day-of-week as checkbox controls and to deactivate unselected existing day rows and insert newly-selected missing days.
- Backend: Implemented `insert_special(cursor, event)` in `functions/dbAdminSync/db_admin_sync.py` which validates inputs, normalizes times/days, and inserts one `special` row per selected day with `insert_method = 'MANUAL'` and `is_active = 'Y'`.
- Backend: Exposed `bar_id` in `get_all_specials` results and added `insert_special` to the allowed `mode` list and routing so the frontend can call it.
- Styling: Added `.admin-day-checkboxes` styles in `admin/admin.css` for consistent checkbox layout.

### Testing
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` to validate the backend Python file and it succeeded.
- Ran `node --check admin/admin.js` to validate the modified admin JavaScript and it succeeded.
- Attempted `node --check admin/admin.css` which failed because `node --check` is not appropriate for CSS (invalid file extension), but the CSS change is a minimal layout addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e539419afc83309bbea7c04c06318a)