### PR TITLE
dbBarSync: detect duplicate website domains and optional SNS alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs. It uses the same RDS connection variable pattern as the existing database Lambdas.
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood and have at least one active special (for alerting workflows), including each matching bar's `bar_name` and full `website_url`; when duplicates are found and `ALERT_SNS_TOPIC_ARN` is configured, it also publishes an SNS message (email-capable via SNS email subscription).
 
   Required environment variables:
   - `RDS_HOST`
   - `DB_USER`
   - `DB_PASSWORD`
   - `DB_NAME`
+  - `ALERT_SNS_TOPIC_ARN` (optional; SNS topic ARN for duplicate-website email alerts)
   - `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
   - `WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `DB_BAR_SYNC_LAMBDA_NAME`
   - `ALERT_SNS_TOPIC_ARN` (SNS topic ARN with subscribed email recipients)
 
-  Optional environment variables:
-  - `AWS_REGION` (used for Lambda/SNS clients)
-
 
 - **`dbSpecialSync`**  
   Handles special-candidate persistence and publish flows. `insert_special_candidate` creates a `special_candidate_run` and inserts candidate rows, and `publish_special_candidate_run` applies approved candidates to active `special` rows.

--- a/README.md
+++ b/README.md
@@ -28,16 +28,25 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
   - `NEIGHBORHOODS_JSON_S3_KEY` (S3 object key in `S3_BUCKET_NAME`; used when no local file is found)
 
 - **`dbBarSync`**  
-  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood and have at least one active special (for alerting workflows), including each matching bar's `bar_name` and full `website_url`; when duplicates are found and `ALERT_SNS_TOPIC_ARN` is configured, it also publishes an SNS message (email-capable via SNS email subscription).
+  This Lambda is invoked only by `googleBarSync`. It handles bar-centric sync tasks. `determine_if_bar_existing` splits candidates into `new_bars` and `existing_bars` by `google_place_id`; `apply_bar_upsert` inserts new bars, upserts open-hours rows, and marks any bar whose Google `business_status` is not `OPERATIONAL` as inactive; `get_bars_by_neighborhood` returns bars for downstream jobs; `detect_duplicate_websites` returns duplicate website-domain groups among active bars only when the bars are in the same neighborhood and have at least one active special (for audit workflows), including each matching bar's `bar_name` and full `website_url`.
 
   Required environment variables:
   - `RDS_HOST`
   - `DB_USER`
   - `DB_PASSWORD`
   - `DB_NAME`
