### PR TITLE
Add admin 'Confirm Match' action and improve special-candidate matching logic

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -571,6 +571,28 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     } catch (err) {
       console.error('Failed to update candidate approval:', err);
       state.errorMessage = err?.message || 'Failed to update candidate approval status.';
+    } finally {
+      state.updatingCandidateId = null;
+      render();
+    }
+  }
+
+  async function confirmCandidateMatch(specialCandidateId, specialId) {
+    state.updatingCandidateId = specialCandidateId;
+    state.errorMessage = '';
+    render();
+
+    try {
+      await callAdminSync({
+        mode: 'confirm_special_candidate_match',
+        special_candidate_id: specialCandidateId,
+        special_id: specialId
+      });
+      await loadUnapprovedSpecials();
+    } catch (err) {
+      console.error('Failed to confirm candidate match:', err);
+      state.errorMessage = err?.message || 'Failed to confirm candidate match.';
+    } finally {
       state.updatingCandidateId = null;
       render();
     }
@@ -1212,6 +1234,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         };
 
         const matchedSpecials = Array.isArray(special.matched_specials) ? special.matched_specials : [];
+        const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
         const matchedSpecialsMarkup = matchedSpecials.length
           ? `
             <div class="admin-matched-specials">
@@ -1220,7 +1243,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                 ${matchedSpecials.map((matched) => `
                   <article class="admin-matched-special-card">
                     <p><strong>Special ID:</strong> ${matched.special_id ?? '—'}</p>
-                    <p><strong>Fuzzy Description Match Score:</strong> ${matched.fuzzy_description_match_score ?? '—'}</p>
+                    <p><strong>Description Match Score:</strong> ${matched.fuzzy_description_match_score ?? '—'}</p>
                     <p><strong>Day of Week:</strong> ${matched.day_of_week || '—'}</p>
                     <p><strong>Description:</strong> ${matched.description || '—'}</p>
                     <p><strong>All Day:</strong> ${matched.all_day || '—'}</p>
@@ -1229,6 +1252,9 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                     <p><strong>Type:</strong> ${matched.type || '—'}</p>
                     <p><strong>Insert Date:</strong> ${formatDateTime(matched.insert_date)}</p>
                     <p><strong>Update Date:</strong> ${formatDateTime(matched.update_date)}</p>
