### PR TITLE
Track missed special runs and auto-deactivate specials after threshold

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -17,6 +17,7 @@ DB_USER = os.environ['DB_USER']
 DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
+MISSED_RUN_DEACTIVATION_THRESHOLD = 3
 
 
 def get_connection():
@@ -265,6 +266,29 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
         if special['special_id'] not in matched_special_ids:
             cursor.execute(
                 """
+                INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+                VALUES (%s, 1, %s, NOW())
+                ON DUPLICATE KEY UPDATE
+                    missed_run_count = IF(last_run_id = VALUES(last_run_id), missed_run_count, missed_run_count + 1),
+                    last_run_id = VALUES(last_run_id),
+                    update_date = NOW()
+                """,
+                (special['special_id'], run_id),
+            )
+            cursor.execute(
+                """
+                SELECT missed_run_count
+                FROM special_missed_runs
+                WHERE special_id = %s
+                """,
+                (special['special_id'],),
+            )
+            missed_run_record = cursor.fetchone() or {}
+            should_deactivate = int(missed_run_record.get('missed_run_count', 0)) >= MISSED_RUN_DEACTIVATION_THRESHOLD
+            if not should_deactivate:
+                continue
+            cursor.execute(
+                """
                 UPDATE special
                 SET is_active = 'N',
                     update_date = NOW()
@@ -294,6 +318,17 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             ),
         )
         inserted_special_count += 1
+        cursor.execute(
+            """
+            INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+            VALUES (%s, 0, %s, NOW())
+            ON DUPLICATE KEY UPDATE
+                missed_run_count = 0,
+                last_run_id = VALUES(last_run_id),
+                update_date = NOW()
+            """,
+            (cursor.lastrowid, run_id),
+        )
         special_to_candidate_id[cursor.lastrowid] = candidate['candidate_id']
 
     for special_id, candidate_id in special_to_candidate_id.items():
@@ -304,6 +339,17 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             WHERE special_id = %s
             """,
             (candidate_id, special_id),
+        )
+        cursor.execute(
+            """
+            INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+            VALUES (%s, 0, %s, NOW())
+            ON DUPLICATE KEY UPDATE
+                missed_run_count = 0,
+                last_run_id = VALUES(last_run_id),
+                update_date = NOW()
+            """,
+            (special_id, run_id),
         )
 
     deactivated_special_count = len(existing_specials) - len(matched_special_ids)

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -19,6 +19,7 @@ DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = 1
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = 1
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
+MISSED_RUN_DEACTIVATION_THRESHOLD = 3
 
 
 def get_connection():
@@ -604,6 +605,29 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             if special.get('is_active') == 'Y':
                 cursor.execute(
                     """
+                    INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+                    VALUES (%s, 1, %s, NOW())
+                    ON DUPLICATE KEY UPDATE
+                        missed_run_count = IF(last_run_id = VALUES(last_run_id), missed_run_count, missed_run_count + 1),
+                        last_run_id = VALUES(last_run_id),
+                        update_date = NOW()
+                    """,
+                    (special['special_id'], run_id),
+                )
+                cursor.execute(
+                    """
+                    SELECT missed_run_count
+                    FROM special_missed_runs
+                    WHERE special_id = %s
+                    """,
+                    (special['special_id'],),
+                )
+                missed_run_record = cursor.fetchone() or {}
+                should_deactivate = int(missed_run_record.get('missed_run_count', 0)) >= MISSED_RUN_DEACTIVATION_THRESHOLD
+                if not should_deactivate:
+                    continue
+                cursor.execute(
+                    """
                     UPDATE special
                     SET is_active = 'N',
                         update_date = NOW()
@@ -621,6 +645,17 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 """,
                 (special['special_id'],),
             )
+            cursor.execute(
+                """
+                INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+                VALUES (%s, 0, %s, NOW())
+                ON DUPLICATE KEY UPDATE
+                    missed_run_count = 0,
+                    last_run_id = VALUES(last_run_id),
+                    update_date = NOW()
+                """,
+                (special['special_id'], run_id),
+            )
         else:
             cursor.execute(
                 """
@@ -629,6 +664,17 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 WHERE special_id = %s
                 """,
                 (special['special_id'],),
+            )
+            cursor.execute(
+                """
+                INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+                VALUES (%s, 0, %s, NOW())
+                ON DUPLICATE KEY UPDATE
+                    missed_run_count = 0,
+                    last_run_id = VALUES(last_run_id),
+                    update_date = NOW()
+                """,
+                (special['special_id'], run_id),
             )
 
     inserted_special_count = 0
@@ -652,6 +698,17 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             ),
         )
         inserted_special_count += 1
+        cursor.execute(
+            """
+            INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+            VALUES (%s, 0, %s, NOW())
+            ON DUPLICATE KEY UPDATE
+                missed_run_count = 0,
+                last_run_id = VALUES(last_run_id),
+                update_date = NOW()
+            """,
+            (cursor.lastrowid, run_id),
+        )
         special_to_candidate_id[cursor.lastrowid] = candidate['candidate_id']
 
     for special_id, candidate_id in special_to_candidate_id.items():


### PR DESCRIPTION
### Motivation
- Ensure specials that stop appearing in candidate runs are detected and auto-deactivated after a configurable number of missed runs to keep the `special` table consistent with incoming candidate data.

### Description
- Add `MISSED_RUN_DEACTIVATION_THRESHOLD = 3` to `db_admin_sync.py` and `db_special_sync.py`.
- Record run visibility in `special_missed_runs` by inserting/updating `missed_run_count`, `last_run_id`, and `update_date` during `publish_special_candidate_run` flows.
- Increment `missed_run_count` when an active `special` is not matched in the latest run and reset it to `0` when a `special` is matched, reactivated, or newly inserted, and deactivate the `special` when `missed_run_count >= MISSED_RUN_DEACTIVATION_THRESHOLD`.
- Initialize `special_missed_runs` entries for newly created or matched specials with `missed_run_count = 0` and the current `run_id`.

### Testing
- Ran the existing automated test suite after the change and observed no regressions (all tests passed).
- No new unit tests were added for `special_missed_runs` in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f25f0c2a5883309fdcabf5836a6550)