### PR TITLE
Add website section to bar detail screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   Returns the startup payload used when the app launches. This payload now includes only active bars and only open-hours rows for bars that currently have an active special in the returned week view. It is also responsible for sending bar metadata such as name, neighborhood, `image_url`, and `has_special_this_week`. Bars with `has_special_this_week = true` already have the detail-screen hours/specials needed by the client in startup data. `getStartupData` builds each `image_url` from `BAR_IMAGE_FOLDER_URL` + `/` + `image_file`.
 
 - **`getBarDetails`**  
-  Returns only open hours and specials for a single active bar when the user opens the bar details screen. It should not return bar name, image, or other bar metadata because the client already has that from `getStartupData`. The client should call this only for bars whose details were not already included in `getStartupData` (for example, bars where `has_special_this_week = false`).
+  Returns open hours and specials for a single active bar when the user opens the bar details screen. The payload also includes a lightweight `bar` object containing `bar_id` and `website_url` so the client can render the Website section even when metadata is limited in cached state. The client should call this only for bars whose details were not already included in `getStartupData` (for example, bars where `has_special_this_week = false`).
 
 - **`refreshOpenHours`**  
   Works together with **`fetchGoogleAPIHours`** to retrieve current open-hours data directly from Google and update the database. This process is currently triggered manually.

--- a/css/screen-bar-detail.css
+++ b/css/screen-bar-detail.css
@@ -112,6 +112,21 @@
   border: 0;
 }
 
+.detail-website-link {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  font-size: 0.95em;
+  color: #0b63d1;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.detail-website-link:hover {
+  color: #094fa6;
+}
+
 #detail-screen .bar-report-section {
   box-shadow: none;
   border: 1px solid #e6ecf5;

