### PR TITLE
Filter neighborhood special generation input to active bars

### DIFF
--- a/functions/dbBarSync/db_bar_sync.py
+++ b/functions/dbBarSync/db_bar_sync.py
@@ -151,6 +151,7 @@ def get_bars_by_neighborhood(cursor, neighborhood: str) -> Dict[str, List[Dict]]
         SELECT bar_id, name AS bar_name, neighborhood, website_url
         FROM bar
         WHERE neighborhood = %s
+            AND is_active = 'Y'
         ORDER BY last_special_candidate_run ASC, bar_id ASC
         """,
         (neighborhood,),


### PR DESCRIPTION
### Motivation
- Neighborhood-mode special candidate generation used `dbBarSync:get_bars_by_neighborhood` which could return inactive bars, causing `generate_candidate_specials` to attempt to crawl or search for specials for closed venues.

### Description
- Restrict `get_bars_by_neighborhood` to active bars by adding `AND is_active = 'Y'` to the SQL `WHERE` clause in `functions/dbBarSync/db_bar_sync.py`.

### Testing
- Ran `python -m py_compile functions/dbBarSync/db_bar_sync.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f3044a848330975c81c3ebef2e9a)