### PR TITLE
Show linked candidates and counts for rejected specials in admin UI and DB sync

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2077,7 +2077,6 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="type">Type${getSortIndicator('rejected-special-management', 'type')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="fetch_method">Method${getSortIndicator('rejected-special-management', 'fetch_method')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="source">Source${getSortIndicator('rejected-special-management', 'source')}</th>
-              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="candidate_matches">Candidate Matches${getSortIndicator('rejected-special-management', 'candidate_matches')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="linked_candidate_count">Linked Candidates${getSortIndicator('rejected-special-management', 'linked_candidate_count')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="insert_date">Last Seen${getSortIndicator('rejected-special-management', 'insert_date')}</th>
             </tr>
@@ -2095,7 +2094,6 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                 <td>${row.type || '—'}</td>
                 <td>${row.fetch_method || '—'}</td>
                 <td>${getSourceMarkup(row.source)}</td>
-                <td>${row.candidate_matches ?? 0}</td>
                 <td>${row.linked_candidate_count ?? 0}</td>
                 <td>${formatDateTime(row.insert_date)}</td>
               </tr>
@@ -2148,17 +2146,18 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         <table class="admin-special-table">
           <thead>
             <tr>
-              <th>Candidate ID</th><th>Status</th><th>Method</th><th>Insert Date</th><th>Description</th>
+              <th>Candidate ID</th><th>Run ID</th><th>Status</th><th>Method</th><th>Source</th><th>Insert Date</th>
             </tr>
           </thead>
           <tbody>
             ${linkedCandidates.map((candidate) => `
               <tr>
                 <td>${candidate.special_candidate_id || '—'}</td>
+                <td>${candidate.run_id || '—'}</td>
                 <td>${candidate.approval_status || '—'}</td>
                 <td>${candidate.fetch_method || '—'}</td>
+                <td>${getSourceMarkup(candidate.source)}</td>
                 <td>${formatDateTime(candidate.insert_date)}</td>
-                <td>${candidate.description || '—'}</td>
               </tr>
             `).join('')}
           </tbody>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2077,8 +2077,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="type">Type${getSortIndicator('rejected-special-management', 'type')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="fetch_method">Method${getSortIndicator('rejected-special-management', 'fetch_method')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="source">Source${getSortIndicator('rejected-special-management', 'source')}</th>
-              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="web_ai_search_matches">Web AI Search Matches${getSortIndicator('rejected-special-management', 'web_ai_search_matches')}</th>
-              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="web_crawl_matches">Web Crawl Matches${getSortIndicator('rejected-special-management', 'web_crawl_matches')}</th>
+              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="candidate_matches">Candidate Matches${getSortIndicator('rejected-special-management', 'candidate_matches')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="linked_candidate_count">Linked Candidates${getSortIndicator('rejected-special-management', 'linked_candidate_count')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="insert_date">Last Seen${getSortIndicator('rejected-special-management', 'insert_date')}</th>
             </tr>
@@ -2096,8 +2095,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                 <td>${row.type || '—'}</td>
                 <td>${row.fetch_method || '—'}</td>
                 <td>${getSourceMarkup(row.source)}</td>
-                <td>${row.web_ai_search_matches ?? 0}</td>
-                <td>${row.web_crawl_matches ?? 0}</td>
+                <td>${row.candidate_matches ?? 0}</td>
                 <td>${row.linked_candidate_count ?? 0}</td>
                 <td>${formatDateTime(row.insert_date)}</td>
               </tr>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -85,6 +85,8 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     specialManagementSort: { key: 'neighborhood', direction: 'asc' },
     barManagementSort: { key: 'name', direction: 'asc' },
     rejectedSpecialSort: { key: 'neighborhood', direction: 'asc' },
+    actionRejectedSpecialId: null,
+    showRejectedDetails: false,
     creatingSpecial: false,
     savingNewSpecial: false,
     newSpecialForm: {
@@ -117,6 +119,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     state.currentView = 'home';
     state.errorMessage = '';
     state.actionRejectedCandidateId = null;
+        state.actionRejectedSpecialId = null;
     state.actionSpecialId = null;
     state.detailSpecials = [];
     state.detailEditing = false;
@@ -2076,12 +2079,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="source">Source${getSortIndicator('rejected-special-management', 'source')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="web_ai_search_matches">Web AI Search Matches${getSortIndicator('rejected-special-management', 'web_ai_search_matches')}</th>
               <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="web_crawl_matches">Web Crawl Matches${getSortIndicator('rejected-special-management', 'web_crawl_matches')}</th>
-              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="insert_date">Insert Date${getSortIndicator('rejected-special-management', 'insert_date')}</th>
+              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="linked_candidate_count">Linked Candidates${getSortIndicator('rejected-special-management', 'linked_candidate_count')}</th>
+              <th class="admin-sortable-header" data-sort-table="rejected-special-management" data-sort-key="insert_date">Last Seen${getSortIndicator('rejected-special-management', 'insert_date')}</th>
             </tr>
           </thead>
           <tbody>
             ${rows.map((row) => `
-              <tr class="admin-special-row" data-rejected-special-candidate-row="${row.special_candidate_id}">
+              <tr class="admin-special-row" data-rejected-special-row="${row.reject_id}">
                 <td>${row.neighborhood || '—'}</td>
                 <td>${row.bar_name || '—'}</td>
                 <td>${row.description || '—'}</td>
@@ -2094,6 +2098,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                 <td>${getSourceMarkup(row.source)}</td>
                 <td>${row.web_ai_search_matches ?? 0}</td>
                 <td>${row.web_crawl_matches ?? 0}</td>
+                <td>${row.linked_candidate_count ?? 0}</td>
                 <td>${formatDateTime(row.insert_date)}</td>
               </tr>
             `).join('')}
@@ -2106,6 +2111,8 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
   function getRejectedSpecialActionMenuMarkup() {
     if (!state.actionRejectedCandidateId) return '';
+    const selectedRow = state.rejectedSpecials.find((row) => Number(row.reject_id) === Number(state.actionRejectedSpecialId));
+    const linkedCandidates = Array.isArray(selectedRow?.linked_candidates) ? selectedRow.linked_candidates : [];
     return `
       <div class="admin-modal-backdrop" data-close-rejected-action-menu="true">
         <div class="admin-modal" role="dialog" aria-label="Rejected special actions">
@@ -2118,8 +2125,46 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           >
             Remove Rejected Special Candidate
           </button>
+          <button
+            type="button"
+            class="admin-tool-button"
+            data-rejected-special-action="view-details"
+          >
+            View Linked Candidates (${linkedCandidates.length})
+          </button>
+          ${state.showRejectedDetails ? getRejectedSpecialDetailsMarkup(selectedRow) : ''}
           <button type="button" class="admin-secondary-btn" data-close-rejected-action-menu="true">Close</button>
         </div>
+      </div>
+    `;
+  }
+
+
+
+  function getRejectedSpecialDetailsMarkup(selectedRow) {
+    if (!selectedRow || !state.actionRejectedSpecialId) return '';
+    const linkedCandidates = Array.isArray(selectedRow.linked_candidates) ? selectedRow.linked_candidates : [];
+    if (!linkedCandidates.length) return '<p class="admin-empty">No linked candidates found.</p>';
+    return `
+      <div class="admin-table-wrap" style="max-height: 240px; margin-top: 0.75rem;">
+        <table class="admin-special-table">
+          <thead>
+            <tr>
+              <th>Candidate ID</th><th>Status</th><th>Method</th><th>Insert Date</th><th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${linkedCandidates.map((candidate) => `
+              <tr>
+                <td>${candidate.special_candidate_id || '—'}</td>
+                <td>${candidate.approval_status || '—'}</td>
+                <td>${candidate.fetch_method || '—'}</td>
+                <td>${formatDateTime(candidate.insert_date)}</td>
+                <td>${candidate.description || '—'}</td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
       </div>
     `;
   }
@@ -2147,11 +2192,15 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
       });
     }
 
-    screenElement.querySelectorAll('[data-rejected-special-candidate-row]').forEach((row) => {
+    screenElement.querySelectorAll('[data-rejected-special-row]').forEach((row) => {
       row.addEventListener('click', () => {
-        const specialCandidateId = Number(row.getAttribute('data-rejected-special-candidate-row'));
-        if (!specialCandidateId) return;
-        state.actionRejectedCandidateId = specialCandidateId;
+        const rejectId = Number(row.getAttribute('data-rejected-special-row'));
+        if (!rejectId) return;
+        const selectedRow = state.rejectedSpecials.find((item) => Number(item.reject_id) === rejectId);
+        if (!selectedRow) return;
+        state.actionRejectedSpecialId = rejectId;
+        state.actionRejectedCandidateId = Number(selectedRow.special_candidate_id) || null;
+        state.showRejectedDetails = false;
         render();
       });
     });
@@ -2160,6 +2209,8 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
       element.addEventListener('click', (event) => {
         if (event.currentTarget !== event.target) return;
         state.actionRejectedCandidateId = null;
+        state.actionRejectedSpecialId = null;
+        state.showRejectedDetails = false;
         render();
       });
     });
@@ -2169,7 +2220,16 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         const specialCandidateId = Number(button.getAttribute('data-special-candidate-id'));
         if (!specialCandidateId) return;
         state.actionRejectedCandidateId = null;
+        state.actionRejectedSpecialId = null;
+        state.showRejectedDetails = false;
         await removeRejectedSpecialCandidate(specialCandidateId);
+      });
+    });
+
+    screenElement.querySelectorAll('[data-rejected-special-action="view-details"]').forEach((button) => {
+      button.addEventListener('click', () => {
+        state.showRejectedDetails = !state.showRejectedDetails;
+        render();
       });
     });
   }

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -633,34 +633,57 @@ def get_rejected_special_candidates(cursor):
     cursor.execute(
         """
         SELECT
-            sc.special_candidate_id,
-            sc.bar_id,
+            scr.reject_id,
+            scr.bar_id,
             b.name AS bar_name,
-            sc.neighborhood,
-            sc.description,
-            sc.days_of_week,
-            sc.type,
-            sc.start_time,
-            sc.end_time,
-            sc.all_day,
-            sc.is_recurring,
-            sc.date,
-            sc.fetch_method,
-            sc.source,
-            sc.approval_status,
-            sc.insert_date,
-            COALESCE(SUM(CASE WHEN scr.fetch_method = 'web_ai_search' THEN 1 ELSE 0 END), 0) AS web_ai_search_matches,
-            COALESCE(SUM(CASE WHEN scr.fetch_method = 'web_crawl' THEN 1 ELSE 0 END), 0) AS web_crawl_matches
-        FROM special_candidate sc
-        JOIN bar b ON b.bar_id = sc.bar_id
-        LEFT JOIN special_candidate_reject_join scrj ON scrj.special_candidate_id = sc.special_candidate_id
-        LEFT JOIN special_candidate_reject scr ON scr.reject_id = scrj.reject_id
-        WHERE sc.approval_status = 'REJECTED'
+            nb.name AS neighborhood,
+            scr.description,
+            scr.days_of_week,
+            COALESCE(MAX(sc.type), '') AS type,
+            scr.start_time,
+            scr.end_time,
+            scr.all_day,
+            scr.is_recurring,
+            scr.date,
+            scr.fetch_method,
+            scr.source,
+            COALESCE(SUM(CASE WHEN linked_sc.fetch_method = 'web_ai_search' THEN 1 ELSE 0 END), 0) AS web_ai_search_matches,
+            COALESCE(SUM(CASE WHEN linked_sc.fetch_method = 'web_crawl' THEN 1 ELSE 0 END), 0) AS web_crawl_matches,
+            MAX(scrj.special_candidate_id) AS latest_special_candidate_id,
+            MAX(linked_sc.insert_date) AS last_seen_candidate_insert_date,
+            COUNT(DISTINCT scrj.special_candidate_id) AS linked_candidate_count
+        FROM special_candidate_reject scr
+        JOIN bar b ON b.bar_id = scr.bar_id
+        LEFT JOIN neighborhood nb ON nb.neighborhood_id = b.neighborhood_id
+        LEFT JOIN special_candidate_reject_join scrj ON scrj.reject_id = scr.reject_id
+        LEFT JOIN special_candidate linked_sc ON linked_sc.special_candidate_id = scrj.special_candidate_id
         GROUP BY
-            sc.special_candidate_id,
-            sc.bar_id,
+            scr.reject_id,
+            scr.bar_id,
             b.name,
-            sc.neighborhood,
+            nb.name,
+            scr.description,
+            scr.days_of_week,
+            scr.start_time,
+            scr.end_time,
+            scr.all_day,
+            scr.is_recurring,
+            scr.date,
+            scr.fetch_method,
+            scr.source
+        ORDER BY
+            neighborhood ASC,
+            b.name ASC,
+            scr.reject_id DESC
+        """
+    )
+    rows = cursor.fetchall()
+
+    cursor.execute(
+        """
+        SELECT
+            scrj.reject_id,
+            sc.special_candidate_id,
             sc.description,
             sc.days_of_week,
             sc.type,
@@ -673,18 +696,42 @@ def get_rejected_special_candidates(cursor):
             sc.source,
             sc.approval_status,
             sc.insert_date
-        ORDER BY
-            sc.neighborhood ASC,
-            b.name ASC,
-            sc.special_candidate_id DESC
+        FROM special_candidate_reject_join scrj
+        JOIN special_candidate sc ON sc.special_candidate_id = scrj.special_candidate_id
+        ORDER BY sc.insert_date DESC, sc.special_candidate_id DESC
         """
     )
-    rows = cursor.fetchall()
+    linked_rows = cursor.fetchall()
+    linked_by_reject_id = {}
+    for linked_row in linked_rows:
+        reject_id = linked_row.get('reject_id')
+        if not reject_id:
+            continue
+        linked_by_reject_id.setdefault(reject_id, []).append(
+            {
+                'special_candidate_id': linked_row.get('special_candidate_id'),
+                'description': linked_row.get('description'),
+                'days_of_week': _parse_days_of_week(linked_row.get('days_of_week')),
+                'type': linked_row.get('type'),
+                'start_time': _normalize_time_value(linked_row.get('start_time')) or None,
+                'end_time': _normalize_time_value(linked_row.get('end_time')) or None,
+                'all_day': linked_row.get('all_day'),
+                'is_recurring': linked_row.get('is_recurring'),
+                'date': linked_row.get('date').isoformat() if hasattr(linked_row.get('date'), 'isoformat') and linked_row.get('date') else linked_row.get('date'),
+                'fetch_method': linked_row.get('fetch_method'),
+                'source': linked_row.get('source'),
+                'approval_status': linked_row.get('approval_status'),
+                'insert_date': linked_row.get('insert_date').isoformat() if linked_row.get('insert_date') else None,
+            }
+        )
+
     specials = []
     for row in rows:
+        reject_id = row.get('reject_id')
         specials.append(
             {
-                'special_candidate_id': row.get('special_candidate_id'),
+                'reject_id': reject_id,
+                'special_candidate_id': row.get('latest_special_candidate_id'),
                 'bar_id': row.get('bar_id'),
                 'bar_name': row.get('bar_name'),
                 'neighborhood': row.get('neighborhood'),
@@ -698,10 +745,11 @@ def get_rejected_special_candidates(cursor):
                 'date': row.get('date').isoformat() if hasattr(row.get('date'), 'isoformat') and row.get('date') else row.get('date'),
                 'fetch_method': row.get('fetch_method'),
                 'source': row.get('source'),
-                'approval_status': row.get('approval_status'),
-                'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
+                'insert_date': row.get('last_seen_candidate_insert_date').isoformat() if row.get('last_seen_candidate_insert_date') else None,
                 'web_ai_search_matches': int(row.get('web_ai_search_matches') or 0),
                 'web_crawl_matches': int(row.get('web_crawl_matches') or 0),
+                'linked_candidate_count': int(row.get('linked_candidate_count') or 0),
+                'linked_candidates': linked_by_reject_id.get(reject_id, []),
             }
         )
     return {'specials': specials, 'special_count': len(specials)}

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -639,7 +639,7 @@ def get_rejected_special_candidates(cursor):
             b.neighborhood AS neighborhood,
             scr.description,
             scr.days_of_week,
-            COALESCE(MAX(sc.type), '') AS type,
+            COALESCE(MAX(linked_sc.type), '') AS type,
             scr.start_time,
             scr.end_time,
             scr.all_day,

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -636,7 +636,7 @@ def get_rejected_special_candidates(cursor):
             scr.reject_id,
             scr.bar_id,
             b.name AS bar_name,
-            nb.name AS neighborhood,
+            b.neighborhood AS neighborhood,
             scr.description,
             scr.days_of_week,
             COALESCE(MAX(sc.type), '') AS type,
@@ -654,14 +654,13 @@ def get_rejected_special_candidates(cursor):
             COUNT(DISTINCT scrj.special_candidate_id) AS linked_candidate_count
         FROM special_candidate_reject scr
         JOIN bar b ON b.bar_id = scr.bar_id
-        LEFT JOIN neighborhood nb ON nb.neighborhood_id = b.neighborhood_id
         LEFT JOIN special_candidate_reject_join scrj ON scrj.reject_id = scr.reject_id
         LEFT JOIN special_candidate linked_sc ON linked_sc.special_candidate_id = scrj.special_candidate_id
         GROUP BY
             scr.reject_id,
             scr.bar_id,
             b.name,
-            nb.name,
+            b.neighborhood,
             scr.description,
             scr.days_of_week,
             scr.start_time,

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -647,7 +647,6 @@ def get_rejected_special_candidates(cursor):
             scr.date,
             scr.fetch_method,
             scr.source,
-            COUNT(scrj.special_candidate_id) AS candidate_matches,
             MAX(scrj.special_candidate_id) AS latest_special_candidate_id,
             MAX(linked_sc.insert_date) AS last_seen_candidate_insert_date,
             COUNT(DISTINCT scrj.special_candidate_id) AS linked_candidate_count
@@ -682,14 +681,7 @@ def get_rejected_special_candidates(cursor):
         SELECT
             scrj.reject_id,
             sc.special_candidate_id,
-            sc.description,
-            sc.days_of_week,
-            sc.type,
-            sc.start_time,
-            sc.end_time,
-            sc.all_day,
-            sc.is_recurring,
-            sc.date,
+            sc.run_id,
             sc.fetch_method,
             sc.source,
             sc.approval_status,
@@ -708,14 +700,7 @@ def get_rejected_special_candidates(cursor):
         linked_by_reject_id.setdefault(reject_id, []).append(
             {
                 'special_candidate_id': linked_row.get('special_candidate_id'),
-                'description': linked_row.get('description'),
-                'days_of_week': _parse_days_of_week(linked_row.get('days_of_week')),
-                'type': linked_row.get('type'),
-                'start_time': _normalize_time_value(linked_row.get('start_time')) or None,
-                'end_time': _normalize_time_value(linked_row.get('end_time')) or None,
-                'all_day': linked_row.get('all_day'),
-                'is_recurring': linked_row.get('is_recurring'),
-                'date': linked_row.get('date').isoformat() if hasattr(linked_row.get('date'), 'isoformat') and linked_row.get('date') else linked_row.get('date'),
+                'run_id': linked_row.get('run_id'),
                 'fetch_method': linked_row.get('fetch_method'),
                 'source': linked_row.get('source'),
                 'approval_status': linked_row.get('approval_status'),
@@ -744,7 +729,6 @@ def get_rejected_special_candidates(cursor):
                 'fetch_method': row.get('fetch_method'),
                 'source': row.get('source'),
                 'insert_date': row.get('last_seen_candidate_insert_date').isoformat() if row.get('last_seen_candidate_insert_date') else None,
-                'candidate_matches': int(row.get('candidate_matches') or 0),
                 'linked_candidate_count': int(row.get('linked_candidate_count') or 0),
                 'linked_candidates': linked_by_reject_id.get(reject_id, []),
             }

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -647,8 +647,7 @@ def get_rejected_special_candidates(cursor):
             scr.date,
             scr.fetch_method,
             scr.source,
-            COALESCE(SUM(CASE WHEN linked_sc.fetch_method = 'web_ai_search' THEN 1 ELSE 0 END), 0) AS web_ai_search_matches,
-            COALESCE(SUM(CASE WHEN linked_sc.fetch_method = 'web_crawl' THEN 1 ELSE 0 END), 0) AS web_crawl_matches,
+            COUNT(scrj.special_candidate_id) AS candidate_matches,
             MAX(scrj.special_candidate_id) AS latest_special_candidate_id,
             MAX(linked_sc.insert_date) AS last_seen_candidate_insert_date,
             COUNT(DISTINCT scrj.special_candidate_id) AS linked_candidate_count
@@ -745,8 +744,7 @@ def get_rejected_special_candidates(cursor):
                 'fetch_method': row.get('fetch_method'),
                 'source': row.get('source'),
                 'insert_date': row.get('last_seen_candidate_insert_date').isoformat() if row.get('last_seen_candidate_insert_date') else None,
-                'web_ai_search_matches': int(row.get('web_ai_search_matches') or 0),
-                'web_crawl_matches': int(row.get('web_crawl_matches') or 0),
+                'candidate_matches': int(row.get('candidate_matches') or 0),
                 'linked_candidate_count': int(row.get('linked_candidate_count') or 0),
                 'linked_candidates': linked_by_reject_id.get(reject_id, []),
             }


### PR DESCRIPTION
### Motivation
- Provide better visibility into rejected special groups by surfacing linked candidate counts and the last-seen timestamp for each rejected special group in the admin UI. 
- Allow inspectors to view the list of special candidates that are linked to a rejected special group to assist triage and removal actions. 

### Description
- Update DB sync query logic in `get_rejected_special_candidates` to aggregate `special_candidate_reject` rows, include `reject_id`, compute `linked_candidate_count`, and return `last_seen_candidate_insert_date` and `latest_special_candidate_id`, and collect linked candidate rows per `reject_id` into `linked_candidates` objects. 
- Change the rejected-special SQL path to read from `special_candidate_reject`/`special_candidate_reject_join` with appropriate joins and grouping, and add a second query to fetch linked special candidates ordered by `insert_date`. 
- Update the admin front-end in `admin/admin.js` to store `actionRejectedSpecialId` and `showRejectedDetails`, change row attributes from `data-rejected-special-candidate-row` to `data-rejected-special-row`, show a new `Linked Candidates` column and a `Last Seen` column, and add a modal action to toggle viewing linked candidates details. 
- Add `getRejectedSpecialDetailsMarkup` to render a small table of linked special candidates, and wire up click handlers to open/close the details view and to set the selected rejected-special context. 

### Testing
- Ran the project's automated backend unit tests focusing on `dbAdminSync` which completed successfully. 
- Ran frontend linting and the admin view automated tests/smoke checks which passed without errors. 
- Confirmed the updated DB query returns aggregated rows and the API payload contains `linked_candidate_count` and `linked_candidates` in automated integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22dbb3a908330ac1287e85d421e41)