### PR TITLE
Sort Bars tab alphabetically using backend-provided order

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -245,8 +245,11 @@ def build_startup_payload(device_id=None):
         )
 
         bars_lookup = {}
+        ordered_bar_ids = []
         for bar in bars:
-            bars_lookup[str(bar['bar_id'])] = {
+            bar_id = str(bar['bar_id'])
+            ordered_bar_ids.append(bar_id)
+            bars_lookup[bar_id] = {
                 'name': bar['name'],
                 'neighborhood': bar['neighborhood'],
                 'image_url': build_bar_image_url(bar['image_file']),
@@ -352,6 +355,7 @@ def build_startup_payload(device_id=None):
                     'google_map_id': GOOGLE_MAP_ID
                 },
                 'bars': bars_lookup,
+                'bar_order': ordered_bar_ids,
                 'open_hours': open_hours_lookup,
                 'specials': specials_lookup,
                 'specials_by_day': specials_by_day

--- a/js/api.js
+++ b/js/api.js
@@ -7,8 +7,12 @@ function buildLegacyBarsData(payload) {
   const barsLookup = payload?.bars || {};
   const openHoursLookup = payload?.open_hours || {};
   const specialsLookup = payload?.specials || {};
+  const orderedBarIds = Array.isArray(payload?.bar_order)
+    ? payload.bar_order.map((barId) => String(barId)).filter((barId) => barsLookup[barId])
+    : Object.keys(barsLookup);
 
-  return Object.entries(barsLookup).map(([barId, bar]) => {
+  return orderedBarIds.map((barId) => {
+    const bar = barsLookup[barId];
     const barSpecialsByDay = {};
 
     Object.entries(specialsLookup).forEach(([specialId, special]) => {


### PR DESCRIPTION
### Motivation
- Ensure the Bars tab lists bars alphabetically by name with ordering controlled by the backend so all clients render a consistent order.

### Description
- Add a `bar_order` list to the startup payload in `functions/getStartupData/get_startup_data.py` that captures the SQL result ordering (preserves the existing `ORDER BY name` output) by appending bar ids in the same loop that builds `bars` lookup.
- Surface `bar_order` on the `startup_payload` as `bar_order` so clients can rely on server-provided ordering.
- Update frontend normalization in `js/api.js` (`buildLegacyBarsData`) to prefer `payload.bar_order` when constructing `barsData`, falling back to `Object.keys(payload.bars)` when `bar_order` is absent.
- Changes touch `functions/getStartupData/get_startup_data.py` and `js/api.js` and do not alter the UI rendering logic beyond providing a stable input order.

### Testing
- Ran `python -m py_compile functions/getStartupData/get_startup_data.py` to validate Python syntax, which completed successfully.
- Attempted `npm test -- --runInBand` to exercise frontend tests, but it could not run in this environment because `package.json` is not present (npm reported an `ENOENT` error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e77f1b748330941152611088054b)