### PR TITLE
Store and surface Google bar descriptions in sync and detail view

### DIFF
--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -67,8 +67,8 @@ def insert_new_bars(cursor, new_bars: List[Dict]) -> Dict[str, int]:
     for bar in new_bars:
         cursor.execute(
             """
-            INSERT INTO bar (name, google_place_id, address, neighborhood, latitude, longitude, website_url, image_file, is_active)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO bar (name, google_place_id, address, neighborhood, latitude, longitude, website_url, description, image_file, is_active)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 bar['name'],
@@ -78,6 +78,7 @@ def insert_new_bars(cursor, new_bars: List[Dict]) -> Dict[str, int]:
                 bar.get('latitude'),
                 bar.get('longitude'),
                 bar.get('website_url'),
+                bar.get('description'),
                 bar.get('image_file'),
                 'Y' if is_bar_operational(bar) else 'N',
             ),
@@ -100,6 +101,7 @@ def upsert_open_hours(cursor, bars: List[Dict]) -> int:
             SET is_active = %s,
                 latitude = %s,
                 longitude = %s,
+                description = %s,
                 update_date = NOW()
             WHERE bar_id = %s
             """,
@@ -107,6 +109,7 @@ def upsert_open_hours(cursor, bars: List[Dict]) -> int:
                 'Y' if is_bar_operational(bar) else 'N',
                 bar.get('latitude'),
                 bar.get('longitude'),
+                bar.get('description'),
                 bar_id,
             ),
         )

