### PR TITLE
Only show ‘Approve - Override Match’ for matched special candidates

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1217,6 +1217,9 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           `
           : '';
 
+
+        const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
+        const showOverrideMatchAction = matchStatus === 'MATCHED';
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
             ${(isEditing || isReadOnlyCandidate) ? '' : `
@@ -1246,7 +1249,9 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                     ? `<button class="admin-action-btn approve" type="button" data-candidate-action="save-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Save</button>
                        <button class="admin-secondary-btn" type="button" data-candidate-action="cancel-edit" data-candidate-id="${candidateId}" ${state.savingCandidate ? 'disabled' : ''}>Cancel</button>`
                     : `<button class="admin-action-btn approve" type="button" data-action="APPROVED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve</button>
-                       <button class="admin-action-btn approve" type="button" data-action="APPROVED_OVERRIDE_MATCH" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve - Override Match</button>
+                       ${showOverrideMatchAction
+                         ? `<button class="admin-action-btn approve" type="button" data-action="APPROVED_OVERRIDE_MATCH" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Approve - Override Match</button>`
+                         : ''}
                        <button class="admin-action-btn reject" type="button" data-action="REJECTED" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Reject</button>`}
                 </div>`}
           </article>


### PR DESCRIPTION
### Motivation
- Remove the unnecessary override action for specials that are not matched so the pending-approval admin UI shows only `Approve` and `Reject` for unmatched candidates.

### Description
- Update `admin/admin.js` to compute `matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase()` and set a `showOverrideMatchAction` flag, and render the `Approve - Override Match` button only when `matchStatus === 'MATCHED'`, leaving `Approve` and `Reject` unchanged.

### Testing
- Ran `node --check admin/admin.js` to verify JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25dff33348330b20a9cf8fe4dd042)