### PR TITLE
Backfill missing special times from open_hours during publish

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -116,6 +116,26 @@ def _normalize_time_value(value) -> str:
     return normalized
 
 
+def _build_open_hours_lookup(open_hours_rows: List[Dict]) -> Dict[str, Dict]:
+    lookup = {}
+    for row in open_hours_rows:
+        day_key = _normalize_day_of_week(row.get('day_of_week'))
+        if not day_key:
+            continue
+        lookup[day_key] = {
+            'open_time': _normalize_time_value(row.get('open_time')),
+            'close_time': _normalize_time_value(row.get('close_time')),
+            'is_closed': _normalize_yn_flag(row.get('is_closed')),
+        }
+    return lookup
+
+
+def _append_missing_hours_note(note_suffixes: Dict[int, List[str]], candidate_id: int, day_of_week: str, missing_field: str) -> None:
+    note_suffixes.setdefault(candidate_id, []).append(
+        f" - missing {missing_field} for {day_of_week}, special not published for {day_of_week}"
+    )
+
+
 def _to_json_safe_number(value):
     if isinstance(value, Decimal):
         return float(value)
@@ -143,6 +163,16 @@ def _is_candidate_same_as_special(candidate_row: Dict, special_row: Dict) -> boo
 def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish: str = 'N') -> Dict[str, int]:
     cursor.execute(
         """
+        SELECT day_of_week, open_time, close_time, is_closed
+        FROM open_hours
+        WHERE bar_id = %s
+        """,
+        (bar_id,),
+    )
+    open_hours_lookup = _build_open_hours_lookup(cursor.fetchall())
+
+    cursor.execute(
+        """
         SELECT special_candidate_id, description, type, days_of_week, start_time, end_time, all_day
         FROM special_candidate
         WHERE bar_id = %s
@@ -154,19 +184,52 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     approved_candidates = cursor.fetchall()
 
     candidate_rows = []
+    candidate_note_suffixes = {}
     for candidate in approved_candidates:
         for day in _parse_days_of_week(candidate.get('days_of_week')):
+            start_time = candidate.get('start_time')
+            end_time = candidate.get('end_time')
+            all_day = candidate.get('all_day')
+            if _normalize_yn_flag(all_day) == 'N':
+                day_hours = open_hours_lookup.get(_normalize_day_of_week(day), {})
+                should_skip = False
+                if not _normalize_time_value(start_time):
+                    resolved_open_time = _normalize_time_value(day_hours.get('open_time'))
+                    if resolved_open_time:
+                        start_time = resolved_open_time
+                    else:
+                        _append_missing_hours_note(candidate_note_suffixes, candidate['special_candidate_id'], day, 'open_time')
+                        should_skip = True
+                if not _normalize_time_value(end_time):
+                    resolved_close_time = _normalize_time_value(day_hours.get('close_time'))
+                    if resolved_close_time:
+                        end_time = resolved_close_time
+                    else:
+                        _append_missing_hours_note(candidate_note_suffixes, candidate['special_candidate_id'], day, 'close_time')
+                        should_skip = True
+                if should_skip:
+                    continue
             candidate_rows.append(
                 {
                     'candidate_id': candidate['special_candidate_id'],
                     'description': candidate.get('description'),
                     'type': candidate.get('type'),
                     'day_of_week': day,
-                    'start_time': candidate.get('start_time'),
-                    'end_time': candidate.get('end_time'),
-                    'all_day': candidate.get('all_day'),
+                    'start_time': start_time,
+                    'end_time': end_time,
+                    'all_day': all_day,
                 }
             )
+
+    for candidate_id, note_suffixes in candidate_note_suffixes.items():
+        cursor.execute(
+            """
+            UPDATE special_candidate
+            SET notes = CONCAT(COALESCE(notes, ''), %s)
+            WHERE special_candidate_id = %s
+            """,
+            (''.join(note_suffixes), candidate_id),
+        )
 
     manual_filter_clause = "AND insert_method <> 'MANUAL'" if IGNORE_MANUAL_SPECIALS_ON_PUBLISH == 'Y' else ''
     cursor.execute(

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -153,6 +153,12 @@ def _should_convert_to_all_day(day_of_week, all_day, start_time, end_time, open_
     )
 
 
+def _append_missing_hours_note(note_suffixes: Dict[int, List[str]], candidate_id: int, day_of_week: str, missing_field: str) -> None:
+    note_suffixes.setdefault(candidate_id, []).append(
+        f" - missing {missing_field} for {day_of_week}, special not published for {day_of_week}"
+    )
+
+
 def _is_candidate_same_as_special(candidate_row: Dict, special_row: Dict) -> bool:
     return (
         _normalize_day_of_week(candidate_row.get('day_of_week')) == _normalize_day_of_week(special_row.get('day_of_week'))
@@ -371,6 +377,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     approved_candidates = cursor.fetchall()
 
     candidate_rows = []
+    candidate_note_suffixes = {}
     for candidate in approved_candidates:
         for day in _parse_days_of_week(candidate.get('days_of_week')):
             start_time = candidate.get('start_time')
@@ -380,6 +387,27 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 all_day = 'Y'
                 start_time = None
                 end_time = None
+
+            if _normalize_yn_flag(all_day) == 'N':
+                day_hours = open_hours_lookup.get(_normalize_day_of_week(day), {})
+                should_skip = False
+                if not _normalize_time_value(start_time):
+                    resolved_open_time = _normalize_time_value(day_hours.get('open_time'))
+                    if resolved_open_time:
+                        start_time = resolved_open_time
+                    else:
+                        _append_missing_hours_note(candidate_note_suffixes, candidate['special_candidate_id'], day, 'open_time')
+                        should_skip = True
+                if not _normalize_time_value(end_time):
+                    resolved_close_time = _normalize_time_value(day_hours.get('close_time'))
+                    if resolved_close_time:
+                        end_time = resolved_close_time
+                    else:
+                        _append_missing_hours_note(candidate_note_suffixes, candidate['special_candidate_id'], day, 'close_time')
+                        should_skip = True
+                if should_skip:
+                    continue
+
             candidate_rows.append(
                 {
                     'candidate_id': candidate['special_candidate_id'],
@@ -391,6 +419,16 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                     'all_day': all_day,
                 }
             )
+
+    for candidate_id, note_suffixes in candidate_note_suffixes.items():
+        cursor.execute(
+            """
+            UPDATE special_candidate
+            SET notes = CONCAT(COALESCE(notes, ''), %s)
+            WHERE special_candidate_id = %s
+            """,
+            (''.join(note_suffixes), candidate_id),
+        )
 
     manual_filter_clause = "AND insert_method <> 'MANUAL'" if IGNORE_MANUAL_SPECIALS_ON_PUBLISH == 'Y' else ''
     cursor.execute(


### PR DESCRIPTION
### Motivation
- Ensure candidate specials with `all_day = 'N'` and missing `start_time`/`end_time` are published using the bar's `open_hours` for the corresponding day when available. 
- If per-day `open_time`/`close_time` is missing, skip publishing that specific day but still publish other days for the same candidate, and record the reason in `special_candidate.notes`.

### Description
- Added an `open_hours` lookup (`_build_open_hours_lookup`) and per-day resolution logic to `publish_special_candidate_run` in both `functions/dbSpecialSync/db_special_sync.py` and `functions/dbAdminSync/db_admin_sync.py` so missing times are backfilled from `open_hours` when `all_day = 'N'`.
- If a candidate day cannot resolve `start_time` or `end_time`, that day is skipped and a note is queued using a new helper `_append_missing_hours_note`, then appended to `special_candidate.notes` at the end of the publish flow using `UPDATE ... SET notes = CONCAT(COALESCE(notes, ''), ...)`.
- Preserve existing behavior where a candidate can expand to multiple day rows from `days_of_week` and allow other days to publish even if one day is skipped; also run the existing `_should_convert_to_all_day` check against `open_hours` before backfill logic.
- Changes applied symmetrically to the admin publish path so both automated and admin publishing flows behave consistently (files changed: `functions/dbSpecialSync/db_special_sync.py`, `functions/dbAdminSync/db_admin_sync.py`).

### Testing
- Ran syntax check: `python -m py_compile functions/dbSpecialSync/db_special_sync.py functions/dbAdminSync/db_admin_sync.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0db667ac0833081e7d1f07043aa4a)