### PR TITLE
Store source special_candidate_id on `special` and remove `approved_special_id` usage

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -244,19 +244,8 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     )
     existing_specials = cursor.fetchall()
 
-    approved_candidate_ids = [candidate['special_candidate_id'] for candidate in approved_candidates if candidate.get('special_candidate_id')]
-    for candidate_id in approved_candidate_ids:
-        cursor.execute(
-            """
-            UPDATE special_candidate
-            SET approved_special_id = NULL
-            WHERE special_candidate_id = %s
-            """,
-            (candidate_id,),
-        )
-
     matched_special_ids = set()
-    candidate_to_special_ids = {}
+    special_to_candidate_id = {}
     unmatched_candidates = []
     for candidate in candidate_rows:
         matched_id = None
@@ -268,7 +257,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 break
         if matched_id is not None:
             matched_special_ids.add(matched_id)
-            candidate_to_special_ids.setdefault(candidate['candidate_id'], set()).add(matched_id)
+            special_to_candidate_id[matched_id] = candidate['candidate_id']
         else:
             unmatched_candidates.append(candidate)
 
@@ -289,8 +278,8 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
         cursor.execute(
             """
             INSERT INTO special
-            (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method, is_active)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'Y')
+            (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method, is_active, special_candidate_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'Y', %s)
             """,
             (
                 bar_id,
@@ -301,20 +290,20 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 candidate.get('description'),
                 candidate.get('type'),
                 'AUTO',
+                candidate['candidate_id'],
             ),
         )
         inserted_special_count += 1
-        candidate_to_special_ids.setdefault(candidate['candidate_id'], set()).add(cursor.lastrowid)
+        special_to_candidate_id[cursor.lastrowid] = candidate['candidate_id']
 
-    for candidate_id, special_ids in candidate_to_special_ids.items():
-        approved_special_id = min(special_ids) if special_ids else None
+    for special_id, candidate_id in special_to_candidate_id.items():
         cursor.execute(
             """
-            UPDATE special_candidate
-            SET approved_special_id = %s
-            WHERE special_candidate_id = %s
+            UPDATE special
+            SET special_candidate_id = %s
+            WHERE special_id = %s
             """,
-            (approved_special_id, candidate_id),
+            (candidate_id, special_id),
         )
 
     deactivated_special_count = len(existing_specials) - len(matched_special_ids)
@@ -552,11 +541,7 @@ def detect_duplicate_specials(cursor, bar_id: int = None) -> Dict[str, object]:
         FROM special s
         JOIN bar b ON b.bar_id = s.bar_id
         LEFT JOIN special_candidate sc
-            ON sc.special_candidate_id = (
-                SELECT MAX(sc2.special_candidate_id)
-                FROM special_candidate sc2
-                WHERE sc2.approved_special_id = s.special_id
-            )
+            ON sc.special_candidate_id = s.special_candidate_id
         WHERE {where_clause}
         ORDER BY s.bar_id, s.day_of_week, s.type, s.special_id
         """,
@@ -948,7 +933,7 @@ def get_all_specials(cursor):
         cursor.execute(
             f"""
             SELECT
-                sc.approved_special_id,
+                s.special_id,
                 sc.special_candidate_id,
                 sc.confidence,
                 sc.fetch_method,
@@ -959,19 +944,21 @@ def get_all_specials(cursor):
                 sc.insert_date,
                 scr.run_id,
                 scr.published_at
-            FROM special_candidate sc
+            FROM special s
+            LEFT JOIN special_candidate sc
+                ON sc.special_candidate_id = s.special_candidate_id
             LEFT JOIN special_candidate_run scr
                 ON scr.run_id = sc.run_id
-            WHERE sc.approved_special_id IN ({placeholders})
+            WHERE s.special_id IN ({placeholders})
             ORDER BY
-                sc.approved_special_id ASC,
+                s.special_id ASC,
                 sc.approval_date DESC,
                 sc.special_candidate_id DESC
             """,
             special_ids,
         )
         for row in cursor.fetchall():
-            special_id = row.get('approved_special_id')
+            special_id = row.get('special_id')
             if not special_id:
                 continue
             candidate_rows_by_special.setdefault(special_id, []).append(
@@ -1333,15 +1320,6 @@ def delete_special(cursor, event):
     special_id = event.get('special_id')
     if not special_id:
         raise ValueError('special_id is required for delete_special')
-
-    cursor.execute(
-        """
-        UPDATE special_candidate
-        SET approved_special_id = NULL
-        WHERE approved_special_id = %s
-        """,
-        (special_id,),
-    )
 
     cursor.execute(
         """

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -271,7 +271,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
     for candidate in candidates:
         approval_status = 'NOT_APPROVED'
         approval_date = None
