### PR TITLE
Show override action for AUTO_MATCHED special candidates

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1331,7 +1331,7 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
           : '';
 
 
-        const showOverrideMatchAction = matchStatus === 'MATCHED';
+        const showOverrideMatchAction = matchStatus === 'MATCHED' || matchStatus === 'AUTO_MATCHED';
         return `
           <article class="admin-candidate-card" data-candidate-id="${candidateId}">
             ${(isEditing || isReadOnlyCandidate) ? '' : `


### PR DESCRIPTION
### Motivation
- Allow administrators to see and use the override/confirm match action for candidates that were automatically matched by the system (`AUTO_MATCHED`) in addition to manually matched (`MATCHED`) candidates.

### Description
- Update `admin/admin.js` to set `showOverrideMatchAction` when `matchStatus === 'MATCHED' || matchStatus === 'AUTO_MATCHED'`, so the override UI is rendered for auto-matched special candidates.

### Testing
- Ran the frontend unit test and lint suite with `npm test` and `npm run lint`, and the suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e7eb4e5083308391b55c797c7779)