### PR TITLE
Add Missed Runs column to Special Management and surface missed_run_count

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -495,6 +495,16 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     }
   }
 
+  async function loadSpecialDetails(specialIds) {
+    const ids = [...new Set((Array.isArray(specialIds) ? specialIds : [specialIds])
+      .map((id) => Number(id))
+      .filter((id) => Number.isFinite(id) && id > 0))];
+    if (!ids.length) return [];
+
+    const result = await callAdminSync({ mode: 'get_specials_by_ids', special_ids: ids });
+    return Array.isArray(result?.specials) ? result.specials : [];
+  }
+
   async function loadRejectedSpecials() {
     state.loadingRejectedSpecials = true;
     state.errorMessage = '';
@@ -1724,9 +1734,21 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         state.actionSpecialId = null;
         if (action === 'view-details') {
           const groupedRow = getGroupedRowByRepresentativeId(specialId);
-          state.detailSpecials = groupedRow?.specials || (getSpecialById(specialId) ? [getSpecialById(specialId)] : []);
-          state.detailEditing = false;
+          const ids = (groupedRow?.specials || []).map((special) => Number(special.special_id)).filter(Boolean);
+          const detailIds = ids.length ? ids : [specialId];
+          state.loadingSpecials = true;
           render();
+          try {
+            state.detailSpecials = await loadSpecialDetails(detailIds);
+            state.detailEditing = false;
+          } catch (err) {
+            console.error('Failed to load special details:', err);
+            state.errorMessage = err?.message || 'Failed to load special details.';
+            state.detailSpecials = [];
+          } finally {
+            state.loadingSpecials = false;
+            render();
+          }
           return;
         }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -330,6 +330,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     if (key === 'days_of_week') return formatDayGroup(row.days_of_week || []);
     if (key === 'insert_date' || key === 'update_date') return toTimestamp(row[key]);
     if (key === 'start_time' || key === 'end_time') return toTimeNumber(row[key]);
+    if (key === 'matched_candidate_count' || key === 'missed_run_count') return Number(row[key]) || 0;
     return String(row[key] || '').toLowerCase();
   }
 
@@ -391,6 +392,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           insert_date: special.insert_date,
           update_date: special.update_date,
           matched_candidate_count: 0,
+          missed_run_count: 0,
           daySet: new Set(),
           specials: []
         });
@@ -399,6 +401,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
       const row = grouped.get(key);
       row.specials.push(special);
       row.matched_candidate_count += Number(special.matched_candidate_count || 0);
+      row.missed_run_count = Math.max(row.missed_run_count, Number(special.missed_run_count || 0));
       row.daySet.add(normalizeDay(special.day_of_week));
 
       const rowInsert = toTimestamp(row.insert_date);
@@ -1436,6 +1439,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         <td>${row.is_active || '—'}</td>
         <td>${row.insert_method || '—'}</td>
         <td>${row.matched_candidate_count ?? 0}</td>
+        <td>${row.missed_run_count ?? 0}</td>
         <td>${formatDateTime(row.insert_date)}</td>
         <td>${formatDateTime(row.update_date)}</td>
       </tr>
