### PR TITLE
Sort pending-approval matched specials by description match score

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1265,6 +1265,12 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
 
         const matchedSpecials = Array.isArray(special.matched_specials) ? special.matched_specials : [];
         const groupedMatchedSpecials = (() => {
+          const getDescriptionMatchScore = (matched) => {
+            const rawScore = matched?.fuzzy_description_match_score;
+            if (rawScore === null || rawScore === undefined || rawScore === '') return Number.NEGATIVE_INFINITY;
+            const numericScore = Number(rawScore);
+            return Number.isFinite(numericScore) ? numericScore : Number.NEGATIVE_INFINITY;
+          };
           const grouped = new Map();
           matchedSpecials.forEach((matched) => {
             const descriptionKey = String(matched?.description || '').trim().toLowerCase();
@@ -1288,11 +1294,13 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
               row.day_of_week.push(matched.day_of_week);
             }
           });
-          return [...grouped.values()].map((row) => ({
-            ...row,
-            special_ids: [...new Set(row.special_ids)],
-            day_of_week: sortDays(row.day_of_week)
-          }));
+          return [...grouped.values()]
+            .map((row) => ({
+              ...row,
+              special_ids: [...new Set(row.special_ids)],
+              day_of_week: sortDays(row.day_of_week)
+            }))
+            .sort((left, right) => getDescriptionMatchScore(right) - getDescriptionMatchScore(left));
         })();
         const matchStatus = String(special.match_status || 'NOT_MATCHED').toUpperCase();
         const matchedSpecialsMarkup = groupedMatchedSpecials.length


### PR DESCRIPTION
### Motivation
- When multiple possible matches exist for a special candidate in the Specials Pending Approval view, admins should see the highest-confidence description matches first.
- The existing grouping could present matches in arbitrary order when scores are missing or non-numeric, creating a poor UX.

### Description
- Added a helper `getDescriptionMatchScore` to robustly parse `fuzzy_description_match_score` and treat `null`/empty/non-numeric values as lowest priority (`Number.NEGATIVE_INFINITY`).
- After grouping duplicate matched-special rows, the grouped results are now sorted by description match score in descending order so higher scores appear first.
- Changes are localized to `admin/admin.js` and do not alter the grouping logic other than appending a sort step after grouping and normalization.

### Testing
- Ran `npm test -- --runInBand` to execute project tests, but the command failed because the repository in this environment does not contain a `package.json`, so automated tests could not be run here.
- Verified the change by inspecting the updated `admin/admin.js` grouping and sorting logic to ensure scores are parsed and ordering is applied as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90a78855483309b040212a17113cf)