### PR TITLE
Add Reject Special action to admin UI and backend

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -695,6 +695,31 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     }
   }
 
+  async function rejectSpecials(specialIds) {
+    const ids = Array.isArray(specialIds) ? specialIds : [specialIds];
+    const validIds = [...new Set(ids.map((id) => Number(id)).filter((id) => Number.isFinite(id) && id > 0))];
+    if (!validIds.length) return;
+
+    state.savingSpecial = true;
+    state.errorMessage = '';
+    render();
+
+    try {
+      for (const specialId of validIds) {
+        await callAdminSync({ mode: 'reject_special', special_id: specialId });
+      }
+      await loadAllSpecials();
+      state.detailSpecials = [];
+      state.detailEditing = false;
+    } catch (err) {
+      console.error('Failed to reject special:', err);
+      state.errorMessage = err?.message || 'Failed to reject special.';
+    } finally {
+      state.savingSpecial = false;
+      render();
+    }
+  }
+
   async function saveBarUpdates(barPayload, openHoursRows) {
     state.savingBar = true;
     state.errorMessage = '';
@@ -811,6 +836,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           <button type="button" class="admin-tool-button" data-special-action="view-details" data-special-id="${state.actionSpecialId}">View Details</button>
           <button type="button" class="admin-tool-button" data-special-action="activate" data-special-id="${state.actionSpecialId}">Activate Special</button>
           <button type="button" class="admin-tool-button" data-special-action="deactivate" data-special-id="${state.actionSpecialId}">Deactivate Special</button>
+          <button type="button" class="admin-tool-button danger" data-special-action="reject" data-special-id="${state.actionSpecialId}">Reject Special</button>
           <button type="button" class="admin-tool-button danger" data-special-action="delete" data-special-id="${state.actionSpecialId}">Delete Special</button>
           <button type="button" class="admin-secondary-btn" data-close-action-menu="true">Close</button>
         </div>
@@ -1721,6 +1747,21 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           );
           if (!confirmed) return;
           await deleteSpecials(ids);
