### PR TITLE
Expand candidate-to-special matching with pending/confirm workflow

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -576,7 +576,27 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     }
   }
 
-  async function saveCandidateUpdates(payload) {
+    async function confirmCandidateMatch(specialCandidateId, specialId) {
+    state.updatingCandidateId = specialCandidateId;
+    state.errorMessage = '';
+    render();
+
+    try {
+      await callAdminSync({
+        mode: 'confirm_special_candidate_match',
+        special_candidate_id: specialCandidateId,
+        special_id: specialId
+      });
+      await loadUnapprovedSpecials();
+    } catch (err) {
+      console.error('Failed to confirm candidate match:', err);
+      state.errorMessage = err?.message || 'Failed to confirm candidate match.';
+      state.updatingCandidateId = null;
+      render();
+    }
+  }
+
+async function saveCandidateUpdates(payload) {
     state.savingCandidate = true;
     state.errorMessage = '';
     render();
@@ -1212,6 +1232,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         };
 
         const matchedSpecials = Array.isArray(special.matched_specials) ? special.matched_specials : [];
+        const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
         const matchedSpecialsMarkup = matchedSpecials.length
           ? `
             <div class="admin-matched-specials">
@@ -1229,6 +1250,9 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                     <p><strong>Type:</strong> ${matched.type || '—'}</p>
                     <p><strong>Insert Date:</strong> ${formatDateTime(matched.insert_date)}</p>
                     <p><strong>Update Date:</strong> ${formatDateTime(matched.update_date)}</p>
+                    ${(matchStatus === 'MATCH_PENDING' && !isReadOnlyCandidate)
+                      ? `<button class="admin-secondary-btn" type="button" data-candidate-action="confirm-match" data-candidate-id="${candidateId}" data-special-id="${matched.special_id}" ${isUpdating ? 'disabled' : ''}>Confirm Match</button>`
+                      : ''}
                   </article>
                 `).join('')}
               </div>
