### PR TITLE
Add NOT_APPROVED count to Specials Pending Approval admin tool

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -77,6 +77,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     generatingBarSecondsElapsed: 0,
     generateResultPayload: null,
     runs: [],
+    pendingApprovalCount: 0,
     confirmingDeleteRunId: null,
     deletingRunId: null,
     rejectedSpecials: [],
@@ -461,9 +462,11 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     try {
       const result = await callAdminSync({ mode: 'get_unapproved_special_candidates' });
       state.runs = Array.isArray(result?.runs) ? result.runs : [];
+      state.pendingApprovalCount = Number(result?.not_approved_count) || 0;
     } catch (err) {
       console.error('Failed to load unapproved specials:', err);
       state.errorMessage = err?.message || 'Failed to load unapproved specials.';
+      state.pendingApprovalCount = 0;
     } finally {
       state.loading = false;
       render();
@@ -1933,6 +1936,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     screenElement.innerHTML = `
       <section class="admin-specials-view" aria-label="Special approvals">
         <h2>Specials Pending Approval</h2>
+        <p class="admin-meta"><strong>Remaining NOT_APPROVED:</strong> ${state.pendingApprovalCount}</p>
         ${state.errorMessage ? `<p class="admin-error">${state.errorMessage}</p>` : ''}
         ${buildRunsMarkup()}
       </section>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -512,7 +512,18 @@ def get_unapproved_special_candidates(cursor):
             special['matched_specials'] = match_lookup.get(candidate_id, [])
 
     runs = list(grouped_runs.values())
-    return {'runs': runs, 'run_count': len(runs), 'special_count': len(rows)}
+    not_approved_count = sum(
+        1
+        for run in runs
+        for special in run.get('specials', [])
+        if special.get('approval_status') == 'NOT_APPROVED'
+    )
+    return {
+        'runs': runs,
+        'run_count': len(runs),
+        'special_count': len(rows),
+        'not_approved_count': not_approved_count,
+    }
 
 
 def get_not_approved_special_candidate_summary(cursor) -> Dict[str, object]:


### PR DESCRIPTION
### Motivation
- Provide a visible count of remaining items that need manual approval so admins can see progress while approving specials.
- Keep the count calculation server-side to ensure the UI shows an authoritative value and avoid client-side recomputation.

### Description
- Added a backend `not_approved_count` field to the `get_unapproved_special_candidates` response by counting specials with `approval_status == 'NOT_APPROVED'` in `functions/dbAdminSync/db_admin_sync.py`.
- Exposed the new field in the API response returned from `get_unapproved_special_candidates` as `not_approved_count`.
- Added `pendingApprovalCount` to the admin page state in `admin/admin.js` and set it from `result?.not_approved_count` in `loadUnapprovedSpecials`.
- Updated the Specials Pending Approval view to render a top-line meta row: `Remaining NOT_APPROVED: ${state.pendingApprovalCount}` and reset the count to `0` on load failure.

### Testing
- Ran `node --check admin/admin.js` which succeeded.
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f370d091308330b5605d7b7e0543ad)