### PR TITLE
Stop parsing and filtering date information in normalize_item

### DIFF
--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -691,11 +691,7 @@ def normalize_item(item, default_source):
     normalized_days = [day for day in days if day in DAY_KEYS]
     raw_item_type = str(item.get('type') or '').strip().lower()
     item_type = raw_item_type if raw_item_type in ('food', 'drink', 'combo', 'unknown') else 'unknown'
-    text_blob = f"{item.get('description') or ''} {item.get('notes') or ''}"
-    parsed_date = _parse_date_from_text(text_blob)
-    if parsed_date and parsed_date < date.today():
-        return None
-    is_recurring = 'N' if parsed_date else 'Y'
+    is_recurring = 'Y'
 
     return {
         'description': str(item.get('description') or '').strip(),
@@ -709,7 +705,7 @@ def normalize_item(item, default_source):
         'source_url': str(item.get('source_url') or item.get('source') or default_source).strip(),
         'fetch_method': '',
         'is_recurring': is_recurring,
-        'date': parsed_date.isoformat() if parsed_date else None
+        'date': None
     }
 
 

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import time
-from datetime import date, datetime, timedelta
+from datetime import datetime
 from html import unescape
 from html.parser import HTMLParser
 from urllib.parse import urljoin, urlparse
@@ -618,66 +618,6 @@ def parse_json_array(text):
         return parsed if isinstance(parsed, list) else []
     except json.JSONDecodeError:
         return []
-
-
-def _parse_date_from_text(text):
-    value = (text or '').strip()
-    if not value:
-        return None
-
-    today = date.today()
-
-    if re.search(r'\btoday\b', value, flags=re.IGNORECASE):
-        return today
-    if re.search(r'\btomorrow\b', value, flags=re.IGNORECASE):
-        return today + timedelta(days=1)
-
-    iso_match = re.search(r'\b(20\d{2})-(\d{2})-(\d{2})\b', value)
-    if iso_match:
-        try:
-            return date(int(iso_match.group(1)), int(iso_match.group(2)), int(iso_match.group(3)))
-        except ValueError:
-            return None
-
-    slash_match = re.search(r'\b(\d{1,2})/(\d{1,2})(?:/(\d{2,4}))?\b', value)
-    if slash_match:
-        month = int(slash_match.group(1))
-        day_val = int(slash_match.group(2))
-        year_val = slash_match.group(3)
-        if not year_val:
-            year = today.year
-        else:
-            year = int(year_val)
-            if year < 100:
-                year += 2000
-        try:
-            parsed = date(year, month, day_val)
-            if not year_val and parsed < today:
-                parsed = date(today.year + 1, month, day_val)
-            return parsed
-        except ValueError:
-            return None
-
-    month_match = re.search(
-        r'\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2})(?:,\s*(\d{4}))?\b',
-        value,
-        flags=re.IGNORECASE
-    )
-    if month_match:
-        month_name = month_match.group(1)
-        day_val = int(month_match.group(2))
-        year_val = month_match.group(3)
-        month_num = datetime.strptime(month_name[:3], '%b').month
-        year = int(year_val) if year_val else today.year
-        try:
-            parsed = date(year, month_num, day_val)
-            if not year_val and parsed < today:
-                parsed = date(today.year + 1, month_num, day_val)
-            return parsed
-        except ValueError:
-            return None
-
-    return None
 
 
 def normalize_item(item, default_source):


### PR DESCRIPTION
### Motivation
- Prevent special items from being rejected or marked non-recurring based on dates parsed from freeform `description`/`notes`, and simplify `normalize_item` so specials are treated as recurring unless explicitly set elsewhere.

### Description
- Remove the text blob date extraction and the early return that filtered out items whose parsed date was in the past from `normalize_item` in `generate_candidate_specials.py`.
- Always set `'is_recurring'` to `'Y'` and set the returned `'date'` field to `None` instead of populating it from parsed text.

### Testing
- Ran the test suite with `pytest -q` and static checks with `flake8`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c434db748330976fc9ef2b3fe1f4)