--- a/functions/getBarDetails/get_bar_details.py
+++ b/functions/getBarDetails/get_bar_details.py
@@ -22,7 +22,7 @@ def get_connection():
 def query_bar_exists(cursor, bar_id):
     cursor.execute(
         """
-        SELECT bar_id, website_url
+        SELECT bar_id, website_url, description
         FROM bar
         WHERE bar_id = %s AND is_active = 'Y'
         """,
@@ -221,7 +221,8 @@ def build_bar_details_payload(bar_id):
                 },
                 'bar': {
                     'bar_id': bar['bar_id'],
-                    'website_url': bar.get('website_url')
+                    'website_url': bar.get('website_url'),
+                    'description': bar.get('description')
                 },
                 'open_hours': open_hours,
                 'specials': specials,

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -24,7 +24,7 @@ def get_connection():
 # Query helpers
 def query_bars(cursor):
     cursor.execute("""
-        SELECT b.bar_id, b.name, b.neighborhood, b.image_file, b.google_place_id, b.latitude, b.longitude, b.website_url
+        SELECT b.bar_id, b.name, b.neighborhood, b.image_file, b.google_place_id, b.latitude, b.longitude, b.website_url, b.description
         FROM bar b
         WHERE b.is_active = 'Y'
           AND EXISTS (
@@ -254,6 +254,7 @@ def build_startup_payload(device_id=None):
                 'latitude': float(bar['latitude']) if bar.get('latitude') is not None else None,
                 'longitude': float(bar['longitude']) if bar.get('longitude') is not None else None,
                 'website_url': bar.get('website_url'),
+                'description': bar.get('description'),
                 'is_open_now': False,
                 'has_special_this_week': False,
                 'favorite': str(bar['bar_id']) in favorite_bar_ids

--- a/functions/googleBarSync/google_bar_sync.py
+++ b/functions/googleBarSync/google_bar_sync.py
@@ -31,6 +31,7 @@ GOOGLE_FIELD_MASK = ','.join([
     'places.rating',
     'places.priceLevel',
     'places.websiteUri',
+    'places.editorialSummary',
     'places.photos',
     'nextPageToken'
 ])
@@ -236,6 +237,7 @@ def build_candidate_bar(place: Dict, neighborhood_name: str) -> Optional[Dict]:
         return None
 
     opening_hours = place.get('currentOpeningHours') or {}
+    editorial_summary = place.get('editorialSummary') or {}
     photos = place.get('photos') or []
     photo_name = (photos[0] or {}).get('name') if photos else None
 
@@ -246,6 +248,7 @@ def build_candidate_bar(place: Dict, neighborhood_name: str) -> Optional[Dict]:
         'latitude': lat,
         'longitude': lng,
         'website_url': place.get('websiteUri'),
+        'description': (editorial_summary.get('text') or '').strip() or None,
         'neighborhood': neighborhood_name,
         'business_status': place.get('businessStatus'),
         'hours': format_open_hours(opening_hours.get('periods', [])),

--- a/index.html
+++ b/index.html
@@ -100,6 +100,10 @@
       </button>
     </div>
     <div class="detail-content">
+      <div class="detail-section" id="detail-description-section" style="display:none;">
+        <h3>Description</h3>
+        <p id="detail-description"></p>
+      </div>
 
       <div class="detail-section">
         <h3>Open Hours</h3>

--- a/js/api.js
+++ b/js/api.js
@@ -35,6 +35,7 @@ function buildLegacyBarsData(payload) {
       longitude: bar.longitude,
       image_url: bar.image_url,
       website_url: bar.website_url,
+      description: bar.description,
       favorite: bar.favorite,
       hours_by_day: openHoursLookup[barId] || {},
       specials_by_day: barSpecialsByDay

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -290,6 +290,20 @@ function updateBarDescriptionSection(selectedBar) {
 }
 
 function renderBarDetailContent(selectedBar, detailPayload) {
+  const normalizedBarId = String(
+    detailPayload?.bar?.bar_id
+      ?? selectedBar?.bar_id
+      ?? selectedBar?.id
+      ?? ''
+  );
+  const startupBar = startupPayload?.bars?.[normalizedBarId] || null;
+  const mergedBarForDescription = {
+    ...startupBar,
+    ...selectedBar,
+    description: detailPayload?.bar?.description ?? startupBar?.description ?? selectedBar?.description
+  };
+  updateBarDescriptionSection(mergedBarForDescription);
+
   const todayKey = detailPayload?.general_data?.current_day || startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
   const orderedDays = getOrderedDaysForDetail(todayKey);
   const openHoursForBar = detailPayload?.open_hours || {};

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -291,17 +291,13 @@ function updateBarDescriptionSection(selectedBar) {
 
 function renderBarDetailContent(selectedBar, detailPayload) {
   const normalizedBarId = String(
-    detailPayload?.bar?.bar_id
-      ?? selectedBar?.bar_id
+    selectedBar?.bar_id
       ?? selectedBar?.id
+      ?? detailPayload?.bar?.bar_id
       ?? ''
   );
   const startupBar = startupPayload?.bars?.[normalizedBarId] || null;
-  const mergedBarForDescription = {
-    ...startupBar,
-    ...selectedBar,
-    description: detailPayload?.bar?.description ?? startupBar?.description ?? selectedBar?.description
-  };
+  const mergedBarForDescription = { ...selectedBar, ...startupBar };
   updateBarDescriptionSection(mergedBarForDescription);
 
   const todayKey = detailPayload?.general_data?.current_day || startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
@@ -488,10 +484,6 @@ async function showDetail(barOrId, previousScreen = currentTab) {
     updateBarWebsiteSection({
       ...selectedBar,
       website_url: detailPayload?.bar?.website_url || selectedBar?.website_url
-    });
-    updateBarDescriptionSection({
-      ...selectedBar,
-      description: detailPayload?.bar?.description || selectedBar?.description
     });
     renderBarDetailContent(selectedBar, detailPayload);
   } catch (err) {

--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -57,7 +57,8 @@ function buildBarDetailPayloadFromStartup(barId) {
       bar_id: Number(normalizedBarId),
       name: barData.name,
       neighborhood: barData.neighborhood,
-      image_url: barData.image_url
+      image_url: barData.image_url,
+      description: barData.description
     },
     general_data: generalData,
     open_hours: startupPayload?.open_hours?.[normalizedBarId] || {},
@@ -272,6 +273,22 @@ function updateBarWebsiteSection(selectedBar) {
   link.textContent = normalizedUrl;
 }
 
+function updateBarDescriptionSection(selectedBar) {
+  const section = document.getElementById('detail-description-section');
+  const descriptionEl = document.getElementById('detail-description');
+  if (!section || !descriptionEl) return;
+
+  const description = String(selectedBar?.description || '').trim();
+  if (!description) {
+    section.style.display = 'none';
+    descriptionEl.textContent = '';
+    return;
+  }
+
+  section.style.display = '';
+  descriptionEl.textContent = description;
+}
+
 function renderBarDetailContent(selectedBar, detailPayload) {
   const todayKey = detailPayload?.general_data?.current_day || startupPayload?.general_data?.current_day || getDayKeyFromName(DAYS_FULL[new Date().getDay()]);
   const orderedDays = getOrderedDaysForDetail(todayKey);
@@ -428,6 +445,7 @@ async function showDetail(barOrId, previousScreen = currentTab) {
   resetBarReportForm();
   updateBarLocationSection(selectedBar);
   updateBarWebsiteSection(selectedBar);
+  updateBarDescriptionSection(selectedBar);
 
   const startupDetailPayload = buildBarDetailPayloadFromStartup(selectedBar.bar_id);
   if (startupDetailPayload) {
@@ -456,6 +474,10 @@ async function showDetail(barOrId, previousScreen = currentTab) {
     updateBarWebsiteSection({
       ...selectedBar,
       website_url: detailPayload?.bar?.website_url || selectedBar?.website_url
+    });
+    updateBarDescriptionSection({
+      ...selectedBar,
+      description: detailPayload?.bar?.description || selectedBar?.description
     });
     renderBarDetailContent(selectedBar, detailPayload);
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Persist bar descriptions from Google Places when new bars are discovered during sync and keep existing bar descriptions up-to-date during sync runs just like open hours are refreshed.
- Surface the stored description on the bar details page in the web UI so users can read a short editorial summary for each bar.

### Description
- Google sync: added `places.editorialSummary` to the Places field mask and map `editorialSummary.text` into candidate bars as `description` in `functions/googleBarSync/google_bar_sync.py`.
- DB sync: updated `functions/dbBarSync/db_bar_sync.py` to persist `description` when inserting new bars and to update `description` for existing bars in the same update path that refreshes active status/location/open-hours.
- API payloads: included `description` in startup and bar-details responses by updating `functions/getStartupData/get_startup_data.py` and `functions/getBarDetails/get_bar_details.py` so frontends can consume it.
- Frontend/UI: threaded `description` through `js/api.js`, added a Description section to the detail markup in `index.html`, and implemented `updateBarDescriptionSection` and integration in `js/render-bar-detail.js` so the detail screen shows/hides the description based on available data.

### Testing
- `python -m py_compile functions/googleBarSync/google_bar_sync.py functions/dbBarSync/db_bar_sync.py functions/getStartupData/get_startup_data.py functions/getBarDetails/get_bar_details.py` succeeded.
- `npm test -- --runInBand` could not be executed in this environment because the repository has no `package.json` (test run failed with ENOENT).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9241a175483309bff97dbbe7ee7d1)