### PR TITLE
Add Delete Special action to admin UI and backend delete_special mode

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -610,6 +610,31 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     }
   }
 
+  async function deleteSpecials(specialIds) {
+    const ids = Array.isArray(specialIds) ? specialIds : [specialIds];
+    const validIds = [...new Set(ids.map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0))];
+    if (!validIds.length) return;
+
+    state.savingSpecial = true;
+    state.errorMessage = '';
+    render();
+
+    try {
+      for (const specialId of validIds) {
+        await callAdminSync({ mode: 'delete_special', special_id: specialId });
+      }
+      await loadAllSpecials();
+      state.detailSpecials = [];
+      state.detailEditing = false;
+    } catch (err) {
+      console.error('Failed to delete special:', err);
+      state.errorMessage = err?.message || 'Failed to delete special.';
+    } finally {
+      state.savingSpecial = false;
+      render();
+    }
+  }
+
   async function saveBarUpdates(barPayload, openHoursRows) {
     state.savingBar = true;
     state.errorMessage = '';
@@ -655,6 +680,7 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
           <button type="button" class="admin-tool-button" data-special-action="view-details" data-special-id="${state.actionSpecialId}">View Details</button>
           <button type="button" class="admin-tool-button" data-special-action="activate" data-special-id="${state.actionSpecialId}">Activate Special</button>
           <button type="button" class="admin-tool-button" data-special-action="deactivate" data-special-id="${state.actionSpecialId}">Deactivate Special</button>
+          <button type="button" class="admin-tool-button danger" data-special-action="delete" data-special-id="${state.actionSpecialId}">Delete Special</button>
           <button type="button" class="admin-secondary-btn" data-close-action-menu="true">Close</button>
         </div>
       </div>
@@ -1391,6 +1417,21 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
             is_active: action === 'activate' ? 'Y' : 'N'
           }));
           await saveSpecialUpdates(updates.length ? updates : [{ special_id: specialId, is_active: action === 'activate' ? 'Y' : 'N' }]);
+          return;
+        }
+
+        if (action === 'delete') {
+          const groupedRow = getGroupedRowByRepresentativeId(specialId);
+          const specialIdsToDelete = (groupedRow?.specials || []).map((special) => Number(special.special_id)).filter(Boolean);
+          const ids = specialIdsToDelete.length ? specialIdsToDelete : [specialId];
+          const deleteCount = ids.length;
+          const confirmed = window.confirm(
+            deleteCount > 1
+              ? `Delete ${deleteCount} specials from the database? This cannot be undone.`
+              : 'Delete this special from the database? This cannot be undone.'
+          );
+          if (!confirmed) return;
+          await deleteSpecials(ids);
         }
       });
     });

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1306,8 +1306,20 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     const searchInput = screenElement.querySelector('[data-special-search-input]');
     if (searchInput) {
       searchInput.addEventListener('input', (event) => {
+        const { selectionStart, selectionEnd } = event.target;
         state.specialSearchTerm = event.target.value;
         render();
+        const nextInput = screenElement.querySelector('[data-special-search-input]');
+        if (nextInput) {
+          nextInput.focus();
+          if (
+            typeof selectionStart === 'number'
+            && typeof selectionEnd === 'number'
+            && typeof nextInput.setSelectionRange === 'function'
+          ) {
+            nextInput.setSelectionRange(selectionStart, selectionEnd);
+          }
+        }
       });
     }
 
@@ -1869,8 +1881,20 @@ const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaw
     const searchInput = screenElement.querySelector('[data-rejected-special-search-input]');
     if (searchInput) {
       searchInput.addEventListener('input', (event) => {
+        const { selectionStart, selectionEnd } = event.target;
         state.specialSearchTerm = event.target.value;
         render();
+        const nextInput = screenElement.querySelector('[data-rejected-special-search-input]');
+        if (nextInput) {
+          nextInput.focus();
+          if (
+            typeof selectionStart === 'number'
+            && typeof selectionEnd === 'number'
+            && typeof nextInput.setSelectionRange === 'function'
+          ) {
+            nextInput.setSelectionRange(selectionStart, selectionEnd);
+          }
+        }
       });
     }
 

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -989,6 +989,41 @@ def insert_special(cursor, event):
     }
 
 
+def delete_special(cursor, event):
+    special_id = event.get('special_id')
+    if not special_id:
+        raise ValueError('special_id is required for delete_special')
+
+    cursor.execute(
+        """
+        UPDATE special_candidate
+        SET approved_special_id = NULL
+        WHERE approved_special_id = %s
+        """,
+        (special_id,),
+    )
+
+    cursor.execute(
+        """
+        DELETE FROM device_special_favorite
+        WHERE special_id = %s
+        """,
+        (special_id,),
+    )
+
+    cursor.execute(
+        """
+        DELETE FROM special
+        WHERE special_id = %s
+        """,
+        (special_id,),
+    )
+    if cursor.rowcount == 0:
+        raise ValueError('special_id was not found')
+
+    return {'special_id': special_id, 'deleted': True}
+
+
 def update_special_candidate(cursor, event):
     special_candidate_id = event.get('special_candidate_id')
     if not special_candidate_id:
@@ -1084,6 +1119,7 @@ def lambda_handler(event, context):
         'update_special_candidate_approval',
         'get_all_specials',
         'update_special',
+        'delete_special',
         'insert_special',
         'update_special_candidate',
         'get_all_bars',
@@ -1099,7 +1135,7 @@ def lambda_handler(event, context):
                         'mode must be one of get_unapproved_special_candidates, '
                         'get_rejected_special_candidates, '
                         'remove_rejected_special_candidate, '
-                        'update_special_candidate_approval, get_all_specials, update_special, insert_special, '
+                        'update_special_candidate_approval, get_all_specials, update_special, delete_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1139,6 +1175,8 @@ def lambda_handler(event, context):
                 result = update_open_hours(cursor, event)
             elif mode == 'update_special_candidate':
                 result = update_special_candidate(cursor, event)
+            elif mode == 'delete_special':
+                result = delete_special(cursor, event)
             elif mode == 'insert_special':
                 result = insert_special(cursor, event)
             else:


### PR DESCRIPTION
### Motivation
- Provide an admin UI action to permanently remove a special from the database when managing specials. 
- Ensure deletion cleans up related references so removing a special does not leave dangling DB state.

### Description
- Added a `Delete Special` button to the Special Actions modal in `admin/admin.js` which prompts for confirmation and supports deleting all grouped specials for a representative row. 
- Implemented a client helper `deleteSpecials(...)` in `admin/admin.js` that calls the admin API with `mode: 'delete_special'`, refreshes the specials list, and updates UI state. 
- Added `delete_special` handler to `functions/dbAdminSync/db_admin_sync.py` which validates `special_id`, clears `special_candidate.approved_special_id` references, deletes any `device_special_favorite` rows referencing the special, deletes the `special` row, and wired the new mode into the Lambda dispatcher and allowed modes list. 

### Testing
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` to validate Python syntax and it succeeded. 
- Ran `node --check admin/admin.js` to validate the modified frontend file and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91c917ab083309ad6e094ed771f96)