### PR TITLE
Add divider and auto-scroll to Specials tab for active/upcoming specials

### DIFF
--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -210,13 +210,8 @@
 }
 
 .active-upcoming-divider {
-  text-align: center;
-  font-size: 0.8em;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #6b7280;
-  margin: -8px 0 4px;
-  padding: 8px 0;
+  margin: -6px 0 6px;
+  height: 0;
   border-top: 1px solid #d1d5db;
 }
 

--- a/css/tab-special.css
+++ b/css/tab-special.css
@@ -209,6 +209,17 @@
   color: #636366;
 }
 
+.active-upcoming-divider {
+  text-align: center;
+  font-size: 0.8em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin: -8px 0 4px;
+  padding: 8px 0;
+  border-top: 1px solid #d1d5db;
+}
+
 .clickable-special {
   cursor: pointer;
 }

--- a/js/render-home.js
+++ b/js/render-home.js
@@ -22,6 +22,7 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
   specialsList.className = 'specials-list';
 
   let renderedSpecials = 0;
+  let hasActiveOrUpcoming = false;
 
   const isToday = dayKey === startupPayload?.general_data?.current_day;
 
@@ -51,6 +52,11 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
     });
     specialsList.appendChild(li);
     renderedSpecials += 1;
+
+    const status = String(special.current_status || '').toLowerCase();
+    if (status === 'active' || status === 'live' || status === 'upcoming') {
+      hasActiveOrUpcoming = true;
+    }
   });
 
   if (renderedSpecials === 0) return null;
@@ -95,7 +101,7 @@ function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
   }
 
   content.appendChild(hoursDiv);
-  return content;
+  return { content, hasActiveOrUpcoming };
 }
 
 function renderBarsWeek() {
@@ -117,7 +123,9 @@ function renderBarsWeek() {
   });
 
 
