### PR TITLE
Add special candidate matching workflow and admin match actions

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -389,6 +389,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           insert_method: special.insert_method,
           insert_date: special.insert_date,
           update_date: special.update_date,
+          matched_candidate_count: 0,
           daySet: new Set(),
           specials: []
         });
@@ -396,6 +397,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
       const row = grouped.get(key);
       row.specials.push(special);
+      row.matched_candidate_count += Number(special.matched_candidate_count || 0);
       row.daySet.add(normalizeDay(special.day_of_week));
 
       const rowInsert = toTimestamp(row.insert_date);
@@ -1211,6 +1213,8 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
             <p><strong>Method:</strong> ${special.fetch_method || '—'}</p>
             <p><strong>Source:</strong> ${getSourceMarkup(special.source)}</p>
             <p><strong>Notes:</strong> ${special.notes || '—'}</p>
+            <p><strong>Match Status:</strong> ${special.match_status || 'NOT_MATCHED'}</p>
+            ${(special.matched_specials || []).length ? `<p><strong>Matched Specials:</strong> ${(special.matched_specials || []).map((matched) => `#${matched.special_id} ${matched.day_of_week} — ${matched.description || '—'}`).join('<br/>')}</p>` : ''}
             ${isReadOnlyCandidate
               ? ''
               : `<div class="admin-actions-row">
@@ -1218,6 +1222,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                     ? `<button class="admin-action-btn approve" type="button" data-candidate-action="save-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Save</button>
                        <button class="admin-secondary-btn" type="button" data-candidate-action="cancel-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Cancel</button>`
                     : `<button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
+                       <button class="admin-action-btn approve" type="button" data-action="APPROVED_OVERRIDE_MATCH" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve - Override Match</button>
                        <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>`}
                 </div>`}
           </article>
@@ -1331,6 +1336,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         <td>${row.type || '—'}</td>
         <td>${row.is_active || '—'}</td>
         <td>${row.insert_method || '—'}</td>
+        <td>${row.matched_candidate_count ?? 0}</td>
         <td>${formatDateTime(row.insert_date)}</td>
         <td>${formatDateTime(row.update_date)}</td>
       </tr>
@@ -1351,6 +1357,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="type">Type${getSortIndicator('special-management', 'type')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="is_active">Is Active${getSortIndicator('special-management', 'is_active')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_method">Insert Method${getSortIndicator('special-management', 'insert_method')}</th>
+              <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="matched_candidate_count">Matched Candidates${getSortIndicator('special-management', 'matched_candidate_count')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_date">Insert Date${getSortIndicator('special-management', 'insert_date')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="update_date">Update Date${getSortIndicator('special-management', 'update_date')}</th>
             </tr>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -356,6 +356,7 @@ def get_unapproved_special_candidates(cursor):
             sc.notes,
             sc.fetch_method,
             sc.source,
+            sc.match_status,
             sc.approval_status,
             sc.insert_date
         FROM special_candidate sc
@@ -410,10 +411,43 @@ def get_unapproved_special_candidates(cursor):
                 'notes': row.get('notes'),
                 'fetch_method': row.get('fetch_method'),
                 'source': row.get('source'),
+                'match_status': row.get('match_status'),
                 'approval_status': row.get('approval_status'),
                 'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
             }
         )
+
+    candidate_ids = [special.get('special_candidate_id') for run in grouped_runs.values() for special in run.get('specials', []) if special.get('special_candidate_id')]
+    match_lookup = {}
+    if candidate_ids:
+        placeholders = ','.join(['%s'] * len(candidate_ids))
+        cursor.execute(
+            f"""
+            SELECT scsm.special_candidate_id, s.special_id, s.day_of_week, s.description, s.start_time, s.end_time, s.all_day, s.is_active
+            FROM special_candidate_special_match scsm
+            JOIN special s ON s.special_id = scsm.special_id
+            WHERE scsm.special_candidate_id IN ({placeholders})
+            ORDER BY scsm.special_candidate_id, s.special_id
+            """,
+            candidate_ids,
+        )
+        for row in cursor.fetchall():
+            candidate_id = row.get('special_candidate_id')
+            match_lookup.setdefault(candidate_id, []).append(
+                {
+                    'special_id': row.get('special_id'),
+                    'day_of_week': row.get('day_of_week'),
+                    'description': row.get('description'),
+                    'start_time': _normalize_time_value(row.get('start_time')) or None,
+                    'end_time': _normalize_time_value(row.get('end_time')) or None,
+                    'all_day': row.get('all_day'),
+                    'is_active': row.get('is_active'),
+                }
+            )
+    for run in grouped_runs.values():
+        for special in run.get('specials', []):
+            candidate_id = special.get('special_candidate_id')
+            special['matched_specials'] = match_lookup.get(candidate_id, [])
 
     runs = list(grouped_runs.values())
     return {'runs': runs, 'run_count': len(runs), 'special_count': len(rows)}
@@ -792,8 +826,8 @@ def delete_special_candidate_run(cursor, run_id: int):
 
 def update_special_candidate_approval(cursor, special_candidate_id: int, approval_status: str):
     normalized_status = str(approval_status or '').strip().upper()
-    if normalized_status not in {'APPROVED', 'REJECTED'}:
-        raise ValueError('approval_status must be APPROVED or REJECTED')
+    if normalized_status not in {'APPROVED', 'REJECTED', 'APPROVED_OVERRIDE_MATCH'}:
+        raise ValueError('approval_status must be APPROVED, APPROVED_OVERRIDE_MATCH, or REJECTED')
 
     cursor.execute(
         """
@@ -862,6 +896,26 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
             (reject_id, special_candidate_id),
         )
 
+        cursor.execute(
+            """
+            DELETE FROM special_candidate_special_match
+            WHERE special_candidate_id = %s
+            """,
+            (special_candidate_id,),
+        )
+
+    if normalized_status == 'APPROVED':
+        cursor.execute(
+            """
+            UPDATE special s
+            JOIN special_candidate_special_match scsm ON scsm.special_id = s.special_id
+            SET s.update_date = NOW(),
+                s.special_candidate_id = %s
+            WHERE scsm.special_candidate_id = %s
+            """,
+            (special_candidate_id, special_candidate_id),
+        )
+
     cursor.execute(
         """
         UPDATE special_candidate
@@ -869,7 +923,7 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
             approval_date = NOW()
         WHERE special_candidate_id = %s
         """,
-        (normalized_status, special_candidate_id),
+        ('APPROVED' if normalized_status == 'APPROVED_OVERRIDE_MATCH' else normalized_status, special_candidate_id),
     )
 
     cursor.execute(
@@ -925,6 +979,14 @@ def get_all_specials(cursor):
         """
     )
     special_rows = cursor.fetchall()
+    cursor.execute(
+        """
+        SELECT special_id, COUNT(*) AS matched_candidate_count
+        FROM special_candidate_special_match
+        GROUP BY special_id
+        """
+    )
+    match_count_lookup = {row['special_id']: int(row.get('matched_candidate_count') or 0) for row in cursor.fetchall()}
     special_ids = [row.get('special_id') for row in special_rows if row.get('special_id')]
 
     candidate_rows_by_special = {}
@@ -1011,6 +1073,7 @@ def get_all_specials(cursor):
                 'special_candidate_ids_csv': ','.join(
                     [str(candidate.get('special_candidate_id')) for candidate in candidate_rows if candidate.get('special_candidate_id')]
                 ),
+                'matched_candidate_count': match_count_lookup.get(special_id, 0),
             }
         )
 

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -320,6 +320,65 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             ),
         )
         candidate_id = cursor.lastrowid
+        candidate_days = _parse_days_of_week(candidate.get('days_of_week'))
+        matched_special_ids = []
+        if candidate_days:
+            placeholders = ','.join(['%s'] * len(candidate_days))
+            cursor.execute(
+                f"""
+                SELECT s.special_id, s.day_of_week, s.description
+                FROM special s
+                WHERE s.bar_id = %s
+                    AND s.is_active = 'Y'
+                    AND s.day_of_week IN ({placeholders})
+                    AND COALESCE(s.all_day, 'N') = %s
+                    AND COALESCE(s.start_time, '00:00:00') = COALESCE(%s, '00:00:00')
+                    AND COALESCE(s.end_time, '00:00:00') = COALESCE(%s, '00:00:00')
+                    AND EXISTS (
+                        SELECT 1
+                        FROM special_candidate scx
+                        WHERE scx.special_candidate_id = s.special_candidate_id
+                            AND COALESCE(scx.source, '') = COALESCE(%s, '')
+                    )
+                """,
+                (
+                    run['bar_id'],
+                    *candidate_days,
+                    _normalize_yn_flag(candidate.get('all_day')),
+                    candidate.get('start_time'),
+                    candidate.get('end_time'),
+                    candidate.get('source') or candidate.get('source_url'),
+                ),
+            )
+            for special in cursor.fetchall():
+                if _descriptions_match(candidate.get('description'), special.get('description')):
+                    matched_special_ids.append(special['special_id'])
+                    cursor.execute(
+                        """
+                        INSERT INTO special_candidate_special_match (special_id, special_candidate_id)
+                        VALUES (%s, %s)
+                        """,
+                        (special['special_id'], candidate_id),
+                    )
+        cursor.execute(
+            """
+            UPDATE special_candidate
+            SET match_status = %s
+            WHERE special_candidate_id = %s
+            """,
+            ('MATCHED' if matched_special_ids else 'NOT_MATCHED', candidate_id),
+        )
+        if matched_special_ids and approval_status == 'AUTO_APPROVED':
+            for special_id in matched_special_ids:
+                cursor.execute(
+                    """
+                    UPDATE special
+                    SET update_date = NOW(),
+                        special_candidate_id = %s
+                    WHERE special_id = %s
+                    """,
+                    (candidate_id, special_id),
+                )
         if is_rejected_candidate:
             for reject_id in matched_reject_ids:
                 cursor.execute(

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -118,6 +118,10 @@ def _normalize_text_value(value) -> str:
     return str(value or '').strip()
 
 
+def _candidate_and_special_sources_match(candidate_source, special_source) -> bool:
+    return _normalize_text_value(candidate_source) == _normalize_text_value(special_source)
+
+
 def _build_open_hours_lookup(open_hours_rows: List[Dict]) -> Dict[str, Dict]:
     lookup = {}
     for row in open_hours_rows:
@@ -323,34 +327,42 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         candidate_days = _parse_days_of_week(candidate.get('days_of_week'))
         matched_special_ids = []
         if candidate_days:
-            placeholders = ','.join(['%s'] * len(candidate_days))
             cursor.execute(
-                f"""
-                SELECT s.special_id, s.day_of_week, s.description
+                """
+                SELECT
+                    s.special_id,
+                    s.day_of_week,
+                    s.all_day,
+                    s.start_time,
+                    s.end_time,
+                    s.description,
+                    scx.source
                 FROM special s
+                LEFT JOIN special_candidate scx
+                    ON scx.special_candidate_id = s.special_candidate_id
                 WHERE s.bar_id = %s
                     AND s.is_active = 'Y'
-                    AND s.day_of_week IN ({placeholders})
-                    AND COALESCE(s.all_day, 'N') = %s
-                    AND COALESCE(s.start_time, '00:00:00') = COALESCE(%s, '00:00:00')
-                    AND COALESCE(s.end_time, '00:00:00') = COALESCE(%s, '00:00:00')
-                    AND EXISTS (
-                        SELECT 1
-                        FROM special_candidate scx
-                        WHERE scx.special_candidate_id = s.special_candidate_id
-                            AND COALESCE(scx.source, '') = COALESCE(%s, '')
-                    )
                 """,
-                (
-                    run['bar_id'],
-                    *candidate_days,
-                    _normalize_yn_flag(candidate.get('all_day')),
-                    candidate.get('start_time'),
-                    candidate.get('end_time'),
-                    candidate.get('source') or candidate.get('source_url'),
-                ),
+                (run['bar_id'],),
             )
+            candidate_source = candidate.get('source') or candidate.get('source_url')
+            normalized_candidate_days = {_normalize_day_of_week(day) for day in candidate_days}
             for special in cursor.fetchall():
+                if _normalize_day_of_week(special.get('day_of_week')) not in normalized_candidate_days:
+                    continue
+                if not _candidate_and_special_sources_match(candidate_source, special.get('source')):
+                    continue
+                if not _is_candidate_same_as_special(
+                    {
+                        'day_of_week': special.get('day_of_week'),
+                        'all_day': candidate.get('all_day'),
+                        'start_time': candidate.get('start_time'),
+                        'end_time': candidate.get('end_time'),
+                        'description': candidate.get('description'),
+                    },
+                    special,
+                ):
+                    continue
                 if _descriptions_match(candidate.get('description'), special.get('description')):
                     matched_special_ids.append(special['special_id'])
                     cursor.execute(


### PR DESCRIPTION
### Motivation
- Reduce duplicate manual edits by matching new `special_candidate` rows to existing `special` rows at creation time using day/time/source and description similarity. 
- Surface matches in the admin pending-approval UI so approvers can accept, override, or reject with predictable effects.

### Description
- New matching performed during `insert_special_candidate` which finds existing `special` rows that share `bar_id`, day(s), time/all-day, source and have similar descriptions, then persists links in `special_candidate_special_match` and sets `special_candidate.match_status` to `MATCHED` or `NOT_MATCHED` (file `functions/dbSpecialSync/db_special_sync.py`).
- When a matched candidate is `AUTO_APPROVED` the implementation updates matched `special.update_date` and re-points `special.special_candidate_id` to the candidate without changing other `special` fields (file `functions/dbSpecialSync/db_special_sync.py`).
- Admin API and approval flow were extended to include `match_status` and matched-special details in the pending list, to delete match rows on `REJECTED`, to update only matched specials on `APPROVED`, and to support a new `APPROVED_OVERRIDE_MATCH` action which maps to full-approve behavior (file `functions/dbAdminSync/db_admin_sync.py`).
- UI changes in `admin/admin.js` show `Match Status` and a list of matched specials next to candidates, add an **Approve - Override Match** action, and add a `Matched Candidates` column in the Special Management table that aggregates counts from `special_candidate_special_match`.

### Testing
- Ran Python byte-compile check: `python -m py_compile functions/dbSpecialSync/db_special_sync.py functions/dbAdminSync/db_admin_sync.py` which succeeded.
- Ran JS syntax check: `node --check admin/admin.js` which succeeded.
- No other automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23fb0abc483308b3f081edfb792c4)