### PR TITLE
dbBarSync: add duplicate-website detection and expose via new mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate normalized `website_url` groups among active bars for alerting workflows. It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars for alerting workflows. It uses the same RDS connection variable pattern as the existing database Lambdas.
 
   Required environment variables:
   - `RDS_HOST`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars for alerting workflows. It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood (for alerting workflows). It uses the same RDS connection variable pattern as the existing database Lambdas.
 
   Required environment variables:
   - `RDS_HOST`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs. It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate normalized `website_url` groups among active bars for alerting workflows. It uses the same RDS connection variable pattern as the existing database Lambdas.
 
   Required environment variables:
   - `RDS_HOST`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood (for alerting workflows). It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood (for alerting workflows), including each matching bar's `bar_name` and full `website_url`. It uses the same RDS connection variable pattern as the existing database Lambdas.
 
   Required environment variables:
   - `RDS_HOST`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood (for alerting workflows), including each matching bar's `bar_name` and full `website_url`. It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood and have at least one active special (for alerting workflows), including each matching bar's `bar_name` and full `website_url`. It uses the same RDS connection variable pattern as the existing database Lambdas.
 
   Required environment variables:
   - `RDS_HOST`

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -174,6 +174,12 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
         WHERE is_active = 'Y'
           AND website_url IS NOT NULL
           AND TRIM(website_url) <> ''
+          AND EXISTS (
+              SELECT 1
+              FROM special
+              WHERE special.bar_id = bar.bar_id
+                AND special.is_active = 'Y'
+          )
         """
     )
     rows = cursor.fetchall()

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -167,6 +167,7 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
         """
         SELECT
             bar_id,
+            neighborhood,
             website_url
         FROM bar
         WHERE is_active = 'Y'
@@ -188,25 +189,30 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
             host = host[4:]
         return host
 
-    domain_groups: Dict[str, List[int]] = {}
+    domain_groups: Dict[str, Dict[str, List[int]]] = {}
     for row in rows:
         domain = _extract_domain(row.get('website_url'))
+        neighborhood = (row.get('neighborhood') or '').strip()
         if not domain:
             continue
-        domain_groups.setdefault(domain, []).append(int(row['bar_id']))
+        if not neighborhood:
+            continue
+        domain_groups.setdefault(domain, {}).setdefault(neighborhood, []).append(int(row['bar_id']))
 
     duplicate_groups = []
