### PR TITLE
Use max rather than sum when aggregating matched_candidate_count for grouped specials

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -400,7 +400,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
       const row = grouped.get(key);
       row.specials.push(special);
-      row.matched_candidate_count += Number(special.matched_candidate_count || 0);
+      row.matched_candidate_count = Math.max(row.matched_candidate_count, Number(special.matched_candidate_count || 0));
       row.missed_run_count = Math.max(row.missed_run_count, Number(special.missed_run_count || 0));
       row.daySet.add(normalizeDay(special.day_of_week));
 
@@ -420,6 +420,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     return [...grouped.values()]
       .map((row) => ({
         ...row,
+        matched_candidate_count: row.matched_candidate_count,
         days_of_week: sortDays([...row.daySet]),
         representative_special_id: row.specials[0]?.special_id
       }))


### PR DESCRIPTION
### Motivation
- Prevent inflated `matched_candidate_count` when grouping multiple special records by using the maximum per group instead of summing counts from each row.

### Description
- Replace additive aggregation of `matched_candidate_count` with `Math.max` so the grouped value reflects the largest count among members.
- Keep `missed_run_count` aggregated via `Math.max` and ensure the returned mapped object explicitly includes `matched_candidate_count`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d599bb3083309adf3e94dae93ec6)