+          return;
+        }
+
+        if (action === 'reject') {
+          const groupedRow = getGroupedRowByRepresentativeId(specialId);
+          const specialIdsToReject = (groupedRow?.specials || []).map((special) => Number(special.special_id)).filter(Boolean);
+          const ids = specialIdsToReject.length ? specialIdsToReject : [specialId];
+          const rejectCount = ids.length;
+          const confirmed = window.confirm(
+            rejectCount > 1
+              ? `Reject ${rejectCount} specials? This will move them to rejected specials and delete the active specials.`
+              : 'Reject this special? This will move it to rejected specials and delete the active special.'
+          );
+          if (!confirmed) return;
+          await rejectSpecials(ids);
         }
       });
     });

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1752,7 +1752,19 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
         if (action === 'reject') {
           const groupedRow = getGroupedRowByRepresentativeId(specialId);
-          const specialIdsToReject = (groupedRow?.specials || []).map((special) => Number(special.special_id)).filter(Boolean);
+          const groupedSpecials = groupedRow?.specials || [];
+          const targetSpecials = groupedSpecials.length
+            ? groupedSpecials
+            : (getSpecialById(specialId) ? [getSpecialById(specialId)] : []);
+          const hasManualSpecial = targetSpecials.some(
+            (special) => String(special?.insert_method || '').toUpperCase() !== 'AUTO'
+          );
+          if (hasManualSpecial) {
+            state.errorMessage = 'Cannot reject a special that is manually created';
+            render();
+            return;
+          }
+          const specialIdsToReject = targetSpecials.map((special) => Number(special.special_id)).filter(Boolean);
           const ids = specialIdsToReject.length ? specialIdsToReject : [specialId];
           const rejectCount = ids.length;
           const confirmed = window.confirm(

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1488,6 +1488,96 @@ def delete_special(cursor, event):
     return {'special_id': special_id, 'deleted': True}
 
 
+def reject_special(cursor, event):
+    special_id = event.get('special_id')
+    if not special_id:
+        raise ValueError('special_id is required for reject_special')
+
+    cursor.execute(
+        """
+        SELECT
+            s.special_id,
+            s.bar_id,
+            s.description,
+            s.day_of_week,
+            s.start_time,
+            s.end_time,
+            s.all_day,
+            sc.is_recurring,
+            sc.date,
+            sc.fetch_method,
+            sc.source,
+            s.special_candidate_id
+        FROM special s
+        LEFT JOIN special_candidate sc ON sc.special_candidate_id = s.special_candidate_id
+        WHERE s.special_id = %s
+        """,
+        (special_id,),
+    )
+    target = cursor.fetchone()
+    if not target:
+        raise ValueError('special_id was not found')
+
+    days_of_week = json.dumps([_normalize_day_of_week(target.get('day_of_week'))])
+    cursor.execute(
+        """
+        INSERT INTO special_candidate_reject
+        (
+            bar_id,
+            description,
+            days_of_week,
+            start_time,
+            end_time,
+            all_day,
+            is_recurring,
+            date,
+            fetch_method,
+            source
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            target.get('bar_id'),
+            target.get('description'),
+            days_of_week,
+            target.get('start_time'),
+            target.get('end_time'),
+            target.get('all_day'),
+            target.get('is_recurring'),
+            target.get('date'),
+            target.get('fetch_method'),
+            target.get('source'),
+        ),
+    )
+    reject_id = cursor.lastrowid
+
+    if target.get('special_candidate_id'):
+        cursor.execute(
+            """
+            INSERT INTO special_candidate_reject_join (reject_id, special_candidate_id)
+            VALUES (%s, %s)
+            """,
+            (reject_id, target.get('special_candidate_id')),
+        )
+
+    cursor.execute(
+        """
+        DELETE FROM device_special_favorite
+        WHERE special_id = %s
+        """,
+        (special_id,),
+    )
+    cursor.execute(
+        """
+        DELETE FROM special
+        WHERE special_id = %s
+        """,
+        (special_id,),
+    )
+
+    return {'special_id': special_id, 'reject_id': reject_id, 'rejected': True}
+
+
 def update_special_candidate(cursor, event):
     special_candidate_id = event.get('special_candidate_id')
     if not special_candidate_id:
@@ -1639,6 +1729,7 @@ def lambda_handler(event, context):
         'get_all_specials',
         'update_special',
         'delete_special',
+        'reject_special',
         'insert_special',
         'update_special_candidate',
         'get_all_bars',
@@ -1657,7 +1748,7 @@ def lambda_handler(event, context):
                         'detect_duplicate_websites, detect_duplicate_specials, '
                         'remove_rejected_special_candidate, '
                         'delete_special_candidate_run, '
-                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, insert_special, '
+                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, reject_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1718,6 +1809,8 @@ def lambda_handler(event, context):
                 result = update_special_candidate(cursor, event)
             elif mode == 'delete_special':
                 result = delete_special(cursor, event)
+            elif mode == 'reject_special':
+                result = reject_special(cursor, event)
             elif mode == 'insert_special':
                 result = insert_special(cursor, event)
             else:

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1499,6 +1499,7 @@ def reject_special(cursor, event):
             s.special_id,
             s.bar_id,
             s.description,
+            s.insert_method,
             s.day_of_week,
             s.start_time,
             s.end_time,
@@ -1517,6 +1518,8 @@ def reject_special(cursor, event):
     target = cursor.fetchone()
     if not target:
         raise ValueError('special_id was not found')
+    if str(target.get('insert_method') or '').strip().upper() != 'AUTO':
+        raise ValueError('Cannot reject a special that is manually created')
 
     days_of_week = json.dumps([_normalize_day_of_week(target.get('day_of_week'))])
     cursor.execute(


### PR DESCRIPTION
### Motivation
- Provide an explicit "Reject Special" admin action that deletes an active `special` and archives its data in the rejection tables, matching existing admin workflows for managing specials.
- Ensure the admin UI supports rejecting grouped specials consistently with other bulk actions.

### Description
- Added a `Reject Special` button to the special actions modal in `admin/admin.js` and wired it to a new `rejectSpecials` flow that confirms with the user and supports grouped specials via `getGroupedRowByRepresentativeId`.
- Implemented `rejectSpecials` in `admin/admin.js` which calls the admin API with `mode: 'reject_special'` for each selected `special_id` and reloads specials afterward.
- Implemented a backend handler `reject_special(cursor, event)` in `functions/dbAdminSync/db_admin_sync.py` which reads the `special`, inserts a row into `special_candidate_reject`, inserts a `special_candidate_reject_join` when `special_candidate_id` exists, deletes related `device_special_favorite` rows, and deletes the `special` row.
- Registered `reject_special` in the allowed `mode` set and added the dispatch branch to `lambda_handler` in `db_admin_sync.py` so the new mode is callable via `callAdminSync`.

### Testing
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` which completed successfully.
- Ran `node --check admin/admin.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e75478d08330ac03dff7f2215e55)