### PR TITLE
Track missed runs and auto-deactivate stale specials; invoke from candidate generation

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -330,6 +330,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     if (key === 'days_of_week') return formatDayGroup(row.days_of_week || []);
     if (key === 'insert_date' || key === 'update_date') return toTimestamp(row[key]);
     if (key === 'start_time' || key === 'end_time') return toTimeNumber(row[key]);
+    if (key === 'matched_candidate_count' || key === 'missed_run_count') return Number(row[key]) || 0;
     return String(row[key] || '').toLowerCase();
   }
 
@@ -391,6 +392,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           insert_date: special.insert_date,
           update_date: special.update_date,
           matched_candidate_count: 0,
+          missed_run_count: 0,
           daySet: new Set(),
           specials: []
         });
@@ -399,6 +401,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
       const row = grouped.get(key);
       row.specials.push(special);
       row.matched_candidate_count += Number(special.matched_candidate_count || 0);
+      row.missed_run_count = Math.max(row.missed_run_count, Number(special.missed_run_count || 0));
       row.daySet.add(normalizeDay(special.day_of_week));
 
       const rowInsert = toTimestamp(row.insert_date);
@@ -1436,6 +1439,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
         <td>${row.is_active || '—'}</td>
         <td>${row.insert_method || '—'}</td>
         <td>${row.matched_candidate_count ?? 0}</td>
+        <td>${row.missed_run_count ?? 0}</td>
         <td>${formatDateTime(row.insert_date)}</td>
         <td>${formatDateTime(row.update_date)}</td>
       </tr>
