### PR TITLE
Show auto-rejected pending specials as read-only cards

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1135,8 +1135,10 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         const candidateId = Number(special.special_candidate_id);
         const approvalStatus = String(special.approval_status || '').trim().toUpperCase();
         const isAutoApproved = approvalStatus === 'AUTO_APPROVED';
+        const isAutoRejected = approvalStatus === 'AUTO_REJECTED';
         const isUpdating = state.updatingCandidateId === candidateId;
-        const isEditing = !isAutoApproved && state.editingCandidateId === candidateId;
+        const isReadOnlyCandidate = isAutoApproved || isAutoRejected;
+        const isEditing = !isReadOnlyCandidate && state.editingCandidateId === candidateId;
         const confidence = special.confidence === null || special.confidence === undefined ? '—' : String(special.confidence);
         const editableValue = (field, fallback = '—') => {
           const value = special[field] ?? '';
@@ -1191,7 +1193,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
-            ${(isEditing || isAutoApproved) ? '' : `
+            ${(isEditing || isReadOnlyCandidate) ? '' : `
               <button class="admin-icon-btn" type="button" aria-label="Edit special candidate" title="Edit" data-candidate-action="edit" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>
                 &#8943;
               </button>
@@ -1209,7 +1211,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
             <p><strong>Method:</strong> ${special.fetch_method || '—'}</p>
             <p><strong>Source:</strong> ${getSourceMarkup(special.source)}</p>
             <p><strong>Notes:</strong> ${special.notes || '—'}</p>
-            ${isAutoApproved
+            ${isReadOnlyCandidate
               ? ''
               : `<div class="admin-actions-row">
                   ${isEditing

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -361,7 +361,7 @@ def get_unapproved_special_candidates(cursor):
         FROM special_candidate sc
         JOIN special_candidate_run scr ON scr.run_id = sc.run_id
         JOIN bar b ON b.bar_id = scr.bar_id
-        WHERE sc.approval_status IN ('NOT_APPROVED', 'AUTO_APPROVED')
+        WHERE sc.approval_status IN ('NOT_APPROVED', 'AUTO_APPROVED', 'AUTO_REJECTED')
             AND COALESCE(sc.is_recurring, 'Y') = 'Y'
             AND sc.run_id IN (
                 SELECT DISTINCT sc2.run_id


### PR DESCRIPTION
### Motivation
- Auto-rejected specials should still appear in the "Specials Pending Approval" admin tool but be displayed the same way as auto-approved specials (no moderation tools or inline editing). 

### Description
- Updated `admin/admin.js` to treat `AUTO_REJECTED` candidates as read-only by adding `isAutoRejected` and `isReadOnlyCandidate = isAutoApproved || isAutoRejected` and using that flag in rendering. 
- Adjusted the candidate card markup to hide the kebab edit button, hide approve/reject/action buttons, and prevent entering inline edit mode for read-only candidates while still rendering them in the run. 

### Testing
- Ran `node --check admin/admin.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23bee8d248330958a202104379edf)