-    for domain, bar_ids in sorted(domain_groups.items(), key=lambda item: (-len(item[1]), item[0])):
-        if len(bar_ids) < 2:
-            continue
-        sorted_bar_ids = sorted(bar_ids)
-        duplicate_groups.append(
-            {
-                'domain': domain,
-                'active_bar_count': len(sorted_bar_ids),
-                'bar_ids': sorted_bar_ids,
-            }
-        )
+    for domain, neighborhood_map in sorted(domain_groups.items(), key=lambda item: item[0]):
+        for neighborhood, bar_ids in sorted(neighborhood_map.items(), key=lambda item: item[0]):
+            if len(bar_ids) < 2:
+                continue
+            sorted_bar_ids = sorted(bar_ids)
+            duplicate_groups.append(
+                {
+                    'domain': domain,
+                    'neighborhood': neighborhood,
+                    'active_bar_count': len(sorted_bar_ids),
+                    'bar_ids': sorted_bar_ids,
+                }
+            )
 
     return {
         'duplicate_group_count': len(duplicate_groups),

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -161,6 +161,41 @@ def get_bars_by_neighborhood(cursor, neighborhood: str) -> Dict[str, List[Dict]]
     return {'bars': cursor.fetchall()}
 
 
+def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
+    cursor.execute(
+        """
+        SELECT
+            LOWER(TRIM(TRAILING '/' FROM website_url)) AS normalized_website_url,
+            COUNT(*) AS active_bar_count,
+            GROUP_CONCAT(bar_id ORDER BY bar_id) AS bar_ids
+        FROM bar
+        WHERE is_active = 'Y'
+          AND website_url IS NOT NULL
+          AND TRIM(website_url) <> ''
+        GROUP BY LOWER(TRIM(TRAILING '/' FROM website_url))
+        HAVING COUNT(*) > 1
+        ORDER BY active_bar_count DESC, normalized_website_url ASC
+        """
+    )
+    rows = cursor.fetchall()
+    duplicate_groups = []
+    for row in rows:
+        bar_ids_csv = row.get('bar_ids') or ''
+        bar_ids = [int(bar_id) for bar_id in bar_ids_csv.split(',') if bar_id]
+        duplicate_groups.append(
+            {
+                'normalized_website_url': row['normalized_website_url'],
+                'active_bar_count': int(row['active_bar_count']),
+                'bar_ids': bar_ids,
+            }
+        )
+
+    return {
+        'duplicate_group_count': len(duplicate_groups),
+        'duplicate_groups': duplicate_groups,
+    }
+
+
 def _parse_confidence(value) -> float:
     if isinstance(value, (int, float)):
         return float(value)
@@ -512,11 +547,11 @@ def publish_candidate_specials(cursor, bar_id: int, run_id: int, auto_publish: s
 def lambda_handler(event, context):
     event = event or {}
     mode = event.get('mode')
-    if mode not in {'determine_if_bar_existing', 'apply_bar_upsert', 'get_bars_by_neighborhood'}:
+    if mode not in {'determine_if_bar_existing', 'apply_bar_upsert', 'get_bars_by_neighborhood', 'detect_duplicate_websites'}:
         return {
             'statusCode': 400,
             'body': json.dumps({
-                'error': 'mode must be one of determine_if_bar_existing, apply_bar_upsert, get_bars_by_neighborhood'
+                'error': 'mode must be one of determine_if_bar_existing, apply_bar_upsert, get_bars_by_neighborhood, detect_duplicate_websites'
             }),
         }
 
@@ -534,6 +569,9 @@ def lambda_handler(event, context):
                 if not neighborhood:
                     raise ValueError('neighborhood is required for get_bars_by_neighborhood')
                 result = get_bars_by_neighborhood(cursor, neighborhood)
+                conn.commit()
+            elif mode == 'detect_duplicate_websites':
+                result = get_duplicate_active_websites(cursor)
                 conn.commit()
         LOGGER.info('dbBarSync %s result=%s', mode, result)
         return {

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -4,6 +4,7 @@ import os
 from difflib import SequenceMatcher
 from datetime import datetime, time, timedelta
 from typing import Dict, List
+from urllib.parse import urlparse
 
 import pymysql
 
@@ -165,28 +166,45 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
     cursor.execute(
         """
         SELECT
-            LOWER(TRIM(TRAILING '/' FROM website_url)) AS normalized_website_url,
-            COUNT(*) AS active_bar_count,
-            GROUP_CONCAT(bar_id ORDER BY bar_id) AS bar_ids
+            bar_id,
+            website_url
         FROM bar
         WHERE is_active = 'Y'
           AND website_url IS NOT NULL
           AND TRIM(website_url) <> ''
-        GROUP BY LOWER(TRIM(TRAILING '/' FROM website_url))
-        HAVING COUNT(*) > 1
-        ORDER BY active_bar_count DESC, normalized_website_url ASC
         """
     )
     rows = cursor.fetchall()
-    duplicate_groups = []
+
+    def _extract_domain(website_url: str) -> str:
+        value = (website_url or '').strip().lower()
+        if not value:
+            return ''
+        if '://' not in value:
+            value = f'https://{value}'
+        parsed = urlparse(value)
+        host = (parsed.netloc or '').split('@')[-1].split(':')[0].strip('.')
+        if host.startswith('www.'):
+            host = host[4:]
+        return host
+
+    domain_groups: Dict[str, List[int]] = {}
     for row in rows:
-        bar_ids_csv = row.get('bar_ids') or ''
-        bar_ids = [int(bar_id) for bar_id in bar_ids_csv.split(',') if bar_id]
+        domain = _extract_domain(row.get('website_url'))
+        if not domain:
+            continue
+        domain_groups.setdefault(domain, []).append(int(row['bar_id']))
+
+    duplicate_groups = []
+    for domain, bar_ids in sorted(domain_groups.items(), key=lambda item: (-len(item[1]), item[0])):
+        if len(bar_ids) < 2:
+            continue
+        sorted_bar_ids = sorted(bar_ids)
         duplicate_groups.append(
             {
-                'normalized_website_url': row['normalized_website_url'],
-                'active_bar_count': int(row['active_bar_count']),
-                'bar_ids': bar_ids,
+                'domain': domain,
+                'active_bar_count': len(sorted_bar_ids),
+                'bar_ids': sorted_bar_ids,
             }
         )
 

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -167,6 +167,7 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
         """
         SELECT
             bar_id,
+            name AS bar_name,
             neighborhood,
             website_url
         FROM bar
@@ -189,28 +190,44 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
             host = host[4:]
         return host
 
-    domain_groups: Dict[str, Dict[str, List[int]]] = {}
+    domain_groups: Dict[str, Dict[str, List[Dict]]] = {}
     for row in rows:
         domain = _extract_domain(row.get('website_url'))
         neighborhood = (row.get('neighborhood') or '').strip()
+        bar_name = (row.get('bar_name') or '').strip()
+        website_url = (row.get('website_url') or '').strip()
         if not domain:
             continue
         if not neighborhood:
             continue
-        domain_groups.setdefault(domain, {}).setdefault(neighborhood, []).append(int(row['bar_id']))
+        domain_groups.setdefault(domain, {}).setdefault(neighborhood, []).append(
+            {
+                'bar_id': int(row['bar_id']),
+                'bar_name': bar_name,
+                'website_url': website_url,
+            }
+        )
 
     duplicate_groups = []
     for domain, neighborhood_map in sorted(domain_groups.items(), key=lambda item: item[0]):
-        for neighborhood, bar_ids in sorted(neighborhood_map.items(), key=lambda item: item[0]):
-            if len(bar_ids) < 2:
+        for neighborhood, bars in sorted(neighborhood_map.items(), key=lambda item: item[0]):
+            if len(bars) < 2:
                 continue
-            sorted_bar_ids = sorted(bar_ids)
+            sorted_bars = sorted(
+                bars,
+                key=lambda bar: (
+                    bar.get('bar_name', '').lower(),
+                    bar.get('bar_id', 0),
+                ),
+            )
+            sorted_bar_ids = [bar['bar_id'] for bar in sorted_bars]
             duplicate_groups.append(
                 {
                     'domain': domain,
                     'neighborhood': neighborhood,
                     'active_bar_count': len(sorted_bar_ids),
                     'bar_ids': sorted_bar_ids,
+                    'bars': sorted_bars,
                 }
             )
 


### PR DESCRIPTION
### Motivation

- Provide a way to surface groups of active bars that share the same normalized `website_url` for alerting and cleanup workflows.

### Description

- Add `get_duplicate_active_websites(cursor)` which queries active `bar` rows, normalizes `website_url` (lowercase, trimmed, trailing slash removed), groups duplicates, and returns counts and `bar_id` lists.
- Expose the new functionality via a `detect_duplicate_websites` `mode` in the Lambda `lambda_handler` so it can be invoked remotely and returns the duplicate groups payload.
- Update `README.md` to document the new `detect_duplicate_websites` behavior for the `dbBarSync` Lambda.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93c9b76ac8330ba65cdaf7be6cf54)