### PR TITLE
Prevent duplicate specials in web crawl prompt

### DIFF
--- a/functions/generateCandidateSpecials/web_crawl_prompt.txt
+++ b/functions/generateCandidateSpecials/web_crawl_prompt.txt
@@ -75,8 +75,10 @@ Final check:
   - Each item should be its own special (Ex: $2 off beers, $5 wings, $2 off appetizers should be three separate specials)
   - BUT when multiple items share the same price or discount, day, and time range, group them into a single special by combining the item names into one description (e.g., "$2 Miller Lite, Bud Light, and White Claw").
   - Ensure special type is still accurate for each parsed special
-- Ensure there are no duplicated specials sent in the response
-  - Criteria for duplicate: matching description, days_of_week, all_day, start_time, end_time
+- Ensure there are no duplicated specials sent in the response.
+  - Criteria for duplicate: matching description, type, days_of_week, all_day, start_time, end_time, and source_url.
+  - Do not emit duplicate candidates even as low-confidence entries; keep only one copy (the most complete version) and remove all others before returning JSON.
+  - Notes must explain extraction confidence only; never mention that an item is repeated or a duplicate.
 
 Return ONLY valid JSON (an array). No explanations.
 


### PR DESCRIPTION
### Motivation
- The crawl sometimes emitted duplicate special candidates (identical description, timing, and source) and even included notes acknowledging repetition, so the extraction prompt must prevent returning duplicate entries.

### Description
- Update `functions/generateCandidateSpecials/web_crawl_prompt.txt` final dedup rules to include `type` and `source_url`, require removing duplicate candidates (keep the most complete copy), and require `notes` to explain confidence only.

### Testing
- Verified the prompt file was updated and PR metadata was created; no automated unit tests were run because this is a prompt-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0db2f4a88330825942ba4522320a)