-  orderedDays.forEach(({ dayKey, dayLabel }) => {
+  let scrollTargetCard = null;
+
+  orderedDays.forEach(({ dayKey, dayLabel }, dayIndex) => {
     const barsForDay = startupPayload?.specials_by_day?.[dayKey] || [];
 
     const dayHeader = document.createElement('div');
@@ -126,6 +134,7 @@ function renderBarsWeek() {
     container.appendChild(dayHeader);
 
     let renderedCardCountForDay = 0;
+    const renderedCardsForDay = [];
 
     barsForDay.forEach((entry) => {
       const barId = String(entry.bar_id);
@@ -160,13 +169,37 @@ function renderBarsWeek() {
         card.appendChild(img);
       }
 
-      const homeContent = buildHomeBarSpecials(bar, entry.specials || [], dayKey, dayLabel);
-      if (!homeContent) return;
+      const homeSpecials = buildHomeBarSpecials(bar, entry.specials || [], dayKey, dayLabel);
+      if (!homeSpecials) return;
 
-      card.appendChild(homeContent);
-      container.appendChild(card);
+      card.appendChild(homeSpecials.content);
+      renderedCardsForDay.push({
+        card,
+        hasActiveOrUpcoming: homeSpecials.hasActiveOrUpcoming
+      });
       renderedCardCountForDay += 1;
     });
+
+    if (renderedCardsForDay.length > 0) {
+      if (dayIndex === 0) {
+        const withoutActiveOrUpcoming = renderedCardsForDay.filter((entry) => !entry.hasActiveOrUpcoming);
+        const withActiveOrUpcoming = renderedCardsForDay.filter((entry) => entry.hasActiveOrUpcoming);
+
+        withoutActiveOrUpcoming.forEach((entry) => container.appendChild(entry.card));
+
+        if (withoutActiveOrUpcoming.length > 0 && withActiveOrUpcoming.length > 0) {
+          const divider = document.createElement('div');
+          divider.className = 'active-upcoming-divider';
+          divider.textContent = 'Active or upcoming specials below';
+          container.appendChild(divider);
+          scrollTargetCard = withActiveOrUpcoming[0].card;
+        }
+
+        withActiveOrUpcoming.forEach((entry) => container.appendChild(entry.card));
+      } else {
+        renderedCardsForDay.forEach((entry) => container.appendChild(entry.card));
+      }
+    }
 
     if (renderedCardCountForDay === 0) {
       const noSpecialsLine = document.createElement('div');
@@ -181,6 +214,26 @@ function renderBarsWeek() {
   });
 
   requestAnimationFrame(() => {
+    const homeScreen = document.getElementById('home-screen');
+    if (homeScreen) {
+      if (scrollTargetCard) {
+        const cardRect = typeof scrollTargetCard.getBoundingClientRect === 'function'
+          ? scrollTargetCard.getBoundingClientRect()
+          : null;
+        const homeRect = typeof homeScreen.getBoundingClientRect === 'function'
+          ? homeScreen.getBoundingClientRect()
+          : null;
+        const currentScrollTop = Number(homeScreen.scrollTop || 0);
+        const fallbackTop = Number(scrollTargetCard.offsetTop || 0);
+        const top = cardRect && homeRect
+          ? (cardRect.top - homeRect.top + currentScrollTop)
+          : fallbackTop;
+        homeScreen.scrollTop = Math.max(0, top);
+      } else {
+        homeScreen.scrollTop = 0;
+      }
+    }
+
     container.style.opacity = 1;
     lucide.createIcons();
   });

--- a/js/render-home.js
+++ b/js/render-home.js
@@ -1,3 +1,5 @@
+const SPECIALS_SCROLL_OFFSET_PX = 10;
+
 function buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel) {
   const specialsLookup = startupPayload?.specials || {};
   const content = document.createElement('div');
@@ -190,7 +192,6 @@ function renderBarsWeek() {
         if (withoutActiveOrUpcoming.length > 0 && withActiveOrUpcoming.length > 0) {
           const divider = document.createElement('div');
           divider.className = 'active-upcoming-divider';
-          divider.textContent = 'Active or upcoming specials below';
           container.appendChild(divider);
           scrollTargetCard = withActiveOrUpcoming[0].card;
         }
@@ -228,7 +229,7 @@ function renderBarsWeek() {
         const top = cardRect && homeRect
           ? (cardRect.top - homeRect.top + currentScrollTop)
           : fallbackTop;
-        homeScreen.scrollTop = Math.max(0, top);
+        homeScreen.scrollTop = Math.max(0, top - SPECIALS_SCROLL_OFFSET_PX);
       } else {
         homeScreen.scrollTop = 0;
       }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -722,10 +722,10 @@ test('renderBarsWeek inserts divider before first bar with active or upcoming sp
 
   const divider = document.querySelector('.active-upcoming-divider');
   assert.ok(divider, 'renders active/upcoming divider');
-  assert.equal(divider.textContent, 'Active or upcoming specials below');
+  assert.equal(divider.textContent, '');
   assert.equal(cards[0].querySelector('.bar-name').textContent, 'Past Specials Bar');
   assert.equal(cards[1].querySelector('.bar-name').textContent, 'Upcoming Specials Bar');
-  assert.equal(homeScreen.scrollTop, cards[1].offsetTop, 'scrolls to first bar after divider');
+  assert.equal(homeScreen.scrollTop, cards[1].offsetTop - 10, 'scrolls slightly above first bar after divider');
 });
 
 test('buildSpecialItem clickable rows stop parent click handling and navigate to special detail', async () => {

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -663,6 +663,71 @@ test('renderBarsWeek groups specials with matching day, time, and type into one 
   assert.equal(items[0].querySelector('.special-description').textContent, '$5 Lager • $6 IPA');
 });
 
+test('renderBarsWeek inserts divider before first bar with active or upcoming specials and scrolls to it', async () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  vm.runInContext(`
+    startupPayload = {
+      general_data: { current_day: 'MON' },
+      bars: {
+        '1': { name: 'Past Specials Bar', neighborhood: 'Downtown', image_url: null, currently_open: false },
+        '2': { name: 'Upcoming Specials Bar', neighborhood: 'Downtown', image_url: null, currently_open: true }
+      },
+      open_hours: {
+        '1': { MON: { display_text: '4:00 PM - 2:00 AM' } },
+        '2': { MON: { display_text: '4:00 PM - 2:00 AM' } }
+      },
+      specials: {
+        '11': { bar_id: 1, description: '$5 Beer', special_type: 'drink', all_day: false, start_time: '16:00', end_time: '18:00', current_status: 'past' },
+        '22': { bar_id: 2, description: '$6 IPA', special_type: 'drink', all_day: false, start_time: '19:00', end_time: '21:00', current_status: 'upcoming' }
+      },
+      specials_by_day: {
+        MON: [{ bar_id: 1, specials: ['11'] }, { bar_id: 2, specials: ['22'] }],
+        TUE: [],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: []
+      }
+    };
+    currentTab = 'specials';
+    activeFilters.types = [];
+    activeFilters.neighborhoods = [];
+    activeFilters.favoritesOnly = false;
+  `, ctx);
+
+  const homeScreen = document.getElementById('home-screen');
+  homeScreen.scrollTop = 0;
+
+  const cards = [];
+  let nextOffset = 0;
+  const originalAppendChild = homeScreen.appendChild.bind(homeScreen);
+  const homeBars = document.getElementById('home-bars');
+  const originalContainerAppend = homeBars.appendChild.bind(homeBars);
+  homeBars.appendChild = (child) => {
+    if (child.className && child.className.includes('bar-card')) {
+      child.offsetTop = nextOffset;
+      nextOffset += 120;
+      cards.push(child);
+    }
+    return originalContainerAppend(child);
+  };
+  homeScreen.appendChild = originalAppendChild;
+
+  ctx.renderBarsWeek();
+  await new Promise((resolve) => setTimeout(resolve, 1));
+
+  const divider = document.querySelector('.active-upcoming-divider');
+  assert.ok(divider, 'renders active/upcoming divider');
+  assert.equal(divider.textContent, 'Active or upcoming specials below');
+  assert.equal(cards[0].querySelector('.bar-name').textContent, 'Past Specials Bar');
+  assert.equal(cards[1].querySelector('.bar-name').textContent, 'Upcoming Specials Bar');
+  assert.equal(homeScreen.scrollTop, cards[1].offsetTop, 'scrolls to first bar after divider');
+});
+
 test('buildSpecialItem clickable rows stop parent click handling and navigate to special detail', async () => {
   const document = new DocumentMock();
   mountBaseNodes(document);


### PR DESCRIPTION
### Motivation
- Improve discoverability by visually separating bars without active/upcoming specials from those with active/upcoming specials and automatically bringing the first relevant card into view when opening the Specials tab.

### Description
- Track whether a built bar card contains any `active`/`live`/`upcoming` specials when building its content and return that metadata from `buildHomeBarSpecials` (`js/render-home.js`).
- For the current day section, render bars without active/upcoming specials first, then insert an `active-upcoming-divider` element, and then render bars that do have active/upcoming specials (`js/render-home.js`).
- Auto-scroll the Specials page so the first bar after the divider is positioned at the top of the viewport when the tab renders, with a fallback using `offsetTop` when `getBoundingClientRect` is unavailable (to support test/document environments) (`js/render-home.js`).
- Add styling for the divider (`.active-upcoming-divider`) in `css/tab-special.css`.
- Add a unit test that verifies divider insertion, ordering, and scroll behavior in `tests/app.test.js`.

### Testing
- Ran unit tests: `node --test tests/app.test.js`; new divider/scroll test passes and the suite reports 18 passing tests and 1 failing test. The single failing test is an existing endpoint assertion mismatch in `submitSpecialReport posts special report payload and resets form` and is unrelated to the changes in this PR. The added test for divider/auto-scroll succeeds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92099e6548330b523d2582730686f)