### PR TITLE
Sort specials pending approval candidates by status order

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1136,7 +1136,22 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     }
 
     return state.runs.map((run) => {
-      const specialsMarkup = (run.specials || []).map((special) => {
+      const sortedSpecials = [...(run.specials || [])].sort((left, right) => {
+        const statusPriority = (special) => {
+          const approvalStatus = String(special?.approval_status || '').trim().toUpperCase();
+          if (approvalStatus === 'NOT_APPROVED') return 0;
+          if (approvalStatus === 'AUTO_APPROVED') return 1;
+          if (approvalStatus === 'AUTO_REJECTED') return 2;
+          return 3;
+        };
+
+        const priorityDiff = statusPriority(left) - statusPriority(right);
+        if (priorityDiff !== 0) return priorityDiff;
+
+        return Number(left?.special_candidate_id || 0) - Number(right?.special_candidate_id || 0);
+      });
+
+      const specialsMarkup = sortedSpecials.map((special) => {
         const candidateId = Number(special.special_candidate_id);
         const approvalStatus = String(special.approval_status || '').trim().toUpperCase();
         const isAutoApproved = approvalStatus === 'AUTO_APPROVED';


### PR DESCRIPTION
### Motivation
- Make the Specials Pending Approval run UI present candidates in a predictable review order: `NOT_APPROVED` first, then `AUTO_APPROVED`, then `AUTO_REJECTED`.
- Ensure ordering is stable so candidates render consistently across views and refreshes.

### Description
- Before rendering a run, copy and sort `run.specials` into `sortedSpecials` and iterate the sorted list instead of the raw array.
- Added a `statusPriority` function that maps `NOT_APPROVED` → `0`, `AUTO_APPROVED` → `1`, and `AUTO_REJECTED` → `2` to implement the requested ordering.
- Added a deterministic tiebreaker that orders items with the same status by ascending `special_candidate_id`.

### Testing
- Ran `node --check admin/admin.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f389b7b7a083309cee0167b8f56d70)