### PR TITLE
Auto-reject candidates with null days_of_week and append rejection note

### DIFF
--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -323,6 +323,8 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         approval_status = 'NOT_APPROVED'
         approval_date = None
         confidence = _parse_confidence(candidate.get('confidence'))
+        candidate_notes = candidate.get('notes')
+        missing_day_data = candidate.get('days_of_week') is None
 
         matched_reject_ids = [
             rejected_candidate.get('reject_id')
@@ -330,12 +332,19 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             if _is_candidate_same_as_reject(candidate, rejected_candidate)
             and rejected_candidate.get('reject_id')
         ]
-        is_rejected_candidate = bool(matched_reject_ids)
+        is_rejected_candidate = bool(matched_reject_ids) or missing_day_data
 
         if is_rejected_candidate:
             approval_status = 'AUTO_REJECTED'
             approval_date = datetime.utcnow()
             auto_rejected_count += 1
+            if missing_day_data:
+                missing_day_notes_suffix = ' - rejected due to missing day data'
+                candidate_notes = (
+                    f"{candidate_notes}{missing_day_notes_suffix}"
+                    if candidate_notes
+                    else missing_day_notes_suffix.lstrip()
+                )
         else:
             fetch_method = (candidate.get('fetch_method') or '').strip()
             auto_approval_threshold = WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD if fetch_method == 'web_ai_search' else WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD
@@ -368,7 +377,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                 candidate.get('fetch_method'),
                 candidate.get('source') or candidate.get('source_url'),
                 candidate.get('confidence'),
-                candidate.get('notes'),
+                candidate_notes,
                 approval_status,
                 approval_date,
             ),


### PR DESCRIPTION
### Motivation
- Prevent specials with missing day data from entering the candidate pipeline as approved/awaiting review and record the reason for rejection in the candidate notes.

### Description
- Detect when `candidate.get('days_of_week') is None` and treat the candidate as rejected during `insert_special_candidate` by setting `approval_status` to `AUTO_REJECTED` and incrementing `auto_rejected_count`.
- Preserve existing reject matching logic and augment it with a `missing_day_data` check so previous auto-reject behavior remains intact.
- Append the suffix ` - rejected due to missing day data` to the candidate `notes` (or set that message when notes are empty) and persist the resulting `candidate_notes` to the `special_candidate.notes` column on insert.
- Replace the direct `candidate.get('notes')` usage with the adjusted `candidate_notes` variable when inserting the row.

### Testing
- Ran `python -m py_compile functions/dbSpecialSync/db_special_sync.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36e6007a883308778f20c00dd280f)