-  - `ALERT_SNS_TOPIC_ARN` (optional; SNS topic ARN for duplicate-website email alerts)
   - `WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
   - `WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD` (optional; defaults to `1.0`)
+
+- **`dataAudit`**  
+  Invokes `dbBarSync` mode `detect_duplicate_websites`, then sends an SNS message when duplicate groups are returned. This lets audit scheduling/alerts run independently from DB sync logic.
+
+  Required environment variables:
+  - `DB_BAR_SYNC_LAMBDA_NAME`
+  - `ALERT_SNS_TOPIC_ARN` (SNS topic ARN with subscribed email recipients)
+
+  Optional environment variables:
+  - `AWS_REGION` (used for Lambda/SNS clients)
 
 
 - **`dbSpecialSync`**  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The folders inside `functions/` each correspond to an AWS Lambda function.
 - **`dataAudit`**  
   Invokes `dbBarSync` mode `detect_duplicate_websites`, then sends an SNS message when duplicate groups are returned. This lets audit scheduling/alerts run independently from DB sync logic.
 
+  Example payload:
+  ```json
+  {
+    "mode": "detect_duplicate_websites"
+  }
+  ```
+
   Required environment variables:
   - `DB_BAR_SYNC_LAMBDA_NAME`
   - `ALERT_SNS_TOPIC_ARN` (SNS topic ARN with subscribed email recipients)

--- a/functions/dataAudit/data_audit.py
+++ b/functions/dataAudit/data_audit.py
@@ -10,10 +10,9 @@ LOGGER.setLevel(logging.INFO)
 
 DB_BAR_SYNC_LAMBDA_NAME = os.environ['DB_BAR_SYNC_LAMBDA_NAME']
 ALERT_SNS_TOPIC_ARN = os.environ.get('ALERT_SNS_TOPIC_ARN', '').strip()
-AWS_REGION = os.environ.get('AWS_REGION', '').strip() or None
 
-LAMBDA_CLIENT = boto3.client('lambda', region_name=AWS_REGION)
-SNS_CLIENT = boto3.client('sns', region_name=AWS_REGION) if ALERT_SNS_TOPIC_ARN else None
+LAMBDA_CLIENT = boto3.client('lambda')
+SNS_CLIENT = boto3.client('sns') if ALERT_SNS_TOPIC_ARN else None
 
 
 def invoke_db_bar_sync(payload: Dict) -> Dict:

--- a/functions/dataAudit/data_audit.py
+++ b/functions/dataAudit/data_audit.py
@@ -1,0 +1,93 @@
+import json
+import logging
+import os
+from typing import Dict
+
+import boto3
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+DB_BAR_SYNC_LAMBDA_NAME = os.environ['DB_BAR_SYNC_LAMBDA_NAME']
+ALERT_SNS_TOPIC_ARN = os.environ.get('ALERT_SNS_TOPIC_ARN', '').strip()
+AWS_REGION = os.environ.get('AWS_REGION', '').strip() or None
+
+LAMBDA_CLIENT = boto3.client('lambda', region_name=AWS_REGION)
+SNS_CLIENT = boto3.client('sns', region_name=AWS_REGION) if ALERT_SNS_TOPIC_ARN else None
+
+
+def invoke_db_bar_sync(payload: Dict) -> Dict:
+    LOGGER.info('dataAudit: invoking dbBarSync payload=%s', payload)
+    response = LAMBDA_CLIENT.invoke(
+        FunctionName=DB_BAR_SYNC_LAMBDA_NAME,
+        InvocationType='RequestResponse',
+        Payload=json.dumps(payload).encode('utf-8'),
+    )
+    if response.get('FunctionError'):
+        raise RuntimeError(f"dbBarSync invocation failed: {response['FunctionError']}")
+
+    response_payload = json.loads(response['Payload'].read())
+    status_code = response_payload.get('statusCode', 500)
+    body = response_payload.get('body')
+    parsed_body = json.loads(body) if isinstance(body, str) else (body or {})
+    if status_code >= 400:
+        raise RuntimeError(f'dbBarSync returned {status_code}: {parsed_body}')
+    return parsed_body
+
+
+def publish_duplicate_alert(result: Dict) -> Dict[str, object]:
+    if not ALERT_SNS_TOPIC_ARN:
+        LOGGER.warning('dataAudit: ALERT_SNS_TOPIC_ARN is not configured; skipping alert publish')
+        return {'email_sent': False, 'email_reason': 'ALERT_SNS_TOPIC_ARN_NOT_CONFIGURED'}
+
+    duplicate_groups = result.get('duplicate_groups', [])
+    if not duplicate_groups:
+        LOGGER.info('dataAudit: no duplicate groups found; skipping alert publish')
+        return {'email_sent': False, 'email_reason': 'NO_DUPLICATES_FOUND'}
+
+    subject = f"[Bar App] Duplicate website domains detected ({len(duplicate_groups)} groups)"
+    message_lines = [
+        'Duplicate website-domain groups were detected for active bars in the same neighborhood with active specials.',
+        '',
+        f"duplicate_group_count: {result.get('duplicate_group_count', 0)}",
+        '',
+    ]
+    for group in duplicate_groups:
+        message_lines.append(
+            f"- Domain: {group.get('domain')} | Neighborhood: {group.get('neighborhood')} | Bars: {group.get('active_bar_count')}"
+        )
+        for bar in group.get('bars', []):
+            message_lines.append(
+                f"  • bar_id={bar.get('bar_id')} | bar_name={bar.get('bar_name')} | website_url={bar.get('website_url')}"
+            )
+        message_lines.append('')
+
+    LOGGER.info('dataAudit: publishing SNS alert topic=%s duplicate_groups=%s', ALERT_SNS_TOPIC_ARN, len(duplicate_groups))
+    SNS_CLIENT.publish(
+        TopicArn=ALERT_SNS_TOPIC_ARN,
+        Subject=subject[:100],
+        Message='\n'.join(message_lines).strip(),
+    )
+    LOGGER.info('dataAudit: SNS publish succeeded')
+    return {'email_sent': True, 'email_reason': 'SENT'}
+
+
+def lambda_handler(event, context):
+    event = event or {}
+    request_id = getattr(context, 'aws_request_id', 'unknown')
+    mode = event.get('mode') or 'detect_duplicate_websites'
+    LOGGER.info('dataAudit request_id=%s mode=%s received', request_id, mode)
+
+    if mode != 'detect_duplicate_websites':
+        return {
+            'statusCode': 400,
+            'body': json.dumps({'error': 'mode must be detect_duplicate_websites'}),
+        }
+
+    result = invoke_db_bar_sync({'mode': 'detect_duplicate_websites'})
+    LOGGER.info('dataAudit request_id=%s duplicate_group_count=%s', request_id, result.get('duplicate_group_count', 0))
+    result.update(publish_duplicate_alert(result))
+    return {
+        'statusCode': 200,
+        'body': json.dumps(result),
+    }

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -167,6 +167,7 @@ def get_bars_by_neighborhood(cursor, neighborhood: str) -> Dict[str, List[Dict]]
 
 
 def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
+    LOGGER.info('detect_duplicate_websites: querying active bars with active specials')
     cursor.execute(
         """
         SELECT
@@ -187,6 +188,7 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
         """
     )
     rows = cursor.fetchall()
+    LOGGER.info('detect_duplicate_websites: fetched %s candidate bars', len(rows))
 
     def _extract_domain(website_url: str) -> str:
         value = (website_url or '').strip().lower()
@@ -254,6 +256,7 @@ def send_duplicate_websites_alert(result: Dict) -> Dict[str, object]:
 
     duplicate_groups = result.get('duplicate_groups', [])
     if not duplicate_groups:
+        LOGGER.info('detect_duplicate_websites: no duplicate groups found; skipping email alert')
         return {'email_sent': False, 'email_reason': 'NO_DUPLICATES_FOUND'}
 
     subject = f"[Bar App] Duplicate website domains detected ({len(duplicate_groups)} groups)"
@@ -274,11 +277,17 @@ def send_duplicate_websites_alert(result: Dict) -> Dict[str, object]:
             )
         message_lines.append('')
 
+    LOGGER.info(
+        'detect_duplicate_websites: publishing SNS alert topic=%s duplicate_groups=%s',
+        ALERT_SNS_TOPIC_ARN,
+        len(duplicate_groups),
+    )
     SNS_CLIENT.publish(
         TopicArn=ALERT_SNS_TOPIC_ARN,
         Subject=subject[:100],
         Message='\n'.join(message_lines).strip(),
     )
+    LOGGER.info('detect_duplicate_websites: SNS alert publish succeeded')
     return {'email_sent': True, 'email_reason': 'SENT'}
 
 
@@ -633,6 +642,8 @@ def publish_candidate_specials(cursor, bar_id: int, run_id: int, auto_publish: s
 def lambda_handler(event, context):
     event = event or {}
     mode = event.get('mode')
+    request_id = getattr(context, 'aws_request_id', 'unknown')
+    LOGGER.info('dbBarSync request_id=%s mode=%s received', request_id, mode)
     if mode not in {'determine_if_bar_existing', 'apply_bar_upsert', 'get_bars_by_neighborhood', 'detect_duplicate_websites'}:
         return {
             'statusCode': 400,
@@ -645,22 +656,37 @@ def lambda_handler(event, context):
     try:
         with conn.cursor() as cursor:
             if mode == 'determine_if_bar_existing':
+                LOGGER.info('dbBarSync request_id=%s mode=%s starting categorize_bars', request_id, mode)
                 result = categorize_bars(cursor, event.get('bars', []))
                 conn.commit()
             elif mode == 'apply_bar_upsert':
+                LOGGER.info('dbBarSync request_id=%s mode=%s starting apply_changes', request_id, mode)
                 result = apply_changes(cursor, event.get('new_bars', []), event.get('existing_bars', []))
                 conn.commit()
             elif mode == 'get_bars_by_neighborhood':
                 neighborhood = event.get('neighborhood')
                 if not neighborhood:
                     raise ValueError('neighborhood is required for get_bars_by_neighborhood')
+                LOGGER.info(
+                    'dbBarSync request_id=%s mode=%s starting get_bars_by_neighborhood neighborhood=%s',
+                    request_id,
+                    mode,
+                    neighborhood,
+                )
                 result = get_bars_by_neighborhood(cursor, neighborhood)
                 conn.commit()
             elif mode == 'detect_duplicate_websites':
+                LOGGER.info('dbBarSync request_id=%s mode=%s starting duplicate detection', request_id, mode)
                 result = get_duplicate_active_websites(cursor)
+                LOGGER.info(
+                    'dbBarSync request_id=%s mode=%s duplicate_group_count=%s',
+                    request_id,
+                    mode,
+                    result.get('duplicate_group_count', 0),
+                )
                 result.update(send_duplicate_websites_alert(result))
                 conn.commit()
-        LOGGER.info('dbBarSync %s result=%s', mode, result)
+        LOGGER.info('dbBarSync request_id=%s mode=%s completed result=%s', request_id, mode, result)
         return {
             'statusCode': 200,
             'body': json.dumps(result),

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -6,7 +6,6 @@ from datetime import datetime, time, timedelta
 from typing import Dict, List
 from urllib.parse import urlparse
 
-import boto3
 import pymysql
 
 LOGGER = logging.getLogger()
@@ -19,9 +18,6 @@ DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = .5
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = .8
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
-ALERT_SNS_TOPIC_ARN = os.environ.get('ALERT_SNS_TOPIC_ARN', '').strip()
-AWS_REGION = os.environ.get('AWS_REGION', '').strip() or None
-SNS_CLIENT = boto3.client('sns', region_name=AWS_REGION) if ALERT_SNS_TOPIC_ARN else None
 
 
 def get_connection():
@@ -247,48 +243,6 @@ def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
         'duplicate_group_count': len(duplicate_groups),
         'duplicate_groups': duplicate_groups,
     }
-
-
-def send_duplicate_websites_alert(result: Dict) -> Dict[str, object]:
-    if not ALERT_SNS_TOPIC_ARN:
-        LOGGER.warning('ALERT_SNS_TOPIC_ARN is not configured; skipping duplicate website email alert')
-        return {'email_sent': False, 'email_reason': 'ALERT_SNS_TOPIC_ARN_NOT_CONFIGURED'}
-
-    duplicate_groups = result.get('duplicate_groups', [])
-    if not duplicate_groups:
-        LOGGER.info('detect_duplicate_websites: no duplicate groups found; skipping email alert')
-        return {'email_sent': False, 'email_reason': 'NO_DUPLICATES_FOUND'}
-
-    subject = f"[Bar App] Duplicate website domains detected ({len(duplicate_groups)} groups)"
-    message_lines = [
-        'Duplicate website-domain groups were detected for active bars in the same neighborhood with active specials.',
-        '',
-        f"duplicate_group_count: {result.get('duplicate_group_count', 0)}",
-        '',
-    ]
-
-    for group in duplicate_groups:
-        message_lines.append(
-            f"- Domain: {group.get('domain')} | Neighborhood: {group.get('neighborhood')} | Bars: {group.get('active_bar_count')}"
-        )
-        for bar in group.get('bars', []):
-            message_lines.append(
-                f"  • bar_id={bar.get('bar_id')} | bar_name={bar.get('bar_name')} | website_url={bar.get('website_url')}"
-            )
-        message_lines.append('')
-
-    LOGGER.info(
-        'detect_duplicate_websites: publishing SNS alert topic=%s duplicate_groups=%s',
-        ALERT_SNS_TOPIC_ARN,
-        len(duplicate_groups),
-    )
-    SNS_CLIENT.publish(
-        TopicArn=ALERT_SNS_TOPIC_ARN,
-        Subject=subject[:100],
-        Message='\n'.join(message_lines).strip(),
-    )
-    LOGGER.info('detect_duplicate_websites: SNS alert publish succeeded')
-    return {'email_sent': True, 'email_reason': 'SENT'}
 
 
 def _parse_confidence(value) -> float:
@@ -684,7 +638,6 @@ def lambda_handler(event, context):
                     mode,
                     result.get('duplicate_group_count', 0),
                 )
-                result.update(send_duplicate_websites_alert(result))
                 conn.commit()
         LOGGER.info('dbBarSync request_id=%s mode=%s completed result=%s', request_id, mode, result)
         return {

--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -4,7 +4,9 @@ import os
 from difflib import SequenceMatcher
 from datetime import datetime, time, timedelta
 from typing import Dict, List
+from urllib.parse import urlparse
 
+import boto3
 import pymysql
 
 LOGGER = logging.getLogger()
@@ -17,6 +19,9 @@ DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = .5
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = .8
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
+ALERT_SNS_TOPIC_ARN = os.environ.get('ALERT_SNS_TOPIC_ARN', '').strip()
+AWS_REGION = os.environ.get('AWS_REGION', '').strip() or None
+SNS_CLIENT = boto3.client('sns', region_name=AWS_REGION) if ALERT_SNS_TOPIC_ARN else None
 
 
 def get_connection():
@@ -159,6 +164,122 @@ def get_bars_by_neighborhood(cursor, neighborhood: str) -> Dict[str, List[Dict]]
         (neighborhood,),
     )
     return {'bars': cursor.fetchall()}
+
+
+def get_duplicate_active_websites(cursor) -> Dict[str, List[Dict]]:
+    cursor.execute(
+        """
+        SELECT
+            bar_id,
+            name AS bar_name,
+            neighborhood,
+            website_url
+        FROM bar
+        WHERE is_active = 'Y'
+          AND website_url IS NOT NULL
+          AND TRIM(website_url) <> ''
+          AND EXISTS (
+              SELECT 1
+              FROM special
+              WHERE special.bar_id = bar.bar_id
+                AND special.is_active = 'Y'
+          )
+        """
+    )
+    rows = cursor.fetchall()
+
+    def _extract_domain(website_url: str) -> str:
+        value = (website_url or '').strip().lower()
+        if not value:
+            return ''
+        if '://' not in value:
+            value = f'https://{value}'
+        parsed = urlparse(value)
+        host = (parsed.netloc or '').split('@')[-1].split(':')[0].strip('.')
+        if host.startswith('www.'):
+            host = host[4:]
+        return host
+
+    domain_groups: Dict[str, Dict[str, List[Dict]]] = {}
+    for row in rows:
+        domain = _extract_domain(row.get('website_url'))
+        neighborhood = (row.get('neighborhood') or '').strip()
+        bar_name = (row.get('bar_name') or '').strip()
+        website_url = (row.get('website_url') or '').strip()
+        if not domain:
+            continue
+        if not neighborhood:
+            continue
+        domain_groups.setdefault(domain, {}).setdefault(neighborhood, []).append(
+            {
+                'bar_id': int(row['bar_id']),
+                'bar_name': bar_name,
+                'website_url': website_url,
+            }
+        )
+
+    duplicate_groups = []
+    for domain, neighborhood_map in sorted(domain_groups.items(), key=lambda item: item[0]):
+        for neighborhood, bars in sorted(neighborhood_map.items(), key=lambda item: item[0]):
+            if len(bars) < 2:
+                continue
+            sorted_bars = sorted(
+                bars,
+                key=lambda bar: (
+                    bar.get('bar_name', '').lower(),
+                    bar.get('bar_id', 0),
+                ),
+            )
+            sorted_bar_ids = [bar['bar_id'] for bar in sorted_bars]
+            duplicate_groups.append(
+                {
+                    'domain': domain,
+                    'neighborhood': neighborhood,
+                    'active_bar_count': len(sorted_bar_ids),
+                    'bar_ids': sorted_bar_ids,
+                    'bars': sorted_bars,
+                }
+            )
+
+    return {
+        'duplicate_group_count': len(duplicate_groups),
+        'duplicate_groups': duplicate_groups,
+    }
+
+
+def send_duplicate_websites_alert(result: Dict) -> Dict[str, object]:
+    if not ALERT_SNS_TOPIC_ARN:
+        LOGGER.warning('ALERT_SNS_TOPIC_ARN is not configured; skipping duplicate website email alert')
+        return {'email_sent': False, 'email_reason': 'ALERT_SNS_TOPIC_ARN_NOT_CONFIGURED'}
+
+    duplicate_groups = result.get('duplicate_groups', [])
+    if not duplicate_groups:
+        return {'email_sent': False, 'email_reason': 'NO_DUPLICATES_FOUND'}
+
+    subject = f"[Bar App] Duplicate website domains detected ({len(duplicate_groups)} groups)"
+    message_lines = [
+        'Duplicate website-domain groups were detected for active bars in the same neighborhood with active specials.',
+        '',
+        f"duplicate_group_count: {result.get('duplicate_group_count', 0)}",
+        '',
+    ]
+
+    for group in duplicate_groups:
+        message_lines.append(
+            f"- Domain: {group.get('domain')} | Neighborhood: {group.get('neighborhood')} | Bars: {group.get('active_bar_count')}"
+        )
+        for bar in group.get('bars', []):
+            message_lines.append(
+                f"  • bar_id={bar.get('bar_id')} | bar_name={bar.get('bar_name')} | website_url={bar.get('website_url')}"
+            )
+        message_lines.append('')
+
+    SNS_CLIENT.publish(
+        TopicArn=ALERT_SNS_TOPIC_ARN,
+        Subject=subject[:100],
+        Message='\n'.join(message_lines).strip(),
+    )
+    return {'email_sent': True, 'email_reason': 'SENT'}
 
 
 def _parse_confidence(value) -> float:
@@ -512,11 +633,11 @@ def publish_candidate_specials(cursor, bar_id: int, run_id: int, auto_publish: s
 def lambda_handler(event, context):
     event = event or {}
     mode = event.get('mode')
-    if mode not in {'determine_if_bar_existing', 'apply_bar_upsert', 'get_bars_by_neighborhood'}:
+    if mode not in {'determine_if_bar_existing', 'apply_bar_upsert', 'get_bars_by_neighborhood', 'detect_duplicate_websites'}:
         return {
             'statusCode': 400,
             'body': json.dumps({
-                'error': 'mode must be one of determine_if_bar_existing, apply_bar_upsert, get_bars_by_neighborhood'
+                'error': 'mode must be one of determine_if_bar_existing, apply_bar_upsert, get_bars_by_neighborhood, detect_duplicate_websites'
             }),
         }
 
@@ -534,6 +655,10 @@ def lambda_handler(event, context):
                 if not neighborhood:
                     raise ValueError('neighborhood is required for get_bars_by_neighborhood')
                 result = get_bars_by_neighborhood(cursor, neighborhood)
+                conn.commit()
+            elif mode == 'detect_duplicate_websites':
+                result = get_duplicate_active_websites(cursor)
+                result.update(send_duplicate_websites_alert(result))
                 conn.commit()
         LOGGER.info('dbBarSync %s result=%s', mode, result)
         return {


### PR DESCRIPTION
### Motivation

- Add automated detection of duplicate website domains among active bars in the same neighborhood that have active specials to support alerting and cleanup workflows.
- Provide an optional email-capable alerting mechanism via SNS when duplicate website groups are found.

### Description

- Add `get_duplicate_active_websites` which selects active bars with active specials, normalizes `website_url` to extract domains using `urlparse`, groups by domain and neighborhood, and returns duplicate groups containing `bar_id`, `bar_name`, and full `website_url`.
- Add `send_duplicate_websites_alert` which publishes a summary message to SNS using `ALERT_SNS_TOPIC_ARN` and optional `AWS_REGION`; it returns status metadata about whether an alert was sent.
- Wire a new Lambda mode `detect_duplicate_websites` into `lambda_handler` so this behavior can be invoked via `dbBarSync` with `mode = 'detect_duplicate_websites'` and add related imports (`boto3`, `urlparse`) and env var handling for `ALERT_SNS_TOPIC_ARN` and `AWS_REGION`.
- Update `README.md` to document the new `detect_duplicate_websites` behavior and the optional `ALERT_SNS_TOPIC_ARN` environment variable.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93c9b76ac8330ba65cdaf7be6cf54)