### PR TITLE
Persist cleared special times as NULL in update_special

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1121,6 +1121,10 @@ def update_special(cursor, event):
         updates['all_day'] = _normalize_yn_flag(updates['all_day'])
     if 'is_active' in updates:
         updates['is_active'] = _normalize_yn_flag(updates['is_active'])
+    if 'start_time' in updates:
+        updates['start_time'] = _normalize_time_value(updates.get('start_time')) or None
+    if 'end_time' in updates:
+        updates['end_time'] = _normalize_time_value(updates.get('end_time')) or None
 
     set_clause = ', '.join([f"{key} = %s" for key in updates])
     values = list(updates.values()) + [special_id]

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -452,6 +452,10 @@ STRICT RULES:
   - Price or discount included in description
   - Food or drink item
   - Clear determination of day/time/recurrance for each item
+  - If special is not all day, clear determination of start and end time
+  - If a price, discount, or deal amount is explicitly stated for an item, it MUST be included in the description
+  - Never output an item name alone if its price/discount is clearly present nearby
+  - If item name and price appear on separate but adjascent lines, merge them into a single description
 
 Extraction strategy (important):
 - Prioritize sections/headings that contain words like: specials, weekly specials, happy hour, deals, promotions.
@@ -489,6 +493,14 @@ Normalization rules:
   - Price or discount amount
   - Food or drink item
   - Clear determination of day/time/recurrance for each item
+  - If a price or discount is visible in the source text but missing from description, fix the description.
+  - If a special is not all-day and the start time or end time is missing, lower the confidence
+  - Omit labels such as "happy hour" or time descriptors from description and keep only the actual offer details in the description.
+- If one of the following are missing from the parsed description, score confidence .5 or less:
+  - Price or discount amount
+  - Food or drink item
+  - Day of week
+  - All_day = N and start_time or end_time is missing
 
 Return ONLY valid JSON (an array). No explanations.
 
@@ -532,9 +544,16 @@ Normalization rules:
 - Set confidence based on evidence strength and source quality. Suggested rubric:
   - 1.00: Special has price or discount type, food or drink item, and clear determination of day/time/recurrance defined for each item corroborated by at least two independent reliable sources with recent updates.
   - 0.85-0.99: Special has price or discount type, food or drink item, and clear determination of day/time/recurrance defined for each item corroborated by only one reliable source with recent updates.
-  - 0.70-0.84: Slight ambiguity of one of: (price or discount type, food or drink item, or day/time/recurrance) or source is questionable
-  - 0.40-0.69: Ambiguity of two of: (price or discount type, food or drink item, or day/time/recurrance)
+  - 0.70-0.84: Slight ambiguity of one of: (price or discount type, food or drink item, day/time/recurrance, start or end time is missing on special that is not all-day) or source is questionable
+  - 0.40-0.69: Ambiguity of two of: (price or discount type, food or drink item, or day/time/recurrance, start or end time is missing on special that is not all-day)
   - 0.10-0.39: stale or weak evidence (old posts, indirect mentions, third-party reposts without confirmation).
+
+Final review:
+- If one of the following is true, score confidence .4 or less:
+  - Price or discount amount missing from description field
+  - Food or drink item missing from description field
+  - days_of_week field is missing
+  - all_day = N and start_time or end_time is missing
 
 Only include items when a concrete source URL is available. Only include items that are an actual discount - don't just include events without a food or drink discount.
 Return ONLY valid JSON. No explanations.


### PR DESCRIPTION
### Motivation
- Clearing `start_time`/`end_time` in the admin UI was being persisted as `00:00:00` because empty strings were sent to MySQL, so times cleared by an admin should be stored as SQL `NULL` instead.

### Description
- Normalize `start_time` and `end_time` in `update_special` by applying `_normalize_time_value(...)` and falling back to `None` before executing the `UPDATE` in `functions/dbAdminSync/db_admin_sync.py` so cleared/empty inputs become `NULL`.

### Testing
- Ran the frontend regression suite with `node --test tests/app.test.js` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9e41f3b883309b9620b6b7e79ad9)