### PR TITLE
Set rejected special-candidate matches to MATCHED_REJECTED

### DIFF
--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -451,6 +451,12 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             approval_date = datetime.utcnow()
             auto_approved_count += 1
             needs_approval_count = max(0, needs_approval_count - 1)
+        match_status = 'NOT_MATCHED'
+        if matched_special_ids:
+            match_status = 'MATCHED'
+        if matched_reject_ids:
+            match_status = 'MATCHED_REJECTED'
+
         cursor.execute(
             """
             UPDATE special_candidate
@@ -460,7 +466,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             WHERE special_candidate_id = %s
             """,
             (
-                'MATCHED' if matched_special_ids else 'NOT_MATCHED',
+                match_status,
                 approval_status,
                 approval_date,
                 candidate_id,


### PR DESCRIPTION
### Motivation
- When a special candidate is matched against an entry in `special_candidate_reject`, the system should mark the candidate as rejected at the match level by setting `match_status` to `MATCHED_REJECTED` so downstream processing can treat it differently.

### Description
- Update `insert_special_candidate` in `functions/dbSpecialSync/db_special_sync.py` to compute a `match_status` variable (default `NOT_MATCHED`), set it to `MATCHED` when active specials match, and set it to `MATCHED_REJECTED` when the candidate matches a `special_candidate_reject`, then use `match_status` in the `UPDATE special_candidate` statement.

### Testing
- No automated tests were run for this logic-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a968632c8330929bad5dd49e565a)