### PR TITLE
Fix missing bar ID in Specials Pending Approval run payload

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -378,6 +378,7 @@ def get_unapproved_special_candidates(cursor):
         """
         SELECT
             scr.run_id,
+            scr.bar_id,
             b.name AS bar_name,
             scr.total_candidates,
             scr.auto_approved_candidates,
@@ -427,6 +428,7 @@ def get_unapproved_special_candidates(cursor):
             run_id,
             {
                 'run_id': run_id,
+                'bar_id': row.get('bar_id'),
                 'bar_name': row.get('bar_name'),
                 'neighborhood': row.get('neighborhood'),
                 'total_candidates': row.get('total_candidates'),


### PR DESCRIPTION
### Motivation
- The admin "Specials Pending Approval" UI renders `run.bar_id` but the backend payload from `get_unapproved_special_candidates` did not include `bar_id`, causing the Bar ID field to display blank.

### Description
- Add `scr.bar_id` to the SQL `SELECT` in `get_unapproved_special_candidates` and include `'bar_id': row.get('bar_id')` in the grouped run object returned by the function.

### Testing
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36ac2b4808330a58ea451c350cd24)