### PR TITLE
Allow auto-matching when candidate end_time is implied as closing and update crawl prompt

### DIFF
--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -471,12 +471,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     continue
                 if candidate_end != special_end:
                     continue
-                candidate_missing_end_time_filled_from_close = (
-                    _normalize_yn_flag(candidate.get('all_day')) == 'N'
-                    and not _normalize_time_value(candidate.get('end_time'))
-                    and bool(_normalize_time_value(open_hours_lookup.get(special_day, {}).get('close_time')))
-                    and candidate_end == _normalize_time_value(open_hours_lookup.get(special_day, {}).get('close_time'))
-                )
                 fuzzy_description_match_score = _description_match_score(
                     candidate.get('description'),
                     special.get('description'),
@@ -487,7 +481,6 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     'special_id': special['special_id'],
                     'day_of_week': _normalize_day_of_week(special.get('day_of_week')),
                     'score': fuzzy_description_match_score,
-                    'missing_end_filled_from_close': candidate_missing_end_time_filled_from_close,
                 })
                 cursor.execute(
                     """
@@ -501,16 +494,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             match_status = 'MATCHED_REJECT'
         elif possible_matches:
             top_score = max(match.get('score', 0.0) for match in possible_matches)
-            single_match_missing_end_filled_from_close = (
-                len(possible_matches) == 1 and bool(possible_matches[0].get('missing_end_filled_from_close'))
-            )
-            can_auto_match = (
-                len(possible_matches) == 1
-                and (
-                    top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
-                    or single_match_missing_end_filled_from_close
-                )
-            )
+            can_auto_match = len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
 
             if not can_auto_match and normalized_candidate_days:
                 matches_by_day = {day: [] for day in normalized_candidate_days}

--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -471,6 +471,12 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     continue
                 if candidate_end != special_end:
                     continue
+                candidate_missing_end_time_filled_from_close = (
+                    _normalize_yn_flag(candidate.get('all_day')) == 'N'
+                    and not _normalize_time_value(candidate.get('end_time'))
+                    and bool(_normalize_time_value(open_hours_lookup.get(special_day, {}).get('close_time')))
+                    and candidate_end == _normalize_time_value(open_hours_lookup.get(special_day, {}).get('close_time'))
+                )
                 fuzzy_description_match_score = _description_match_score(
                     candidate.get('description'),
                     special.get('description'),
@@ -481,6 +487,7 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     'special_id': special['special_id'],
                     'day_of_week': _normalize_day_of_week(special.get('day_of_week')),
                     'score': fuzzy_description_match_score,
+                    'missing_end_filled_from_close': candidate_missing_end_time_filled_from_close,
                 })
                 cursor.execute(
                     """
@@ -494,7 +501,16 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
             match_status = 'MATCHED_REJECT'
         elif possible_matches:
             top_score = max(match.get('score', 0.0) for match in possible_matches)
-            can_auto_match = len(possible_matches) == 1 and top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
+            single_match_missing_end_filled_from_close = (
+                len(possible_matches) == 1 and bool(possible_matches[0].get('missing_end_filled_from_close'))
+            )
+            can_auto_match = (
+                len(possible_matches) == 1
+                and (
+                    top_score >= SPECIAL_CANDIDATE_SPECIAL_MATCH_DESC_AUTO_MATCH_THRESHOLD
+                    or single_match_missing_end_filled_from_close
+                )
+            )
 
             if not can_auto_match and normalized_candidate_days:
                 matches_by_day = {day: [] for day in normalized_candidate_days}

--- a/functions/generateCandidateSpecials/web_crawl_prompt.txt
+++ b/functions/generateCandidateSpecials/web_crawl_prompt.txt
@@ -63,6 +63,7 @@ Normalization rules:
   - Clear determination of day/time/recurrance for each item
   - If a price or discount is visible in the source text but missing from description, fix the description.
   - If a special is not all-day and the start time or end time is missing, lower the confidence
+  - Exception: do not lower confidence when end_time is missing but the source clearly indicates the special runs until close/closing (treat missing end_time as closing time for that day).
   - Omit labels such as "happy hour" or time descriptors from description and keep only the actual offer details in the description.
 - If one of the following are missing from the parsed description, score confidence .5 or less:
   - Price or discount amount


### PR DESCRIPTION
### Motivation
- Improve matching of scraped specials when the source omits an explicit `end_time` but indicates the offer runs until closing, avoiding false non-matches.
- Align the web-crawl parsing instructions with the matching logic so confidence scoring treats missing `end_time` that implies close as valid.

### Description
- In `functions/dbSpecialSync/db_special_sync.py` add detection of a candidate whose missing `end_time` was implicitly filled from the venue's closing time and attach a `missing_end_filled_from_close` flag to possible matches. 
- Update the auto-match logic to allow automatic matching when there is a single possible match and that match has `missing_end_filled_from_close`, in addition to the existing fuzzy-score threshold condition. 
- Propagate the new flag through the `possible_matches` structure and use it when computing `can_auto_match`.
- Update `functions/generateCandidateSpecials/web_crawl_prompt.txt` to add an exception to the confidence rules that says not to lower confidence when `end_time` is missing but the source clearly indicates the special runs until close/closing.

### Testing
- Ran existing unit tests targeting the special candidate matching logic and they passed successfully. 
- Ran static checks/linter on modified files with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa15c8aa148330897e22d4b296520d)