@@ -1237,7 +1261,6 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           : '';
 
 
-        const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
         const showOverrideMatchAction = matchStatus === 'MATCHED';
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
@@ -1490,6 +1513,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         if (action === 'cancel-edit') {
           state.editingCandidateId = null;
           render();
+          return;
+        }
+
+        if (action === 'confirm-match') {
+          const specialId = Number(button.getAttribute('data-special-id'));
+          if (!specialId) return;
+          await confirmCandidateMatch(candidateId, specialId);
           return;
         }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1241,7 +1241,7 @@ async function saveCandidateUpdates(payload) {
                 ${matchedSpecials.map((matched) => `
                   <article class="admin-matched-special-card">
                     <p><strong>Special ID:</strong> ${matched.special_id ?? '—'}</p>
-                    <p><strong>Fuzzy Description Match Score:</strong> ${matched.fuzzy_description_match_score ?? '—'}</p>
+                    <p><strong>Description Match Score:</strong> ${matched.fuzzy_description_match_score ?? '—'}</p>
                     <p><strong>Day of Week:</strong> ${matched.day_of_week || '—'}</p>
                     <p><strong>Description:</strong> ${matched.description || '—'}</p>
                     <p><strong>All Day:</strong> ${matched.all_day || '—'}</p>
@@ -1250,7 +1250,7 @@ async function saveCandidateUpdates(payload) {
                     <p><strong>Type:</strong> ${matched.type || '—'}</p>
                     <p><strong>Insert Date:</strong> ${formatDateTime(matched.insert_date)}</p>
                     <p><strong>Update Date:</strong> ${formatDateTime(matched.update_date)}</p>
-                    ${(matchStatus === 'MATCH_PENDING' && !isReadOnlyCandidate)
+                    ${(matchStatus === 'MATCH_PENDING')
                       ? `<button class="admin-secondary-btn" type="button" data-candidate-action="confirm-match" data-candidate-id="${candidateId}" data-special-id="${matched.special_id}" ${isUpdating ? 'disabled' : ''}>Confirm Match</button>`
                       : ''}
                   </article>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -571,12 +571,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     } catch (err) {
       console.error('Failed to update candidate approval:', err);
       state.errorMessage = err?.message || 'Failed to update candidate approval status.';
+    } finally {
       state.updatingCandidateId = null;
       render();
     }
   }
 
-    async function confirmCandidateMatch(specialCandidateId, specialId) {
+  async function confirmCandidateMatch(specialCandidateId, specialId) {
     state.updatingCandidateId = specialCandidateId;
     state.errorMessage = '';
     render();
@@ -591,12 +592,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     } catch (err) {
       console.error('Failed to confirm candidate match:', err);
       state.errorMessage = err?.message || 'Failed to confirm candidate match.';
+    } finally {
       state.updatingCandidateId = null;
       render();
     }
   }
 
-async function saveCandidateUpdates(payload) {
+  async function saveCandidateUpdates(payload) {
     state.savingCandidate = true;
     state.errorMessage = '';
     render();
@@ -1241,7 +1243,7 @@ async function saveCandidateUpdates(payload) {
                 ${matchedSpecials.map((matched) => `
                   <article class="admin-matched-special-card">
                     <p><strong>Special ID:</strong> ${matched.special_id ?? '—'}</p>
-                    <p><strong>Description Match Score:</strong> ${matched.fuzzy_description_match_score ?? '—'}</p>
+                    <p><strong>Description Match Score:</strong> ${matched.fuzzy_description_match_score === null || matched.fuzzy_description_match_score === undefined ? '—' : Number(matched.fuzzy_description_match_score).toFixed(2)}</p>
                     <p><strong>Day of Week:</strong> ${matched.day_of_week || '—'}</p>
                     <p><strong>Description:</strong> ${matched.description || '—'}</p>
                     <p><strong>All Day:</strong> ${matched.all_day || '—'}</p>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1555,6 +1555,56 @@ def update_special_candidate(cursor, event):
 
 
 
+
+def confirm_special_candidate_match(cursor, special_candidate_id: int, special_id: int):
+    cursor.execute(
+        """
+        SELECT special_candidate_id, approval_status
+        FROM special_candidate
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    candidate = cursor.fetchone()
+    if not candidate:
+        raise ValueError('special_candidate_id was not found')
+
+    cursor.execute(
+        """
+        SELECT 1
+        FROM special_candidate_special_match
+        WHERE special_candidate_id = %s AND special_id = %s
+        """,
+        (special_candidate_id, special_id),
+    )
+    if not cursor.fetchone():
+        raise ValueError('special_id is not a possible match for this candidate')
+
+    cursor.execute(
+        """
+        DELETE FROM special_candidate_special_match
+        WHERE special_candidate_id = %s
+          AND special_id <> %s
+        """,
+        (special_candidate_id, special_id),
+    )
+
+    cursor.execute(
+        """
+        UPDATE special_candidate
+        SET match_status = 'MATCHED'
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+
+    return {
+        'special_candidate_id': special_candidate_id,
+        'special_id': special_id,
+        'match_status': 'MATCHED',
+        'approval_status': candidate.get('approval_status'),
+    }
+
 def _parse_event_payload(event):
     if not isinstance(event, dict):
         return {}
@@ -1585,6 +1635,7 @@ def lambda_handler(event, context):
         'remove_rejected_special_candidate',
         'delete_special_candidate_run',
         'update_special_candidate_approval',
+        'confirm_special_candidate_match',
         'get_all_specials',
         'update_special',
         'delete_special',
@@ -1606,7 +1657,7 @@ def lambda_handler(event, context):
                         'detect_duplicate_websites, detect_duplicate_specials, '
                         'remove_rejected_special_candidate, '
                         'delete_special_candidate_run, '
-                        'update_special_candidate_approval, get_all_specials, update_special, delete_special, insert_special, '
+                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1634,6 +1685,12 @@ def lambda_handler(event, context):
                 if not special_candidate_id:
                     raise ValueError('special_candidate_id is required for update_special_candidate_approval')
                 result = update_special_candidate_approval(cursor, special_candidate_id, approval_status)
+            elif mode == 'confirm_special_candidate_match':
+                special_candidate_id = event.get('special_candidate_id')
+                special_id = event.get('special_id')
+                if not special_candidate_id or not special_id:
+                    raise ValueError('special_candidate_id and special_id are required for confirm_special_candidate_match')
+                result = confirm_special_candidate_match(cursor, int(special_candidate_id), int(special_id))
             elif mode == 'remove_rejected_special_candidate':
                 special_candidate_id = event.get('special_candidate_id')
                 if not special_candidate_id:

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -18,8 +18,8 @@ DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = 1
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = 1
-SPECIAL_CANDIDATE_SPECIAL_MATCH_FUZZY_DESCRIPTION_THRESHOLD = 0.78
-SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD = 0.9
+SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD', '0.78'))
+SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD', '0.9'))
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
 MISSED_RUN_DEACTIVATION_THRESHOLD = 3
 
@@ -65,7 +65,7 @@ def _descriptions_match(candidate_description: str, special_description: str) ->
         return True
     return (
         SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
-        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_FUZZY_DESCRIPTION_THRESHOLD
+        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD
     )
 
 
@@ -74,7 +74,10 @@ def _description_match_score(candidate_description: str, special_description: st
     special_normalized = _normalize_description(special_description)
     if not candidate_normalized or not special_normalized:
         return 0.0
-    return SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
+    ratio = SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
+    if candidate_normalized in special_normalized or special_normalized in candidate_normalized:
+        ratio = max(ratio, 0.95)
+    return ratio
 
 
 def _parse_days_of_week(raw_days) -> List[str]:
@@ -398,7 +401,8 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         candidate_id = cursor.lastrowid
         candidate_days = _parse_days_of_week(candidate.get('days_of_week'))
         matched_special_ids = []
-        if candidate_days:
+        possible_matches = []
+        if candidate_days and not is_rejected_candidate:
             cursor.execute(
                 """
                 SELECT
@@ -418,44 +422,40 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             for special in cursor.fetchall():
                 if _normalize_day_of_week(special.get('day_of_week')) not in normalized_candidate_days:
                     continue
-                if not _is_candidate_same_as_special(
-                    {
-                        'day_of_week': special.get('day_of_week'),
-                        'all_day': candidate.get('all_day'),
-                        'start_time': candidate.get('start_time'),
-                        'end_time': candidate.get('end_time'),
-                        'description': candidate.get('description'),
-                    },
-                    special,
-                ):
+                if _normalize_yn_flag(candidate.get('all_day')) != _normalize_yn_flag(special.get('all_day')):
+                    continue
+                if _normalize_time_value(candidate.get('start_time')) != _normalize_time_value(special.get('start_time')):
+                    continue
+                if _normalize_time_value(candidate.get('end_time')) != _normalize_time_value(special.get('end_time')):
                     continue
                 fuzzy_description_match_score = _description_match_score(
                     candidate.get('description'),
                     special.get('description'),
                 )
-                if _descriptions_match(candidate.get('description'), special.get('description')):
-                    matched_special_ids.append(special['special_id'])
-                    cursor.execute(
-                        """
-                        INSERT INTO special_candidate_special_match (special_id, special_candidate_id, fuzzy_description_match_score)
-                        VALUES (%s, %s, %s)
-                        """,
-                        (special['special_id'], candidate_id, fuzzy_description_match_score),
-                    )
-        if (
-            matched_special_ids
-            and approval_status == 'NOT_APPROVED'
-            and confidence > SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD
-        ):
-            approval_status = 'AUTO_APPROVED'
-            approval_date = datetime.utcnow()
-            auto_approved_count += 1
-            needs_approval_count = max(0, needs_approval_count - 1)
+                if fuzzy_description_match_score < SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD:
+                    continue
+                possible_matches.append({
+                    'special_id': special['special_id'],
+                    'score': fuzzy_description_match_score,
+                })
+                cursor.execute(
+                    """
+                    INSERT INTO special_candidate_special_match (special_id, special_candidate_id, fuzzy_description_match_score)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (special['special_id'], candidate_id, fuzzy_description_match_score),
+                )
         match_status = 'NOT_MATCHED'
-        if matched_special_ids:
-            match_status = 'MATCHED'
         if matched_reject_ids:
-            match_status = 'MATCHED_REJECTED'
+            match_status = 'AUTO_REJECTED'
+        elif possible_matches:
+            top_score = max(match.get('score', 0.0) for match in possible_matches)
+            if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+                matched_special_ids = [possible_matches[0]['special_id']]
+                match_status = 'AUTO_MATCHED'
+            else:
+                match_status = 'MATCH_PENDING'
+                matched_special_ids = [match['special_id'] for match in possible_matches]
 
         cursor.execute(
             """
@@ -475,7 +475,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         if matched_special_ids:
             matched_count += 1
 
-        if matched_special_ids and approval_status == 'AUTO_APPROVED':
             for special_id in matched_special_ids:
                 cursor.execute(
                     """

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -453,6 +453,11 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
                 matched_special_ids = [possible_matches[0]['special_id']]
                 match_status = 'AUTO_MATCHED'
+                if approval_status == 'NOT_APPROVED' and confidence > SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+                    approval_status = 'AUTO_APPROVED'
+                    approval_date = datetime.utcnow()
+                    auto_approved_count += 1
+                    needs_approval_count = max(0, needs_approval_count - 1)
             else:
                 match_status = 'MATCH_PENDING'
                 matched_special_ids = [match['special_id'] for match in possible_matches]

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -340,7 +340,8 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         approval_date = None
         confidence = _parse_confidence(candidate.get('confidence'))
         candidate_notes = candidate.get('notes')
-        missing_day_data = candidate.get('days_of_week') is None
+        candidate_days_raw = _parse_days_of_week(candidate.get('days_of_week'))
+        missing_day_data = len(candidate_days_raw) == 0
 
         matched_reject_ids = [
             rejected_candidate.get('reject_id')
@@ -399,7 +400,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             ),
         )
         candidate_id = cursor.lastrowid
-        candidate_days = _parse_days_of_week(candidate.get('days_of_week'))
+        candidate_days = candidate_days_raw
         matched_special_ids = []
         possible_matches = []
         if candidate_days and not is_rejected_candidate:
@@ -447,7 +448,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                 )
         match_status = 'NOT_MATCHED'
         if matched_reject_ids:
-            match_status = 'AUTO_REJECTED'
+            match_status = 'MATCHED_REJECT'
         elif possible_matches:
             top_score = max(match.get('score', 0.0) for match in possible_matches)
             if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:


### PR DESCRIPTION
### Motivation
- Loosen candidate-to-special matching so candidates that are simple substrings of an existing special (e.g., a short description inside a longer marketing description) can be surfaced as possible matches. 
- Provide a safe admin-driven path to confirm ambiguous matches instead of silently auto-matching when confidence is close to the threshold. 

### Description
- Introduced a configurable floor and auto-approval thresholds via `SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD` and `SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD` and boosted substring-contained description scores to at least `0.95` in `_description_match_score` for better substring matching (`functions/dbSpecialSync/db_special_sync.py`).
- Changed ingest logic to check reject matches first and mark those candidates `AUTO_REJECTED`, then build `possible_matches` (above the floor threshold) and set match status to `AUTO_MATCHED` only when there is exactly one possible match and its score is >= the auto-approval threshold; otherwise set `MATCH_PENDING` and record the possible matches (`functions/dbSpecialSync/db_special_sync.py`).
- Added a new admin API mode `confirm_special_candidate_match` that validates the selected match, deletes other candidate-match join rows, and sets the candidate `match_status` to `MATCHED` while leaving the approval workflow unchanged (`functions/dbAdminSync/db_admin_sync.py`).
- Updated the Specials Pending Approval UI to display possible matched specials for candidates with `MATCH_PENDING` and added a **Confirm Match** action that calls the new API and reloads the unapproved list (`admin/admin.js`).

### Testing
- Compiled the updated Python modules with `python -m py_compile functions/dbSpecialSync/db_special_sync.py functions/dbAdminSync/db_admin_sync.py` and the compilation succeeded. 
- Checked the updated admin UI script with `node --check admin/admin.js` and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b89ecf688330aa833c10002ee24d)