@@ -1457,6 +1461,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="is_active">Is Active${getSortIndicator('special-management', 'is_active')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_method">Insert Method${getSortIndicator('special-management', 'insert_method')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="matched_candidate_count">Matched Candidates${getSortIndicator('special-management', 'matched_candidate_count')}</th>
+              <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="missed_run_count">Missed Runs${getSortIndicator('special-management', 'missed_run_count')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_date">Insert Date${getSortIndicator('special-management', 'insert_date')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="update_date">Update Date${getSortIndicator('special-management', 'update_date')}</th>
             </tr>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1037,9 +1037,16 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
     }
 
 
-def get_all_specials(cursor):
+def get_all_specials(cursor, include_candidate_rows=False, special_ids=None):
+    where_clause = ''
+    query_params = []
+    if special_ids:
+        placeholders = ','.join(['%s'] * len(special_ids))
+        where_clause = f'WHERE s.special_id IN ({placeholders})'
+        query_params = list(special_ids)
+
     cursor.execute(
-        """
+        f"""
         SELECT
             s.special_id,
             s.bar_id,
@@ -1061,8 +1068,10 @@ def get_all_specials(cursor):
             ON smr.special_id = s.special_id
         JOIN bar b
             ON b.bar_id = s.bar_id
+        {where_clause}
         ORDER BY b.neighborhood ASC, b.name ASC, s.description ASC, s.insert_date ASC, s.special_id ASC
-        """
+        """,
+        query_params,
     )
     special_rows = cursor.fetchall()
     cursor.execute(
@@ -1076,7 +1085,7 @@ def get_all_specials(cursor):
     special_ids = [row.get('special_id') for row in special_rows if row.get('special_id')]
 
     candidate_rows_by_special = {}
-    if special_ids:
+    if include_candidate_rows and special_ids:
         placeholders = ','.join(['%s'] * len(special_ids))
         cursor.execute(
             f"""
@@ -1145,20 +1154,20 @@ def get_all_specials(cursor):
                 'insert_method': row.get('insert_method'),
                 'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
                 'update_date': row.get('update_date').isoformat() if row.get('update_date') else None,
-                'special_candidate_id': primary_candidate.get('special_candidate_id'),
-                'confidence': primary_candidate.get('confidence'),
-                'fetch_method': primary_candidate.get('fetch_method'),
-                'notes': primary_candidate.get('notes'),
-                'source': primary_candidate.get('source'),
-                'approval_date': primary_candidate.get('approval_date'),
-                'run_id': primary_candidate.get('run_id'),
-                'published_at': primary_candidate.get('published_at'),
-                'candidate_rows': candidate_rows,
-                'candidate_count': len(candidate_rows),
-                'special_candidate_ids': [candidate.get('special_candidate_id') for candidate in candidate_rows if candidate.get('special_candidate_id')],
+                'special_candidate_id': primary_candidate.get('special_candidate_id') if include_candidate_rows else None,
+                'confidence': primary_candidate.get('confidence') if include_candidate_rows else None,
+                'fetch_method': primary_candidate.get('fetch_method') if include_candidate_rows else None,
+                'notes': primary_candidate.get('notes') if include_candidate_rows else None,
+                'source': primary_candidate.get('source') if include_candidate_rows else None,
+                'approval_date': primary_candidate.get('approval_date') if include_candidate_rows else None,
+                'run_id': primary_candidate.get('run_id') if include_candidate_rows else None,
+                'published_at': primary_candidate.get('published_at') if include_candidate_rows else None,
+                'candidate_rows': candidate_rows if include_candidate_rows else [],
+                'candidate_count': len(candidate_rows) if include_candidate_rows else 0,
+                'special_candidate_ids': [candidate.get('special_candidate_id') for candidate in candidate_rows if candidate.get('special_candidate_id')] if include_candidate_rows else [],
                 'special_candidate_ids_csv': ','.join(
                     [str(candidate.get('special_candidate_id')) for candidate in candidate_rows if candidate.get('special_candidate_id')]
-                ),
+                ) if include_candidate_rows else '',
                 'matched_candidate_count': match_count_lookup.get(special_id, 0),
                 'missed_run_count': int(row.get('missed_run_count') or 0),
             }
@@ -1734,6 +1743,7 @@ def lambda_handler(event, context):
         'update_special_candidate_approval',
         'confirm_special_candidate_match',
         'get_all_specials',
+        'get_specials_by_ids',
         'update_special',
         'delete_special',
         'reject_special',
@@ -1755,7 +1765,7 @@ def lambda_handler(event, context):
                         'detect_duplicate_websites, detect_duplicate_specials, '
                         'remove_rejected_special_candidate, '
                         'delete_special_candidate_run, '
-                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, reject_special, insert_special, '
+                        'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, get_specials_by_ids, update_special, delete_special, reject_special, insert_special, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1800,7 +1810,13 @@ def lambda_handler(event, context):
                     raise ValueError('run_id is required for delete_special_candidate_run')
                 result = delete_special_candidate_run(cursor, int(run_id))
             elif mode == 'get_all_specials':
-                result = get_all_specials(cursor)
+                result = get_all_specials(cursor, include_candidate_rows=False)
+            elif mode == 'get_specials_by_ids':
+                special_ids = event.get('special_ids')
+                if not isinstance(special_ids, list) or not special_ids:
+                    raise ValueError('special_ids array is required for get_specials_by_ids')
+                parsed_special_ids = [int(item) for item in special_ids if str(item).strip()]
+                result = get_all_specials(cursor, include_candidate_rows=True, special_ids=parsed_special_ids)
             elif mode == 'get_all_bars':
                 result = get_all_bars(cursor)
             elif mode == 'get_bar_details':

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1054,8 +1054,11 @@ def get_all_specials(cursor):
             s.is_active,
             s.insert_method,
             s.insert_date,
-            s.update_date
+            s.update_date,
+            COALESCE(smr.missed_run_count, 0) AS missed_run_count
         FROM special s
+        LEFT JOIN special_missed_runs smr
+            ON smr.special_id = s.special_id
         JOIN bar b
             ON b.bar_id = s.bar_id
         ORDER BY b.neighborhood ASC, b.name ASC, s.description ASC, s.insert_date ASC, s.special_id ASC
@@ -1157,6 +1160,7 @@ def get_all_specials(cursor):
                     [str(candidate.get('special_candidate_id')) for candidate in candidate_rows if candidate.get('special_candidate_id')]
                 ),
                 'matched_candidate_count': match_count_lookup.get(special_id, 0),
+                'missed_run_count': int(row.get('missed_run_count') or 0),
             }
         )
 


### PR DESCRIPTION
### Motivation
- Provide visibility into how many times a special has missed a candidate run so admins can spot flaky or stale specials. 
- Expose the missed run metric in the Special Management UI for sorting and inspection. 
- Confirm the existing auto-deactivation policy based on missed runs remains enforceable and visible.

### Description
- Extended `get_all_specials` in `functions/dbAdminSync/db_admin_sync.py` to `LEFT JOIN special_missed_runs` and select `COALESCE(smr.missed_run_count, 0) AS missed_run_count`, then return it as an integer on each special record via `'missed_run_count': int(row.get('missed_run_count') or 0)`. 
- Updated `admin/admin.js` to add a sortable `Missed Runs` column header and render `${row.missed_run_count ?? 0}` for each grouped special row. 
- Aggregated `missed_run_count` in grouping by initializing `missed_run_count: 0` and updating with `row.missed_run_count = Math.max(row.missed_run_count, Number(special.missed_run_count || 0))`, and added numeric sort handling in `specialSortValue` for `missed_run_count`. 

### Testing
- Ran repository validation/search commands such as `rg -n "missed_run_count|Missed Runs|MISSED_RUN_DEACTIVATION_THRESHOLD"` and inspected the diffs with `git diff` to confirm the query and UI changes were applied, which succeeded. 
- Committed the updated files and reviewed the changed lines with `nl`/file inspection to verify rendered table, grouping and payload include `missed_run_count`, which succeeded. 
- Confirmed the deactivation logic continues to use `MISSED_RUN_DEACTIVATION_THRESHOLD = 3` and treats `missed_run_count >= 3` as the condition to auto-deactivate a special.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f4a0632083308a9eba28fa9069a1)