### PR TITLE
dataAudit: skip pending-approval alert when no pending specials

### DIFF
--- a/functions/dataAudit/data_audit.py
+++ b/functions/dataAudit/data_audit.py
@@ -83,6 +83,10 @@ def publish_duplicate_specials_alert(result: Dict) -> Dict[str, object]:
 
 def publish_pending_approval_alert(result: Dict) -> Dict[str, object]:
     pending_count = int(result.get('not_approved_count', 0) or 0)
+    if pending_count == 0:
+        LOGGER.info('dataAudit: no pending approvals found; skipping alert publish')
+        return {'email_sent': False, 'email_reason': 'NO_PENDING_APPROVALS'}
+
     subject = f"Specials Pending Approval ({pending_count} specials)"
     message_lines = [
         f"There are {pending_count} pending approval.",


### PR DESCRIPTION
### Motivation
- Avoid sending empty pending-approval emails by short-circuiting when there are no pending specials in `publish_pending_approval_alert`.

### Description
- Add an early return in `publish_pending_approval_alert` that logs with `LOGGER.info` and returns `{'email_sent': False, 'email_reason': 'NO_PENDING_APPROVALS'}` when `pending_count == 0`.

### Testing
- Ran the project's automated unit test suite and existing tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365e81d408330be1df1aea0b940c6)