### PR TITLE
Sort Bars Alphabetically from Backend

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -33,7 +33,7 @@ def query_bars(cursor):
               WHERE s.bar_id = b.bar_id
                 AND s.is_active = 'Y'
           )
-        ORDER BY neighborhood, name
+        ORDER BY name
     """)
     return cursor.fetchall()
 

--- a/js/render-home.js
+++ b/js/render-home.js
@@ -252,11 +252,6 @@ function getSortedFilteredBars(bars) {
       if (!query) return true;
       const name = (bar.name || '').toLowerCase();
       return name.includes(query);
-    })
-    .sort((a, b) => {
-      const neighborhoodCompare = (a.neighborhood || '').localeCompare(b.neighborhood || '', undefined, { sensitivity: 'base' });
-      if (neighborhoodCompare !== 0) return neighborhoodCompare;
-      return (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' });
     });
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the Bars tab shows all bars in a single global alphabetical order owned by the backend rather than applying additional client-side neighborhood ordering.

### Description
- Change the startup payload SQL in `getStartupData` to `ORDER BY name` so bars are returned in pure alphabetical order from the backend (`functions/getStartupData/get_startup_data.py`).
- Remove the frontend secondary sorting (neighborhood then name) from `getSortedFilteredBars` so the UI preserves the backend-provided ordering (`js/render-home.js`).
- Files modified: `functions/getStartupData/get_startup_data.py` and `js/render-home.js`.

### Testing
- Ran the automated test suite with `node tests/app.test.js`, and all tests passed (`19` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e6b924d08330a03e0cf81cdabfae)