### PR TITLE
Only invoke pending candidate audit when approvals are needed

### DIFF
--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -969,12 +969,13 @@ def lambda_handler(event, context):
         )
         data_audit_invoked = False
         data_audit_error = None
-        try:
-            invoke_data_audit({'mode': 'pending_special_candidates'})
-            data_audit_invoked = True
-        except Exception as audit_exc:
-            data_audit_error = str(audit_exc)
-            LOGGER.exception('Failed to invoke dataAudit pending_special_candidates mode')
+        if needs_approval_count > 0:
+            try:
+                invoke_data_audit({'mode': 'pending_special_candidates'})
+                data_audit_invoked = True
+            except Exception as audit_exc:
+                data_audit_error = str(audit_exc)
+                LOGGER.exception('Failed to invoke dataAudit pending_special_candidates mode')
 
         return {
             'statusCode': 200,


### PR DESCRIPTION
### Motivation
- Prevent triggering the data-audit/email flow when there are no `NOT_APPROVED` candidate specials to review, reducing unnecessary notifications and lambda invocations.

### Description
- Wrap the `invoke_data_audit({'mode': 'pending_special_candidates'})` call in a conditional so it only runs when `needs_approval_count > 0`, preserving the original error handling and the `data_audit_invoked`/`data_audit_error` response fields.

### Testing
- Ran `python -m py_compile functions/generateCandidateSpecials/generate_candidate_specials.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365e81d408330be1df1aea0b940c6)