### PR TITLE
Sort recurring special candidates by approval status in DB query

### DIFF
--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -417,7 +417,15 @@ def get_unapproved_special_candidates(cursor):
                 WHERE sc2.approval_status = 'NOT_APPROVED'
                     AND COALESCE(sc2.is_recurring, 'Y') = 'Y'
             )
-        ORDER BY scr.run_id DESC, sc.special_candidate_id ASC
+        ORDER BY
+            scr.run_id DESC,
+            CASE sc.approval_status
+                WHEN 'NOT_APPROVED' THEN 0
+                WHEN 'AUTO_APPROVED' THEN 1
+                WHEN 'AUTO_REJECTED' THEN 2
+                ELSE 3
+            END ASC,
+            sc.special_candidate_id ASC
         """
     )
     rows = cursor.fetchall()


### PR DESCRIPTION
### Motivation
- Ensure recurring `special_candidate` rows are returned in an administrator-friendly order so `NOT_APPROVED` candidates appear before `AUTO_APPROVED` and `AUTO_REJECTED` when fetching unapproved runs.

### Description
- Modify the SQL `ORDER BY` in `get_unapproved_special_candidates` to add a `CASE` on `sc.approval_status` that ranks `NOT_APPROVED`, `AUTO_APPROVED`, and `AUTO_REJECTED` respectively, then fall back to `sc.special_candidate_id ASC`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f389b7b7a083309cee0167b8f56d70)