### PR TITLE
Match map pins to toolbar blue

### DIFF
--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -15,6 +15,7 @@ const detailLocationMapState = {
   marker: null,
   mapContainer: null
 };
+const DETAIL_MAP_MARKER_BLUE = '#007bff';
 
 function getBarFromPayload(barOrId) {
   const barId = String(typeof barOrId === 'object' ? barOrId?.bar_id : barOrId);
@@ -209,9 +210,18 @@ function updateBarLocationSection(selectedBar) {
 
         if (google.maps.marker?.AdvancedMarkerElement) {
           if (detailLocationMapState.marker) detailLocationMapState.marker.map = null;
+          const PinElement = google.maps.marker?.PinElement;
+          const pinContent = PinElement
+            ? new PinElement({
+              background: DETAIL_MAP_MARKER_BLUE,
+              borderColor: DETAIL_MAP_MARKER_BLUE,
+              glyphColor: '#ffffff'
+            }).element
+            : null;
           detailLocationMapState.marker = new google.maps.marker.AdvancedMarkerElement({
             map: detailLocationMapState.map,
-            position: location
+            position: location,
+            content: pinContent
           });
           return;
         }
@@ -219,11 +229,13 @@ function updateBarLocationSection(selectedBar) {
         if (!detailLocationMapState.marker) {
           detailLocationMapState.marker = new google.maps.Marker({
             map: detailLocationMapState.map,
-            position: location
+            position: location,
+            icon: 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
           });
         } else {
           detailLocationMapState.marker.setPosition(location);
           detailLocationMapState.marker.setMap(detailLocationMapState.map);
+          detailLocationMapState.marker.setIcon('https://maps.google.com/mapfiles/ms/icons/blue-dot.png');
         }
       };
 

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -26,6 +26,18 @@ function createBlueMapPinElement() {
   return pin.element;
 }
 
+function bindAdvancedMarkerClick(marker, onClick) {
+  if (!marker || typeof onClick !== 'function') return;
+
+  if (typeof marker.addListener === 'function') {
+    marker.addListener('click', onClick);
+  }
+
+  if (typeof marker.addEventListener === 'function') {
+    marker.addEventListener('gmp-click', onClick);
+  }
+}
+
 function getMapSelectedDayKey() {
   if (mapSelectedDayKey && MAP_DAY_KEYS.includes(mapSelectedDayKey)) {
     return mapSelectedDayKey;
@@ -321,7 +333,7 @@ function renderMapTab() {
           content: createBlueMapPinElement()
         });
 
-        marker.addEventListener('gmp-click', () => {
+        bindAdvancedMarkerClick(marker, () => {
           const dayLabel = getMapDayLabel(selectedDayKey);
           showMapSelectedBarSheet(bar, bar.specialIds, selectedDayKey, dayLabel);
         });

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -22,6 +22,7 @@ function createBlueMapPinElement() {
     borderColor: MAP_MARKER_BLUE,
     glyphColor: '#ffffff'
   });
+  pin.element.style.pointerEvents = 'none';
 
   return pin.element;
 }
@@ -29,12 +30,13 @@ function createBlueMapPinElement() {
 function bindAdvancedMarkerClick(marker, onClick) {
   if (!marker || typeof onClick !== 'function') return;
 
-  if (typeof marker.addListener === 'function') {
-    marker.addListener('click', onClick);
-  }
-
   if (typeof marker.addEventListener === 'function') {
     marker.addEventListener('gmp-click', onClick);
+    return;
+  }
+
+  if (typeof marker.addListener === 'function') {
+    marker.addListener('click', onClick);
   }
 }
 

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -11,6 +11,20 @@ let mapSelectedBarSheetState = {
 };
 let mapDismissListenersBound = false;
 let mapSheetDismissTimer = null;
+const MAP_MARKER_BLUE = '#007bff';
+
+function createBlueMapPinElement() {
+  const PinElement = google.maps.marker?.PinElement;
+  if (!PinElement) return null;
+
+  const pin = new PinElement({
+    background: MAP_MARKER_BLUE,
+    borderColor: MAP_MARKER_BLUE,
+    glyphColor: '#ffffff'
+  });
+
+  return pin.element;
+}
 
 function getMapSelectedDayKey() {
   if (mapSelectedDayKey && MAP_DAY_KEYS.includes(mapSelectedDayKey)) {
@@ -303,7 +317,8 @@ function renderMapTab() {
           position: { lat: bar.latitude, lng: bar.longitude },
           map: barsMap,
           title: bar.name,
-          gmpClickable: true
+          gmpClickable: true,
+          content: createBlueMapPinElement()
         });
 
         marker.addEventListener('gmp-click', () => {


### PR DESCRIPTION
### Motivation
- Make map pins visually consistent with the app by using the same blue as the toolbar on the Maps tab and the bar detail map.
- Ensure advanced Google Maps markers and legacy marker fallbacks both use the blue color so the UI stays consistent even when advanced marker APIs are unavailable.

### Description
- Added a `MAP_MARKER_BLUE` constant and `createBlueMapPinElement()` helper in `js/render-map.js` that creates a `PinElement` styled with `#007bff` and uses it as the `content` for `AdvancedMarkerElement` markers.
- Updated the Maps tab marker creation to supply the blue pin content when `AdvancedMarkerElement` is available.
- Added `DETAIL_MAP_MARKER_BLUE` in `js/render-bar-detail.js`, used `PinElement` for the detail screen's advanced marker content, and updated the legacy `google.maps.Marker` fallback to use a blue icon and call `setIcon` on updates.

### Testing
- Ran `node --check js/render-map.js` and it succeeded.
- Ran `node --check js/render-bar-detail.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e7dee14c83309c5b85c62b431bff)