### PR TITLE
Fix admin timestamp parsing so DB datetimes are treated as UTC before display

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -158,12 +158,43 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     if (value instanceof Date) {
       return Number.isNaN(value.getTime()) ? null : value;
     }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      const epochMs = value < 1e12 ? value * 1000 : value;
+      const epochDate = new Date(epochMs);
+      return Number.isNaN(epochDate.getTime()) ? null : epochDate;
+    }
 
     const raw = String(value).trim();
     if (!raw) return null;
 
+    const utcWithoutTimezoneMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2}))?(?:\.(\d{1,6}))?)?$/);
+    if (utcWithoutTimezoneMatch) {
+      const [
+        ,
+        year,
+        month,
+        day,
+        hour = '00',
+        minute = '00',
+        second = '00',
+        fractional = '0'
+      ] = utcWithoutTimezoneMatch;
+      const milliseconds = Number(fractional.padEnd(3, '0').slice(0, 3));
+      const utcMs = Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+        milliseconds
+      );
+      const utcDate = new Date(utcMs);
+      return Number.isNaN(utcDate.getTime()) ? null : utcDate;
+    }
+
     const hasExplicitTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw);
-    const normalized = hasExplicitTimezone ? raw : raw.replace(' ', 'T');
+    const normalized = raw.replace(' ', 'T');
     const isoValue = hasExplicitTimezone ? normalized : `${normalized}Z`;
     const date = new Date(isoValue);
     if (Number.isNaN(date.getTime())) return null;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -148,9 +148,26 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
 
   function formatDateTime(value) {
     if (!value) return '—';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return String(value);
+    const date = parseDateValue(value);
+    if (!date) return String(value);
     return ADMIN_DATETIME_FORMATTER.format(date);
+  }
+
+  function parseDateValue(value) {
+    if (!value) return null;
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    const raw = String(value).trim();
+    if (!raw) return null;
+
+    const hasExplicitTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw);
+    const normalized = hasExplicitTimezone ? raw : raw.replace(' ', 'T');
+    const isoValue = hasExplicitTimezone ? normalized : `${normalized}Z`;
+    const date = new Date(isoValue);
+    if (Number.isNaN(date.getTime())) return null;
+    return date;
   }
 
   function formatTime(value) {
@@ -232,8 +249,9 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
   }
 
   function toTimestamp(value) {
-    if (!value) return 0;
-    const parsed = new Date(value).getTime();
+    const parsedDate = parseDateValue(value);
+    if (!parsedDate) return 0;
+    const parsed = parsedDate.getTime();
     return Number.isNaN(parsed) ? 0 : parsed;
   }
 
@@ -316,14 +334,14 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
       row.specials.push(special);
       row.daySet.add(normalizeDay(special.day_of_week));
 
-      const rowInsert = new Date(row.insert_date || 0).getTime();
-      const specialInsert = new Date(special.insert_date || 0).getTime();
+      const rowInsert = toTimestamp(row.insert_date);
+      const specialInsert = toTimestamp(special.insert_date);
       if (!row.insert_date || specialInsert < rowInsert) {
         row.insert_date = special.insert_date;
       }
 
-      const rowUpdate = new Date(row.update_date || 0).getTime();
-      const specialUpdate = new Date(special.update_date || 0).getTime();
+      const rowUpdate = toTimestamp(row.update_date);
+      const specialUpdate = toTimestamp(special.update_date);
       if (!row.update_date || specialUpdate > rowUpdate) {
         row.update_date = special.update_date;
       }
@@ -342,8 +360,8 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
         if (barCompare !== 0) return barCompare;
         const descriptionCompare = String(a.description || '').localeCompare(String(b.description || ''));
         if (descriptionCompare !== 0) return descriptionCompare;
-        const dateA = new Date(a.insert_date || 0).getTime();
-        const dateB = new Date(b.insert_date || 0).getTime();
+        const dateA = toTimestamp(a.insert_date);
+        const dateB = toTimestamp(b.insert_date);
         return dateA - dateB;
       });
   }


### PR DESCRIPTION
### Motivation

- Admin UI displayed EDT/EST labels without actually converting hours because timestamp strings from the DB like `YYYY-MM-DD HH:mm:ss` were being parsed as local time. 
- The goal is to ensure timestamps without explicit timezone are interpreted as UTC so formatting into `America/New_York` yields the correct local hour.

### Description

- Added a shared `parseDateValue` helper in `admin/admin.js` that normalizes input, treats timezone-less strings as UTC, and returns a `Date` or `null`.
- Updated `formatDateTime` to use `parseDateValue` and to safely fall back for invalid values.
- Replaced direct `new Date(...)` usages in timestamp comparisons with `toTimestamp` which now delegates to `parseDateValue` for consistent parsing.
- Updated grouping/sorting logic for specials to use `toTimestamp(...)` so insert/update rollups and ordering use the corrected timezone-aware parsing.

### Testing

- Ran `node --check admin/admin.js` which succeeded without errors. 
- Ran `node --test tests/app.test.js`, which produced 17 passing tests and 1 failing test; the single failure is an existing assertion expecting a different API URL in `submitSpecialReport` and is unrelated to the timezone parsing changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56ba7555883308757eaa7ce5c74c8)