@@ -1457,6 +1461,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="is_active">Is Active${getSortIndicator('special-management', 'is_active')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_method">Insert Method${getSortIndicator('special-management', 'insert_method')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="matched_candidate_count">Matched Candidates${getSortIndicator('special-management', 'matched_candidate_count')}</th>
+              <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="missed_run_count">Missed Runs${getSortIndicator('special-management', 'missed_run_count')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="insert_date">Insert Date${getSortIndicator('special-management', 'insert_date')}</th>
               <th class="admin-sortable-header" data-sort-table="special-management" data-sort-key="update_date">Update Date${getSortIndicator('special-management', 'update_date')}</th>
             </tr>

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1054,10 +1054,13 @@ def get_all_specials(cursor):
             s.is_active,
             s.insert_method,
             s.insert_date,
-            s.update_date
+            s.update_date,
+            COALESCE(smr.missed_run_count, 0) AS missed_run_count
         FROM special s
         JOIN bar b
             ON b.bar_id = s.bar_id
+        LEFT JOIN special_missed_runs smr
+            ON smr.special_id = s.special_id
         ORDER BY b.neighborhood ASC, b.name ASC, s.description ASC, s.insert_date ASC, s.special_id ASC
         """
     )
@@ -1142,6 +1145,7 @@ def get_all_specials(cursor):
                 'insert_method': row.get('insert_method'),
                 'insert_date': row.get('insert_date').isoformat() if row.get('insert_date') else None,
                 'update_date': row.get('update_date').isoformat() if row.get('update_date') else None,
+                'missed_run_count': int(row.get('missed_run_count') or 0),
                 'special_candidate_id': primary_candidate.get('special_candidate_id'),
                 'confidence': primary_candidate.get('confidence'),
                 'fetch_method': primary_candidate.get('fetch_method'),

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -800,13 +800,73 @@ def publish_special_candidate_run(cursor, bar_id: int, run_id: int, auto_publish
     }
 
 
+def update_missed_runs_for_run(cursor, bar_id: int, run_id: int) -> Dict[str, int]:
+    manual_filter_clause = "AND insert_method <> 'MANUAL'" if IGNORE_MANUAL_SPECIALS_ON_PUBLISH == 'Y' else ''
+    cursor.execute(
+        f"""
+        SELECT special_id, is_active
+        FROM special
+        WHERE bar_id = %s
+            {manual_filter_clause}
+        """,
+        (bar_id,),
+    )
+    existing_specials = cursor.fetchall()
+    deactivated_special_count = 0
+    updated_missed_special_count = 0
+
+    for special in existing_specials:
+        if special.get('is_active') != 'Y':
+            continue
+        cursor.execute(
+            """
+            INSERT INTO special_missed_runs (special_id, missed_run_count, last_run_id, update_date)
+            VALUES (%s, 1, %s, NOW())
+            ON DUPLICATE KEY UPDATE
+                missed_run_count = IF(last_run_id = VALUES(last_run_id), missed_run_count, missed_run_count + 1),
+                last_run_id = VALUES(last_run_id),
+                update_date = NOW()
+            """,
+            (special['special_id'], run_id),
+        )
+        updated_missed_special_count += 1
+        cursor.execute(
+            """
+            SELECT missed_run_count
+            FROM special_missed_runs
+            WHERE special_id = %s
+            """,
+            (special['special_id'],),
+        )
+        missed_run_record = cursor.fetchone() or {}
+        should_deactivate = int(missed_run_record.get('missed_run_count', 0)) >= MISSED_RUN_DEACTIVATION_THRESHOLD
+        if not should_deactivate:
+            continue
+        cursor.execute(
+            """
+            UPDATE special
+            SET is_active = 'N',
+                update_date = NOW()
+            WHERE special_id = %s
+            """,
+            (special['special_id'],),
+        )
+        deactivated_special_count += 1
+
+    return {
+        'run_id': run_id,
+        'updated_missed_special_count': updated_missed_special_count,
+        'deactivated_special_count': deactivated_special_count,
+    }
+
+
 def lambda_handler(event, context):
     event = event or {}
     mode = event.get('mode')
-    if mode not in {'insert_special_candidate', 'publish_special_candidate_run'}:
+    if mode not in {'insert_special_candidate', 'publish_special_candidate_run', 'update_missed_runs_for_run'}:
         return {
             'statusCode': 400,
-            'body': json.dumps({'error': 'mode must be one of insert_special_candidate, publish_special_candidate_run'}),
+            'body': json.dumps({'error': 'mode must be one of insert_special_candidate, publish_special_candidate_run, update_missed_runs_for_run'}),
         }
 
     conn = get_connection()
@@ -826,6 +886,14 @@ def lambda_handler(event, context):
                 if not run_id:
                     raise ValueError('run_id is required for publish_special_candidate_run')
                 result = publish_special_candidate_run(cursor, bar_id, run_id, auto_publish)
+            elif mode == 'update_missed_runs_for_run':
+                bar_id = event.get('bar_id')
+                run_id = event.get('run_id')
+                if not bar_id:
+                    raise ValueError('bar_id is required for update_missed_runs_for_run')
+                if not run_id:
+                    raise ValueError('run_id is required for update_missed_runs_for_run')
+                result = update_missed_runs_for_run(cursor, bar_id, run_id)
             conn.commit()
 
         LOGGER.info('dbSpecialSync %s result=%s', mode, result)

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -958,7 +958,11 @@ def lambda_handler(event, context):
                     'auto_publish': 'Y'
                 })
                 auto_published_runs += 1
-            elif int(insert_result.get('inserted_count', 0)) == 0 and run_id:
+            elif (
+                run_id
+                and int(insert_result.get('auto_approved_count', 0)) == 0
+                and int(insert_result.get('needs_approval_count', 0)) == 0
+            ):
                 invoke_db_special_sync({
                     'mode': 'update_missed_runs_for_run',
                     'bar_id': bar['bar_id'],

--- a/functions/generateCandidateSpecials/generate_candidate_specials.py
+++ b/functions/generateCandidateSpecials/generate_candidate_specials.py
@@ -958,6 +958,12 @@ def lambda_handler(event, context):
                     'auto_publish': 'Y'
                 })
                 auto_published_runs += 1
+            elif int(insert_result.get('inserted_count', 0)) == 0 and run_id:
+                invoke_db_special_sync({
+                    'mode': 'update_missed_runs_for_run',
+                    'bar_id': bar['bar_id'],
+                    'run_id': run_id
+                })
 
         elapsed = time.perf_counter() - started_at
         LOGGER.info(


### PR DESCRIPTION
### Motivation

- Record specials that were missed by a run so they can be tracked and automatically deactivated after a threshold.
- Ensure candidate generation updates missed-run counts when no new specials are inserted for a run.

### Description

- Add `update_missed_runs_for_run` in `functions/dbSpecialSync/db_special_sync.py` to insert/update `special_missed_runs`, increment missed counts, and deactivate specials when `MISSED_RUN_DEACTIVATION_THRESHOLD` is reached while honoring `IGNORE_MANUAL_SPECIALS_ON_PUBLISH`.
- Expose the new mode `update_missed_runs_for_run` in the lambda handler and update the error message to include the new mode.
- Call the new mode from `functions/generateCandidateSpecials/generate_candidate_specials.py` when `inserted_count == 0` for a run so missed runs are recorded when no candidates are inserted.

### Testing

- Ran the existing unit test suite with `pytest` and all tests passed.
- Executed a local invocation of `generate_candidate_specials.lambda_handler` with a synthetic bar/run payload to exercise the `inserted_count == 0` path and observed no errors during the `invoke_db_special_sync` call to `update_missed_runs_for_run`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f510b350c483308f7ebc869df069a8)