### PR TITLE
Update expected insertUserReport endpoint in special report test

### DIFF
--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -458,7 +458,7 @@ test('submitSpecialReport posts special report payload and resets form', async (
   await ctx.submitSpecialReport({ preventDefault() {} });
 
   assert.equal(fetchCalls.length, 1, 'calls fetch once');
-  assert.equal(fetchCalls[0].url, 'https://3kz7x6tvvi.execute-api.us-east-2.amazonaws.com/default/insertUserReport');
+  assert.equal(fetchCalls[0].url, 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/insertUserReport');
   assert.equal(fetchCalls[0].options.method, 'POST');
 
   const body = JSON.parse(fetchCalls[0].options.body);


### PR DESCRIPTION
### Motivation
- Align the test expectation with the current API Gateway endpoint used for submitting special reports.

### Description
- Update the expected fetch URL in `tests/app.test.js` for the `submitSpecialReport` test from `https://3kz7x6tvvi.execute-api.us-east-2.amazonaws.com/default/insertUserReport` to `https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/insertUserReport`.

### Testing
- Ran unit tests with `npm test` and the test suite including the `submitSpecialReport` test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93cd89118833083480262ab63a20e)