### PR TITLE
Add missed-run tracking to specials and surface it in admin UI

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -327,6 +327,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
   }
 
   function specialSortValue(row, key) {
+    if (key === 'matched_candidate_count' || key === 'missed_run_count') return Number(row[key]) || 0;
     if (key === 'days_of_week') return formatDayGroup(row.days_of_week || []);
     if (key === 'insert_date' || key === 'update_date') return toTimestamp(row[key]);
     if (key === 'start_time' || key === 'end_time') return toTimeNumber(row[key]);
@@ -391,6 +392,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           insert_date: special.insert_date,
           update_date: special.update_date,
           matched_candidate_count: 0,
+          missed_run_count: 0,
           daySet: new Set(),
           specials: []
         });
@@ -399,6 +401,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
       const row = grouped.get(key);
       row.specials.push(special);
       row.matched_candidate_count += Number(special.matched_candidate_count || 0);
+      row.missed_run_count = Math.max(row.missed_run_count, Number(special.missed_run_count || 0));
       row.daySet.add(normalizeDay(special.day_of_week));
 
       const rowInsert = toTimestamp(row.insert_date);
@@ -1436,6 +1439,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         <td>${row.is_active || '—'}</td>
         <td>${row.insert_method || '—'}</td>
         <td>${row.matched_candidate_count ?? 0}</td>
+        <td>${row.missed_run_count ?? 0}</td>
         <td>${formatDateTime(row.insert_date)}</td>
         <td>${formatDateTime(row.update_date)}</td>
       </tr>
@@ -1457,6 +1461,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="is_active">Is Active${getSortIndicator('special-management', 'is_active')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_method">Insert Method${getSortIndicator('special-management', 'insert_method')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="matched_candidate_count">Matched Candidates${getSortIndicator('special-management', 'matched_candidate_count')}</th>
+              <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="missed_run_count">Missed Runs${getSortIndicator('special-management', 'missed_run_count')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_date">Insert Date${getSortIndicator('special-management', 'insert_date')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="update_date">Update Date${getSortIndicator('special-management', 'update_date')}</th>
             </tr>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -235,10 +235,9 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     manual_filter_clause = "AND insert_method <> 'MANUAL'" if IGNORE_MANUAL_SPECIALS_ON_PUBLISH == 'Y' else ''
     cursor.execute(
         f"""
-        SELECT special_id, day_of_week, all_day, start_time, end_time, description
+        SELECT special_id, day_of_week, all_day, start_time, end_time, description, is_active
         FROM special
         WHERE bar_id = %s
-            AND is_active = 'Y'
             {manual_filter_clause}
         """,
         (bar_id,),
@@ -269,7 +268,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                 INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
                 VALUES (%s, 1, %s, NOW())
                 ON DUPLICATE KEY UPDATE
-                    missed_run_count = IF(last_run_id = VALUES(last_run_id), missed_run_count, missed_run_count + 1),
+                    missed_run_count = missed_run_count + 1,
                     last_run_id = VALUES(last_run_id),
                     update_date = NOW()
                 """,
@@ -285,7 +284,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             )
             missed_run_record = cursor.fetchone() or {}
             should_deactivate = int(missed_run_record.get('missed_run_count', 0)) >= MISSED_RUN_DEACTIVATION_THRESHOLD
-            if not should_deactivate:
+            if not should_deactivate or special.get('is_active') != 'Y':
                 continue
             cursor.execute(
                 """
@@ -336,6 +335,8 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
             """
             UPDATE special
             SET special_candidate_id = %s
+                , is_active = 'Y'
+                , update_date = NOW()
             WHERE special_id = %s
             """,
             (candidate_id, special_id),
@@ -993,10 +994,21 @@ def update_special_candidate_approval(cursor, special_candidate_id: int, approva
             UPDATE special s
             JOIN special_candidate_special_match scsm ON scsm.special_id = s.special_id
             SET s.update_date = NOW(),
+                s.is_active = 'Y',
                 s.special_candidate_id = %s
             WHERE scsm.special_candidate_id = %s
             """,
             (special_candidate_id, special_candidate_id),
+        )
+        cursor.execute(
+            """
+            UPDATE special_missed_runs smr
+            JOIN special_candidate_special_match scsm ON scsm.special_id = smr.special_id
+            SET smr.missed_run_count = 0,
+                smr.update_date = NOW()
+            WHERE scsm.special_candidate_id = %s
+            """,
+            (special_candidate_id,),
         )
 
     cursor.execute(
@@ -1062,6 +1074,14 @@ def get_all_specials(cursor):
         """
     )
     special_rows = cursor.fetchall()
+    cursor.execute(
+        """
+        SELECT special_id, MAX(missed_run_count) AS missed_run_count
+        FROM special_missed_runs
+        GROUP BY special_id
+        """
+    )
+    missed_run_lookup = {row['special_id']: int(row.get('missed_run_count') or 0) for row in cursor.fetchall()}
     cursor.execute(
         """
         SELECT special_id, COUNT(*) AS matched_candidate_count
@@ -1157,6 +1177,7 @@ def get_all_specials(cursor):
                     [str(candidate.get('special_candidate_id')) for candidate in candidate_rows if candidate.get('special_candidate_id')]
                 ),
                 'matched_candidate_count': match_count_lookup.get(special_id, 0),
+                'missed_run_count': missed_run_lookup.get(special_id, 0),
             }
         )
 

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -662,7 +662,7 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
                     INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
                     VALUES (%s, 1, %s, NOW())
                     ON DUPLICATE KEY UPDATE
-                        missed_run_count = IF(last_run_id = VALUES(last_run_id), missed_run_count, missed_run_count + 1),
+                        missed_run_count = missed_run_count + 1,
                         last_run_id = VALUES(last_run_id),
                         update_date = NOW()
                     """,


### PR DESCRIPTION
### Motivation
- Expose and aggregate `missed_run_count` for specials so operators can see how many runs have missed matching candidates and allow automatic deactivation when thresholds are exceeded. 
- Ensure missed-run bookkeeping is reset when a special is approved or matched to a candidate and keep special activation state consistent when matches occur.

### Description
- Backend: track `missed_run_count` via `special_missed_runs` and include `missed_run_count` lookup in `get_all_specials` by querying `special_missed_runs` with `MAX(missed_run_count)` grouped by `special_id`. 
- Backend: increment `missed_run_count` on missed matches using `ON DUPLICATE KEY UPDATE missed_run_count = missed_run_count + 1`, avoid deactivation if the special is already inactive, set matched specials to `is_active = 'Y'` and update timestamps when matched, and reset `missed_run_count` to `0` for specials when a candidate is approved. 
- Backend: include `is_active` in the earlier `SELECT` used during publish flow so deactivation logic can inspect current activation state. 
- Frontend: aggregate `missed_run_count` when grouping specials (`row.missed_run_count = Math.max(...)`), add a `Missed Runs` sortable column to the specials admin table, display `missed_run_count` in each grouped row, and treat `missed_run_count` (and `matched_candidate_count`) as numeric in sorting via `specialSortValue`.

### Testing
- Ran the project's automated backend test suite and SQL-related unit tests, which completed without failures. 
- Ran the frontend build and linter to ensure the admin UI compiles, with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5024224488330aaf1042b948c2e0d)