-        approved_special_id = None
         confidence = _parse_confidence(candidate.get('confidence'))
 
         matched_reject_ids = [
@@ -296,8 +295,8 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         cursor.execute(
             """
             INSERT INTO special_candidate
-            (run_id, bar_id, bar_name, neighborhood, description, type, days_of_week, start_time, end_time, all_day, is_recurring, date, fetch_method, source, confidence, notes, approval_status, approval_date, approved_special_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            (run_id, bar_id, bar_name, neighborhood, description, type, days_of_week, start_time, end_time, all_day, is_recurring, date, fetch_method, source, confidence, notes, approval_status, approval_date)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 run_id,
@@ -318,7 +317,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                 candidate.get('notes'),
                 approval_status,
                 approval_date,
-                approved_special_id,
             ),
         )
         candidate_id = cursor.lastrowid
@@ -464,19 +462,8 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             special['start_time'] = None
             special['end_time'] = None
 
-    approved_candidate_ids = [candidate['special_candidate_id'] for candidate in approved_candidates if candidate.get('special_candidate_id')]
-    for candidate_id in approved_candidate_ids:
-        cursor.execute(
-            """
-            UPDATE special_candidate
-            SET approved_special_id = NULL
-            WHERE special_candidate_id = %s
-            """,
-            (candidate_id,),
-        )
-
     matched_special_ids = set()
-    candidate_to_special_ids = {}
+    special_to_candidate_id = {}
     unmatched_candidates = []
     for candidate in candidate_rows:
         matched_id = None
@@ -488,7 +475,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 break
         if matched_id is not None:
             matched_special_ids.add(matched_id)
-            candidate_to_special_ids.setdefault(candidate['candidate_id'], set()).add(matched_id)
+            special_to_candidate_id[matched_id] = candidate['candidate_id']
         else:
             unmatched_candidates.append(candidate)
 
@@ -529,8 +516,8 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
         cursor.execute(
             """
             INSERT INTO special
-            (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method, is_active)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'Y')
+            (bar_id, day_of_week, all_day, start_time, end_time, description, type, insert_method, is_active, special_candidate_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'Y', %s)
             """,
             (
                 bar_id,
@@ -541,20 +528,20 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 candidate.get('description'),
                 candidate.get('type'),
                 'AUTO',
+                candidate['candidate_id'],
             ),
         )
         inserted_special_count += 1
-        candidate_to_special_ids.setdefault(candidate['candidate_id'], set()).add(cursor.lastrowid)
+        special_to_candidate_id[cursor.lastrowid] = candidate['candidate_id']
 
-    for candidate_id, special_ids in candidate_to_special_ids.items():
-        approved_special_id = min(special_ids) if special_ids else None
+    for special_id, candidate_id in special_to_candidate_id.items():
         cursor.execute(
             """
-            UPDATE special_candidate
-            SET approved_special_id = %s
-            WHERE special_candidate_id = %s
+            UPDATE special
+            SET special_candidate_id = %s
+            WHERE special_id = %s
             """,
-            (approved_special_id, candidate_id),
+            (candidate_id, special_id),
         )
 
     deactivated_special_count = sum(


### PR DESCRIPTION
### Motivation
- Deprecate the `approved_special_id` field on `special_candidate` and instead record the candidate provenance on the canonical `special` row so each `special` stores the `special_candidate_id` used when it was created.
- Ensure publish and admin flows can resolve candidate metadata from the `special` table rather than relying on back-references from candidates.

### Description
- Stop writing `approved_special_id` when inserting candidates in `insert_special_candidate` by removing that column from the `INSERT` and parameters in `functions/dbSpecialSync/db_special_sync.py`. 
- When publishing candidates, write the source candidate id into `special.special_candidate_id` for both matched existing `special` rows and newly inserted `special` rows in `functions/dbSpecialSync/db_special_sync.py` and `functions/dbAdminSync/db_admin_sync.py`.
- Update admin query paths (`detect_duplicate_specials`, `get_all_specials`, and related joins) to join `special_candidate` via `special.special_candidate_id` and to select candidate metadata from that join in `functions/dbAdminSync/db_admin_sync.py`.
- Remove stale cleanup logic that previously nulled `special_candidate.approved_special_id` in the `delete_special` flow in `functions/dbAdminSync/db_admin_sync.py`.

### Testing
- Ran `python -m py_compile functions/dbSpecialSync/db_special_sync.py functions/dbAdminSync/db_admin_sync.py` and compilation completed successfully. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f239052278833099e7ef70bd0ee735)