### PR TITLE
Improve special candidate auto-matching to consider day_of_week for multi-day specials

### DIFF
--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -438,6 +438,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     continue
                 possible_matches.append({
                     'special_id': special['special_id'],
+                    'day_of_week': _normalize_day_of_week(special.get('day_of_week')),
                     'score': fuzzy_description_match_score,
                 })
                 cursor.execute(
@@ -452,8 +453,28 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             match_status = 'MATCHED_REJECT'
         elif possible_matches:
             top_score = max(match.get('score', 0.0) for match in possible_matches)
-            if len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD:
-                matched_special_ids = [possible_matches[0]['special_id']]
+            can_auto_match = len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
+
+            if not can_auto_match and normalized_candidate_days:
+                matches_by_day = {day: [] for day in normalized_candidate_days}
+                for possible_match in possible_matches:
+                    match_day = possible_match.get('day_of_week')
+                    if match_day in matches_by_day:
+                        matches_by_day[match_day].append(possible_match)
+
+                has_exactly_one_match_per_day = (
+                    set(matches_by_day.keys()) == normalized_candidate_days
+                    and all(len(day_matches) == 1 for day_matches in matches_by_day.values())
+                    and all(
+                        day_matches[0].get('score', 0.0) >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
+                        for day_matches in matches_by_day.values()
+                    )
+                )
+                if has_exactly_one_match_per_day:
+                    can_auto_match = True
+
+            if can_auto_match:
+                matched_special_ids = [match['special_id'] for match in possible_matches]
                 match_status = 'AUTO_MATCHED'
                 if approval_status == 'NOT_APPROVED' and confidence >= SPECIAL_CANDIDATE_SPECIAL_MATCH_CONFIDENCE_AUTO_APPROVAL_THRESHOLD:
                     approval_status = 'AUTO_APPROVED'


### PR DESCRIPTION
### Motivation
- Ensure special candidates that span multiple days can be auto-matched when there is a clear one-to-one correspondence by day.
- Reduce false pending matches by leveraging `day_of_week` and per-day description match scores for more accurate auto-matching decisions.

### Description
- Include `day_of_week` in each `possible_matches` entry so matches carry the normalized day information.
- Add logic that groups `possible_matches` by the candidate's normalized days and allows auto-match when there is exactly one match per candidate day and every match meets `SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD`.
- Preserve the original single-match auto-match path (`len(possible_matches) == 1` and top score check) and otherwise mark ambiguous cases as `MATCH_PENDING` or `MATCHED_REJECT` as before.
- Leave the existing auto-approval behavior intact where `match_status` becomes `AUTO_MATCHED` and `approval_status` may become `AUTO_APPROVED` when thresholds are met.

### Testing
- Ran the code path exercising `insert_special_candidate` with single-day and multi-day candidate scenarios using the matching thresholds; expected auto-match and pending outcomes were observed and the changes behaved as intended. 
- Executed the repository unit tests related to special matching; they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6334315148330b8b0a9a6b93c7382)