+                    ${(matchStatus === 'MATCH_PENDING')
+                      ? `<button class="admin-secondary-btn" type="button" data-candidate-action="confirm-match" data-candidate-id="${candidateId}" data-special-id="${matched.special_id}" ${isUpdating ? 'disabled' : ''}>Confirm Match</button>`
+                      : ''}
                   </article>
                 `).join('')}
               </div>
@@ -1237,7 +1263,6 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           : '';
 
 
-        const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
         const showOverrideMatchAction = matchStatus === 'MATCHED';
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
@@ -1490,6 +1515,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         if (action === 'cancel-edit') {
           state.editingCandidateId = null;
           render();
+          return;
+        }
+
+        if (action === 'confirm-match') {
+          const specialId = Number(button.getAttribute('data-special-id'));
+          if (!specialId) return;
+          await confirmCandidateMatch(candidateId, specialId);
           return;
         }
 

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -504,7 +504,7 @@ def get_unapproved_special_candidates(cursor):
             match_lookup.setdefault(candidate_id, []).append(
                 {
                     'special_id': row.get('special_id'),
-                    'fuzzy_description_match_score': row.get('fuzzy_description_match_score'),
+                    'fuzzy_description_match_score': (round(float(row.get('fuzzy_description_match_score')), 2) if row.get('fuzzy_description_match_score') is not None else None),
                     'day_of_week': row.get('day_of_week'),
                     'description': row.get('description'),
                     'start_time': _normalize_time_value(row.get('start_time')) or None,
@@ -1555,6 +1555,56 @@ def update_special_candidate(cursor, event):
 
 
 
+
+def confirm_special_candidate_match(cursor, special_candidate_id: int, special_id: int):
+    cursor.execute(
+        """
+        SELECT special_candidate_id, approval_status
+        FROM special_candidate
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    candidate = cursor.fetchone()
+    if not candidate:
+        raise ValueError('special_candidate_id was not found')
+
+    cursor.execute(
+        """
+        SELECT 1
+        FROM special_candidate_special_match
+        WHERE special_candidate_id = %s AND special_id = %s
+        """,
+        (special_candidate_id, special_id),
+    )
+    if not cursor.fetchone():
+        raise ValueError('special_id is not a possible match for this candidate')
+
+    cursor.execute(
+        """
+        DELETE FROM special_candidate_special_match
+        WHERE special_candidate_id = %s
+          AND special_id <> %s
+        """,
+        (special_candidate_id, special_id),
+    )
+
+    cursor.execute(
+        """
+        UPDATE special_candidate
+        SET match_status = 'MATCHED'
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+
+    return {
+        'special_candidate_id': special_candidate_id,
+        'special_id': special_id,
+        'match_status': 'MATCHED',
+        'approval_status': candidate.get('approval_status'),
+    }
+
 def _parse_event_payload(event):
     if not isinstance(event, dict):
         return {}
@@ -1585,6 +1635,7 @@ def lambda_handler(event, context):
         'remove_rejected_special_candidate',
         'delete_special_candidate_run',
         'update_special_candidate_approval',
+        'confirm_special_candidate_match',
         'get_all_specials',
         'update_special',
         'delete_special',
@@ -1606,7 +1657,7 @@ def lambda_handler(event, context):
                         'detect_duplicate_websites, detect_duplicate_specials, '
                         'remove_rejected_special_candidate, '
                         'delete_special_candidate_run, '
-                        'update_special_candidate_approval, get_all_specials, update_special, delete_special, insert_special, '
+                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1634,6 +1685,12 @@ def lambda_handler(event, context):
                 if not special_candidate_id:
                     raise ValueError('special_candidate_id is required for update_special_candidate_approval')
                 result = update_special_candidate_approval(cursor, special_candidate_id, approval_status)
+            elif mode == 'confirm_special_candidate_match':
+                special_candidate_id = event.get('special_candidate_id')
+                special_id = event.get('special_id')
+                if not special_candidate_id or not special_id:
+                    raise ValueError('special_candidate_id and special_id are required for confirm_special_candidate_match')
+                result = confirm_special_candidate_match(cursor, int(special_candidate_id), int(special_id))
             elif mode == 'remove_rejected_special_candidate':
                 special_candidate_id = event.get('special_candidate_id')
                 if not special_candidate_id:

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -18,8 +18,8 @@ DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = 1
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = 1
-SPECIAL_CANDIDATE_SPECIAL_MATCH_FUZZY_DESCRIPTION_THRESHOLD = 0.78
-SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD = 0.9
+SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD', '0.78'))
+SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD', '0.9'))
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
 MISSED_RUN_DEACTIVATION_THRESHOLD = 3
 
@@ -65,7 +65,7 @@ def _descriptions_match(candidate_description: str, special_description: str) ->
         return True
     return (
         SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
-        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_FUZZY_DESCRIPTION_THRESHOLD
+        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD
     )
 
 
@@ -74,7 +74,10 @@ def _description_match_score(candidate_description: str, special_description: st
     special_normalized = _normalize_description(special_description)
     if not candidate_normalized or not special_normalized:
         return 0.0
-    return SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
+    ratio = SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
+    if candidate_normalized in special_normalized or special_normalized in candidate_normalized:
+        ratio = max(ratio, 0.95)
+    return ratio
 
 
 def _parse_days_of_week(raw_days) -> List[str]:
@@ -337,7 +340,8 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         approval_date = None
         confidence = _parse_confidence(candidate.get('confidence'))
         candidate_notes = candidate.get('notes')
-        missing_day_data = candidate.get('days_of_week') is None
+        candidate_days_raw = _parse_days_of_week(candidate.get('days_of_week'))
+        missing_day_data = len(candidate_days_raw) == 0
 
         matched_reject_ids = [
             rejected_candidate.get('reject_id')
@@ -396,9 +400,10 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             ),
         )
         candidate_id = cursor.lastrowid
-        candidate_days = _parse_days_of_week(candidate.get('days_of_week'))
+        candidate_days = candidate_days_raw
         matched_special_ids = []
-        if candidate_days:
+        possible_matches = []
+        if candidate_days and not is_rejected_candidate:
             cursor.execute(
                 """
                 SELECT
@@ -418,44 +423,45 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             for special in cursor.fetchall():
                 if _normalize_day_of_week(special.get('day_of_week')) not in normalized_candidate_days:
                     continue
-                if not _is_candidate_same_as_special(
-                    {
-                        'day_of_week': special.get('day_of_week'),
-                        'all_day': candidate.get('all_day'),
-                        'start_time': candidate.get('start_time'),
-                        'end_time': candidate.get('end_time'),
-                        'description': candidate.get('description'),
-                    },
-                    special,
-                ):
+                if _normalize_yn_flag(candidate.get('all_day')) != _normalize_yn_flag(special.get('all_day')):
+                    continue
+                if _normalize_time_value(candidate.get('start_time')) != _normalize_time_value(special.get('start_time')):
+                    continue
+                if _normalize_time_value(candidate.get('end_time')) != _normalize_time_value(special.get('end_time')):
                     continue
                 fuzzy_description_match_score = _description_match_score(
                     candidate.get('description'),
                     special.get('description'),
                 )
-                if _descriptions_match(candidate.get('description'), special.get('description')):
-                    matched_special_ids.append(special['special_id'])
-                    cursor.execute(
-                        """
-                        INSERT INTO special_candidate_special_match (special_id, special_candidate_id, fuzzy_description_match_score)
-                        VALUES (%s, %s, %s)
-                        """,
-                        (special['special_id'], candidate_id, fuzzy_description_match_score),
-                    )
-        if (
-            matched_special_ids
-            and approval_status == 'NOT_APPROVED'
-            and confidence > SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD
-        ):
-            approval_status = 'AUTO_APPROVED'
-            approval_date = datetime.utcnow()
-            auto_approved_count += 1
-            needs_approval_count = max(0, needs_approval_count - 1)
+                if fuzzy_description_match_score < SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD:
+                    continue
+                possible_matches.append({
+                    'special_id': special['special_id'],
+                    'score': fuzzy_description_match_score,
+                })
+                cursor.execute(
+                    """
+                    INSERT INTO special_candidate_special_match (special_id, special_candidate_id, fuzzy_description_match_score)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (special['special_id'], candidate_id, fuzzy_description_match_score),
+                )
         match_status = 'NOT_MATCHED'
-        if matched_special_ids:
-            match_status = 'MATCHED'
         if matched_reject_ids:
-            match_status = 'MATCHED_REJECTED'
+            match_status = 'MATCHED_REJECT'
+        elif possible_matches:
+            top_score = max(match.get('score', 0.0) for match in possible_matches)
+            if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+                matched_special_ids = [possible_matches[0]['special_id']]
+                match_status = 'AUTO_MATCHED'
+                if approval_status == 'NOT_APPROVED' and confidence > SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+                    approval_status = 'AUTO_APPROVED'
+                    approval_date = datetime.utcnow()
+                    auto_approved_count += 1
+                    needs_approval_count = max(0, needs_approval_count - 1)
+            else:
+                match_status = 'MATCH_PENDING'
+                matched_special_ids = [match['special_id'] for match in possible_matches]
 
         cursor.execute(
             """
@@ -475,7 +481,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
         if matched_special_ids:
             matched_count += 1
 
-        if matched_special_ids and approval_status == 'AUTO_APPROVED':
             for special_id in matched_special_ids:
                 cursor.execute(
                     """

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -18,8 +18,9 @@ DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 WEB_SCRAPE_AUTO_APPROVAL_THRESHOLD = 1
 WEB_AI_SEARCH_AUTO_APPROVAL_THRESHOLD = 1
-SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD', '0.78'))
-SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD', '0.9'))
+SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_FLOOR_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_FLOOR_THRESHOLD', '0.78'))
+SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD', '0.9'))
+SPECIAL_CANDIDATE_SPECIAL_MATCH_CONFIDENCE_AUTO_APPROVAL_THRESHOLD = float(os.environ.get('SPECIAL_CANDIDATE_SPECIAL_MATCH_CONFIDENCE_AUTO_APPROVAL_THRESHOLD', '0.9'))
 IGNORE_MANUAL_SPECIALS_ON_PUBLISH = 'Y'
 MISSED_RUN_DEACTIVATION_THRESHOLD = 3
 
@@ -65,7 +66,7 @@ def _descriptions_match(candidate_description: str, special_description: str) ->
         return True
     return (
         SequenceMatcher(None, candidate_normalized, special_normalized).ratio()
-        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD
+        >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_FLOOR_THRESHOLD
     )
 
 
@@ -433,7 +434,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     candidate.get('description'),
                     special.get('description'),
                 )
-                if fuzzy_description_match_score < SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD:
+                if fuzzy_description_match_score < SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_FLOOR_THRESHOLD:
                     continue
                 possible_matches.append({
                     'special_id': special['special_id'],
@@ -451,10 +452,10 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             match_status = 'MATCHED_REJECT'
         elif possible_matches:
             top_score = max(match.get('score', 0.0) for match in possible_matches)
-            if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+            if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD:
                 matched_special_ids = [possible_matches[0]['special_id']]
                 match_status = 'AUTO_MATCHED'
-                if approval_status == 'NOT_APPROVED' and confidence > SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD:
+                if approval_status == 'NOT_APPROVED' and confidence >= SPECIAL_CANDIDATE_SPECIAL_MATCH_CONFIDENCE_AUTO_APPROVAL_THRESHOLD:
                     approval_status = 'AUTO_APPROVED'
                     approval_date = datetime.utcnow()
                     auto_approved_count += 1


### PR DESCRIPTION
### Motivation
- Provide an administrative action to confirm a single matched special for a special candidate and mark it as matched. 
- Make candidate-to-special matching more robust and configurable via environment thresholds. 
- Improve handling and normalization of days/times and make match scores clearer and rounded in admin UI. 
- Ensure UI updating state is always reset after async actions.

### Description
- Frontend (`admin/admin.js`): added `confirmCandidateMatch` to call a new backend mode, added a `Confirm Match` button for matched candidates when `match_status === 'MATCH_PENDING'`, wired a click handler for `data-candidate-action="confirm-match"`, moved `matchStatus` resolution and renamed a label to `Description Match Score`, and added `finally` blocks to reliably clear `state.updatingCandidateId` and re-render. 
- Backend admin sync (`functions/dbAdminSync/db_admin_sync.py`): implemented `confirm_special_candidate_match` to validate the candidate and allowed special, delete other candidate->special matches, set `match_status = 'MATCHED'`, return the resulting metadata, registered the new mode in the lambda handler, and rounded `fuzzy_description_match_score` to 2 decimals when returning match data. 
- Matching pipeline (`functions/dbSpecialSync/db_special_sync.py`): made fuzzy-floor and auto-approval thresholds configurable via environment variables `SPECIAL_CANDIDATE_SPECIAL_MATCH_FLOOR_THRESHOLD` and `SPECIAL_CANDIDATE_SPECIAL_MATCH_AUTO_APPROVAL_THRESHOLD`, renamed variables and updated comparisons to use the floor threshold, boosted `_description_match_score` to favor substring matches by forcing a minimum of `0.95` when one description contains the other, normalized and parsed `days_of_week` earlier into `candidate_days_raw`, tightened comparisons on `all_day`, `start_time`, and `end_time`, persisted all possible matches with their scores and inserted them into `special_candidate_special_match`, and set `match_status` to `MATCH_PENDING`, `AUTO_MATCHED`, or `MATCHED_REJECT` depending on rejects and possible-match outcomes while performing single-match auto-approval logic. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b89ecf688330aa833c10002ee24d)