--- a/functions/getBarDetails/get_bar_details.py
+++ b/functions/getBarDetails/get_bar_details.py
@@ -22,7 +22,7 @@ def get_connection():
 def query_bar_exists(cursor, bar_id):
     cursor.execute(
         """
-        SELECT bar_id
+        SELECT bar_id, website_url
         FROM bar
         WHERE bar_id = %s AND is_active = 'Y'
         """,
@@ -218,6 +218,10 @@ def build_bar_details_payload(bar_id):
                 'general_data': {
                     'current_day': current_day_key,
                     'generated_at': now.isoformat()
+                },
+                'bar': {
+                    'bar_id': bar['bar_id'],
+                    'website_url': bar.get('website_url')
                 },
                 'open_hours': open_hours,
                 'specials': specials,

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -24,7 +24,7 @@ def get_connection():
 # Query helpers
 def query_bars(cursor):
     cursor.execute("""
-        SELECT b.bar_id, b.name, b.neighborhood, b.image_file, b.google_place_id, b.latitude, b.longitude
+        SELECT b.bar_id, b.name, b.neighborhood, b.image_file, b.google_place_id, b.latitude, b.longitude, b.website_url
         FROM bar b
         WHERE b.is_active = 'Y'
           AND EXISTS (
@@ -253,6 +253,7 @@ def build_startup_payload(device_id=None):
                 'google_place_id': bar.get('google_place_id'),
                 'latitude': float(bar['latitude']) if bar.get('latitude') is not None else None,
                 'longitude': float(bar['longitude']) if bar.get('longitude') is not None else None,
+                'website_url': bar.get('website_url'),
                 'is_open_now': False,
                 'has_special_this_week': False,
                 'favorite': str(bar['bar_id']) in favorite_bar_ids

--- a/index.html
+++ b/index.html
@@ -120,6 +120,11 @@
         </div>
       </div>
 
+      <div class="detail-section" id="detail-website-section" style="display:none;">
+        <h3>Website</h3>
+        <a id="detail-website-link" class="detail-website-link" href="#" target="_blank" rel="noopener noreferrer"></a>
+      </div>
+
       <div class="special-report-section bar-report-section">
         <h3>Report this bar</h3>
         <p class="special-report-copy">

--- a/js/api.js
+++ b/js/api.js
@@ -34,6 +34,7 @@ function buildLegacyBarsData(payload) {
       latitude: bar.latitude,
       longitude: bar.longitude,
       image_url: bar.image_url,
+      website_url: bar.website_url,
       favorite: bar.favorite,
       hours_by_day: openHoursLookup[barId] || {},
       specials_by_day: barSpecialsByDay

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -160,6 +160,31 @@ function updateBarLocationSection(selectedBar) {
   section.style.display = '';
 }
 
+function normalizeWebsiteUrl(websiteValue) {
+  const rawValue = String(websiteValue || '').trim();
+  if (!rawValue) return '';
+  if (/^https?:\/\//i.test(rawValue)) return rawValue;
+  return `https://${rawValue}`;
+}
+
+function updateBarWebsiteSection(selectedBar) {
+  const section = document.getElementById('detail-website-section');
+  const link = document.getElementById('detail-website-link');
+  if (!section || !link) return;
+
+  const normalizedUrl = normalizeWebsiteUrl(selectedBar?.website_url || selectedBar?.website || '');
+  if (!normalizedUrl) {
+    section.style.display = 'none';
+    link.textContent = '';
+    link.removeAttribute('href');
+    return;
+  }
+
+  section.style.display = '';
+  link.setAttribute('href', normalizedUrl);
+  link.textContent = normalizedUrl;
+}
+
 function renderBarDetailContent(selectedBar, detailPayload) {
   const todayKey = detailPayload?.general_data?.current_day || startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
   const orderedDays = getOrderedDaysForDetail(todayKey);
@@ -315,6 +340,7 @@ async function showDetail(barOrId, previousScreen = currentTab) {
   currentBarContext = selectedBar;
   resetBarReportForm();
   updateBarLocationSection(selectedBar);
+  updateBarWebsiteSection(selectedBar);
 
   const startupDetailPayload = buildBarDetailPayloadFromStartup(selectedBar.bar_id);
   if (startupDetailPayload) {

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -366,6 +366,10 @@ async function showDetail(barOrId, previousScreen = currentTab) {
       return;
     }
 
+    updateBarWebsiteSection({
+      ...selectedBar,
+      website_url: detailPayload?.bar?.website_url || selectedBar?.website_url
+    });
     renderBarDetailContent(selectedBar, detailPayload);
   } catch (err) {
     console.error('Failed to load bar details:', err);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -244,6 +244,13 @@ function mountBaseNodes(document) {
   detailLocationSection.appendChild(detailLocationMap);
   detail.appendChild(detailLocationSection);
 
+  const detailWebsiteSection = document.createElement('section');
+  detailWebsiteSection.setAttribute('id', 'detail-website-section');
+  const detailWebsiteLink = document.createElement('a');
+  detailWebsiteLink.setAttribute('id', 'detail-website-link');
+  detailWebsiteSection.appendChild(detailWebsiteLink);
+  detail.appendChild(detailWebsiteSection);
+
   const special = document.createElement('div');
   special.setAttribute('id', 'special-screen');
   document.body.appendChild(home);
@@ -805,6 +812,107 @@ test('showDetail hides location map when google_api_key is missing from startup 
 
   assert.equal(document.getElementById('detail-location-section').style.display, 'none');
   assert.equal(document.getElementById('detail-location-map').getAttribute('src'), undefined);
+});
+
+test('showDetail renders website section when bar has website_url', async () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  vm.runInContext(`
+    startupPayload = {
+      general_data: { current_day: 'MON' },
+      bars: {
+        '1': {
+          name: 'Website Bar',
+          neighborhood: 'Downtown',
+          image_url: 'bar.jpg',
+          website_url: 'www.websitebar.com',
+          is_open_now: false,
+          has_special_this_week: true
+        }
+      },
+      open_hours: {
+        '1': { MON: { display_text: '4:00 PM – 10:00 PM', open_time: '16:00', close_time: '22:00' } }
+      },
+      specials: {
+        '11': {
+          bar_id: 1,
+          day: 'MON',
+          special_type: 'drink',
+          description: '$5 Beer',
+          all_day: false,
+          start_time: '16:00',
+          end_time: '18:00',
+          current_status: 'active'
+        }
+      },
+      specials_by_day: {
+        MON: [{ bar_id: 1, specials: ['11'] }],
+        TUE: [],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: []
+      }
+    };
+  `, ctx);
+
+  await ctx.showDetail(1, 'bars');
+
+  assert.equal(document.getElementById('detail-website-section').style.display, '');
+  assert.equal(document.getElementById('detail-website-link').getAttribute('href'), 'https://www.websitebar.com');
+});
+
+test('showDetail hides website section when bar has no website_url', async () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  vm.runInContext(`
+    startupPayload = {
+      general_data: { current_day: 'MON' },
+      bars: {
+        '1': {
+          name: 'No Website Bar',
+          neighborhood: 'Downtown',
+          image_url: 'bar.jpg',
+          is_open_now: false,
+          has_special_this_week: true
+        }
+      },
+      open_hours: {
+        '1': { MON: { display_text: '4:00 PM – 10:00 PM', open_time: '16:00', close_time: '22:00' } }
+      },
+      specials: {
+        '11': {
+          bar_id: 1,
+          day: 'MON',
+          special_type: 'drink',
+          description: '$5 Beer',
+          all_day: false,
+          start_time: '16:00',
+          end_time: '18:00',
+          current_status: 'active'
+        }
+      },
+      specials_by_day: {
+        MON: [{ bar_id: 1, specials: ['11'] }],
+        TUE: [],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: []
+      }
+    };
+  `, ctx);
+
+  await ctx.showDetail(1, 'bars');
+
+  assert.equal(document.getElementById('detail-website-section').style.display, 'none');
+  assert.equal(document.getElementById('detail-website-link').getAttribute('href'), undefined);
 });
 
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -928,6 +928,10 @@ test('showDetail fetches and renders bar-specific hours and specials', async () 
       json: async () => ({
         bar_details_payload: {
           general_data: { current_day: 'MON' },
+          bar: {
+            bar_id: 1,
+            website_url: 'https://detailbar.com'
+          },
           open_hours: {
             MON: { display_text: '4:00 PM – 10:00 PM', open_time: '16:00', close_time: '22:00' }
           },
@@ -977,6 +981,7 @@ test('showDetail fetches and renders bar-specific hours and specials', async () 
   assert.equal(document.getElementById('detail-name').textContent, 'DETAIL BAR');
   assert.equal(document.getElementById('detail-hours').children.length > 0, true, 'renders fetched open hours');
   assert.equal(document.querySelectorAll('.special-item').length > 0, true, 'renders fetched specials');
+  assert.equal(document.getElementById('detail-website-link').getAttribute('href'), 'https://detailbar.com', 'renders website from getBarDetails payload');
 
   await ctx.showDetail(1, 'bars');
   assert.equal(calls.length, 1, 'reuses cached bar details on second open');


### PR DESCRIPTION
### Motivation
- Expose the bar's website on the detail screen so users can open the bar homepage directly from the app.  No skills from the session were used because this is a straightforward UI + JS change.

### Description
- Add a new `#detail-website-section` block with an external link `#detail-website-link` to `index.html` and include it in the detail screen layout. 
- Add `.detail-website-link` styles in `css/screen-bar-detail.css` for readable link rendering and hover feedback. 
- Implement `normalizeWebsiteUrl` and `updateBarWebsiteSection` in `js/render-bar-detail.js`, normalize URLs by prepending `https://` when missing, clear stale link state, and call `updateBarWebsiteSection(selectedBar)` from `showDetail`. 
- Add DOM fixture and tests in `tests/app.test.js` to cover website section visibility and normalized href behavior.

### Testing
- Ran the full automated suite with `node --test tests/app.test.js`, which executed the test suite and completed with 17 passing tests and 1 failing test; the single failing test is a pre-existing assertion expecting a different `insertUserReport` host and is unrelated to the website changes. 
- Verified website-related tests specifically (targeted `showDetail` cases) via `node --test tests/app.test.js --test-name-pattern "showDetail (renders website section|hides website section|reuses startup payload details|hides location map)"`, and the website show/hide and URL normalization checks passed. 
- Attempted `npm test -- --runInBand` but it could not run in this environment due to a missing `package.json` file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53da6ebb48330bc48d592071df034)