### PR TITLE
Use blue pin for map markers, improve advanced marker click handling, and add tests

### DIFF
--- a/js/render-bar-detail.js
+++ b/js/render-bar-detail.js
@@ -15,6 +15,7 @@ const detailLocationMapState = {
   marker: null,
   mapContainer: null
 };
+const DETAIL_MAP_MARKER_BLUE = '#007bff';
 
 function getBarFromPayload(barOrId) {
   const barId = String(typeof barOrId === 'object' ? barOrId?.bar_id : barOrId);
@@ -209,9 +210,18 @@ function updateBarLocationSection(selectedBar) {
 
         if (google.maps.marker?.AdvancedMarkerElement) {
           if (detailLocationMapState.marker) detailLocationMapState.marker.map = null;
+          const PinElement = google.maps.marker?.PinElement;
+          const pinContent = PinElement
+            ? new PinElement({
+              background: DETAIL_MAP_MARKER_BLUE,
+              borderColor: DETAIL_MAP_MARKER_BLUE,
+              glyphColor: '#ffffff'
+            }).element
+            : null;
           detailLocationMapState.marker = new google.maps.marker.AdvancedMarkerElement({
             map: detailLocationMapState.map,
-            position: location
+            position: location,
+            content: pinContent
           });
           return;
         }
@@ -219,11 +229,13 @@ function updateBarLocationSection(selectedBar) {
         if (!detailLocationMapState.marker) {
           detailLocationMapState.marker = new google.maps.Marker({
             map: detailLocationMapState.map,
-            position: location
+            position: location,
+            icon: 'https://maps.google.com/mapfiles/ms/icons/blue-dot.png'
           });
         } else {
           detailLocationMapState.marker.setPosition(location);
           detailLocationMapState.marker.setMap(detailLocationMapState.map);
+          detailLocationMapState.marker.setIcon('https://maps.google.com/mapfiles/ms/icons/blue-dot.png');
         }
       };
 

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -11,6 +11,33 @@ let mapSelectedBarSheetState = {
 };
 let mapDismissListenersBound = false;
 let mapSheetDismissTimer = null;
+let mapLastMarkerTapAt = 0;
+const MAP_MARKER_BLUE = '#007bff';
+
+function createBlueMapPinElement() {
+  const PinElement = google.maps.marker?.PinElement;
+  if (!PinElement) return null;
+
+  const pin = new PinElement({
+    background: MAP_MARKER_BLUE,
+    borderColor: MAP_MARKER_BLUE,
+    glyphColor: '#ffffff'
+  });
+
+  return pin.element;
+}
+
+function bindAdvancedMarkerClick(marker, onClick) {
+  if (!marker || typeof onClick !== 'function') return;
+
+  if (typeof marker.addListener === 'function') {
+    marker.addListener('click', onClick);
+  }
+
+  if (typeof marker.addEventListener === 'function') {
+    marker.addEventListener('gmp-click', onClick);
+  }
+}
 
 function getMapSelectedDayKey() {
   if (mapSelectedDayKey && MAP_DAY_KEYS.includes(mapSelectedDayKey)) {
@@ -203,6 +230,7 @@ function bindMapInteractionDismiss() {
   if (!barsMap || mapDismissListenersBound) return;
 
   const dismissIfOpen = () => {
+    if (Date.now() - mapLastMarkerTapAt < 300) return;
     if (!mapSelectedBarSheetState.barId) return;
     dismissMapSelectedBarSheetAnimated();
   };
@@ -303,10 +331,12 @@ function renderMapTab() {
           position: { lat: bar.latitude, lng: bar.longitude },
           map: barsMap,
           title: bar.name,
-          gmpClickable: true
+          gmpClickable: true,
+          content: createBlueMapPinElement()
         });
 
-        marker.addEventListener('gmp-click', () => {
+        bindAdvancedMarkerClick(marker, () => {
+          mapLastMarkerTapAt = Date.now();
           const dayLabel = getMapDayLabel(selectedDayKey);
           showMapSelectedBarSheet(bar, bar.specialIds, selectedDayKey, dayLabel);
         });

--- a/js/render-map.js
+++ b/js/render-map.js
@@ -203,13 +203,13 @@ function showMapSelectedBarSheet(bar, specialIds, dayKey, dayLabel) {
     card.appendChild(image);
   }
 
-  const cardContent = buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel);
-  if (!cardContent) {
+  const homeSpecials = buildHomeBarSpecials(bar, specialIds, dayKey, dayLabel);
+  if (!homeSpecials || !homeSpecials.content) {
     dismissMapSelectedBarSheet();
     return;
   }
 
-  card.appendChild(cardContent);
+  card.appendChild(homeSpecials.content);
   content.appendChild(card);
   if (window.lucide && typeof window.lucide.createIcons === 'function') {
     window.lucide.createIcons();

--- a/tests/render-map.test.js
+++ b/tests/render-map.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+function loadRenderMapContext() {
+  const listeners = {};
+  const mockMap = {
+    addListener(event, callback) {
+      listeners[event] = callback;
+    }
+  };
+
+  const context = {
+    console,
+    Date,
+    setTimeout,
+    clearTimeout,
+    startupPayload: {},
+    mapSelectedDayKey: null,
+    DAYS_FULL: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+    activeFilters: { neighborhoods: [], types: [] },
+    specialMatchesTypeFilters: () => true,
+    buildHomeBarSpecials: () => ({}),
+    animateTapAndNavigate: () => {},
+    showDetail: () => {},
+    currentTab: 'map',
+    document: { getElementById: () => null, createElement: () => ({}) },
+    window: {},
+    google: { maps: { marker: {} } }
+  };
+
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync('js/render-map.js', 'utf8'), context);
+  context.__mockMap = mockMap;
+  vm.runInContext('barsMap = __mockMap;', context);
+  return { context, listeners, mockMap };
+}
+
+test('bindAdvancedMarkerClick binds click and gmp-click handlers', () => {
+  const { context } = loadRenderMapContext();
+  const calls = [];
+  const marker = {
+    addListener(name) {
+      calls.push(name);
+    },
+    addEventListener(name) {
+      calls.push(name);
+    }
+  };
+
+  context.bindAdvancedMarkerClick(marker, () => {});
+  assert.deepEqual(calls, ['click', 'gmp-click']);
+});
+
+test('map click dismissal ignores immediate click after marker tap', () => {
+  const { context, listeners, mockMap } = loadRenderMapContext();
+  let dismissCalls = 0;
+
+  context.dismissMapSelectedBarSheetAnimated = () => { dismissCalls += 1; };
+  context.__mockMap = mockMap;
+  vm.runInContext('barsMap = __mockMap; mapDismissListenersBound = false; mapSelectedBarSheetState.barId = "1"; mapLastMarkerTapAt = Date.now();', context);
+
+  context.bindMapInteractionDismiss();
+  listeners.click();
+  assert.equal(dismissCalls, 0);
+});

--- a/tests/render-map.test.js
+++ b/tests/render-map.test.js
@@ -37,6 +37,41 @@ function loadRenderMapContext() {
   return { context, listeners, mockMap };
 }
 
+function createStrictDocument() {
+  const byId = new Map();
+  const makeElement = () => ({
+    __isElement: true,
+    children: [],
+    className: '',
+    style: {},
+    dataset: {},
+    classList: { add() {}, remove() {} },
+    appendChild(child) {
+      if (!child || child.__isElement !== true) {
+        throw new TypeError('appendChild expects an element');
+      }
+      this.children.push(child);
+    },
+    addEventListener() {},
+    setPointerCapture() {}
+  });
+
+  const document = {
+    createElement: makeElement,
+    getElementById(id) {
+      return byId.get(id) || null;
+    }
+  };
+
+  const sheet = makeElement();
+  sheet.style.display = 'none';
+  const content = makeElement();
+  byId.set('map-selected-card-sheet', sheet);
+  byId.set('map-selected-card-content', content);
+
+  return { document, sheet, content, makeElement };
+}
+
 test('bindAdvancedMarkerClick binds click and gmp-click handlers', () => {
   const { context } = loadRenderMapContext();
   const calls = [];
@@ -64,4 +99,17 @@ test('map click dismissal ignores immediate click after marker tap', () => {
   context.bindMapInteractionDismiss();
   listeners.click();
   assert.equal(dismissCalls, 0);
+});
+
+test('showMapSelectedBarSheet appends homeSpecials.content element', () => {
+  const { context } = loadRenderMapContext();
+  const { document, sheet, content, makeElement } = createStrictDocument();
+  context.document = document;
+  context.window = {};
+  context.buildHomeBarSpecials = () => ({ content: makeElement(), hasActiveOrUpcoming: true });
+
+  context.showMapSelectedBarSheet({ bar_id: 1, name: 'Test Bar' }, ['100'], 'MON', 'Monday');
+
+  assert.equal(sheet.style.display, '');
+  assert.equal(content.children.length, 1);
 });


### PR DESCRIPTION
### Motivation
- Standardize map marker appearance to a blue pin for both AdvancedMarkerElement and legacy markers to match UI styling.
- Ensure advanced marker click events are handled consistently across Google Maps APIs and prevent the map sheet from immediately dismissing after a marker tap.
- Add unit tests to cover marker event binding and dismissal timing behavior.

### Description
- Introduced `MAP_MARKER_BLUE` / `DETAIL_MAP_MARKER_BLUE` color constants and use a `PinElement` when available to render a blue pin for advanced markers via `content` in `render-map.js` and `render-bar-detail.js`.
- Added `createBlueMapPinElement()` helper and `bindAdvancedMarkerClick()` to centralize marker content creation and attach both `click` and `gmp-click` handlers.
- For legacy `google.maps.Marker` fallbacks, set the icon to the blue-dot PNG and ensure icon is applied on marker updates in `render-bar-detail.js`.
- Added `mapLastMarkerTapAt` timestamp and logic in `bindMapInteractionDismiss()` to ignore dismissals immediately following a marker tap.
- Added unit tests in `tests/render-map.test.js` to verify `bindAdvancedMarkerClick` binds both event types and that immediate dismissal after a marker tap is ignored.

### Testing
- Added `tests/render-map.test.js` with two tests: one asserting both `click` and `gmp-click` listeners are bound, and one asserting map click dismissal is ignored when the last marker tap was recent; both tests were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e7dee14c83309c5b85c62b431bff)