### PR TITLE
Add unmatch flow for pending-approval candidate matches

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -602,6 +602,26 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
     }
   }
 
+  async function unmatchCandidate(specialCandidateId) {
+    state.updatingCandidateId = specialCandidateId;
+    state.errorMessage = '';
+    render();
+
+    try {
+      await callAdminSync({
+        mode: 'unmatch_special_candidate',
+        special_candidate_id: specialCandidateId
+      });
+      await loadUnapprovedSpecials();
+    } catch (err) {
+      console.error('Failed to unmatch candidate:', err);
+      state.errorMessage = err?.message || 'Failed to unmatch candidate.';
+    } finally {
+      state.updatingCandidateId = null;
+      render();
+    }
+  }
+
   async function saveCandidateUpdates(payload) {
     state.savingCandidate = true;
     state.errorMessage = '';
@@ -1323,7 +1343,9 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
                     <p><strong>Update Date:</strong> ${formatDateTime(matched.update_date)}</p>
                     ${(matchStatus === 'MATCH_PENDING')
                       ? `<button class="admin-secondary-btn" type="button" data-candidate-action="confirm-match" data-candidate-id="${candidateId}" data-special-ids="${escapeAttribute((matched.special_ids && matched.special_ids.length ? matched.special_ids : [matched.special_id]).filter((specialId) => specialId !== undefined && specialId !== null).join(','))}" ${isUpdating ? 'disabled' : ''}>Confirm Match</button>`
-                      : ''}
+                      : (matchStatus === 'MATCHED'
+                        ? `<button class="admin-secondary-btn" type="button" data-candidate-action="unmatch" data-candidate-id="${candidateId}" ${isUpdating ? 'disabled' : ''}>Unmatch</button>`
+                        : '')}
                   </article>
                 `).join('')}
               </div>
@@ -1598,6 +1620,11 @@ const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-e
             .filter(Boolean);
           if (!specialIds.length) return;
           await confirmCandidateMatch(candidateId, specialIds);
+          return;
+        }
+
+        if (action === 'unmatch') {
+          await unmatchCandidate(candidateId);
           return;
         }
 

--- a/functions/dbAdminSync/db_admin_sync.py
+++ b/functions/dbAdminSync/db_admin_sync.py
@@ -1837,6 +1837,33 @@ def confirm_special_candidate_match(cursor, special_candidate_id: int, special_i
         'approval_status': approval_status,
     }
 
+def unmatch_special_candidate(cursor, special_candidate_id: int):
+    cursor.execute(
+        """
+        SELECT special_candidate_id
+        FROM special_candidate
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+    candidate = cursor.fetchone()
+    if not candidate:
+        raise ValueError('special_candidate_id was not found')
+
+    cursor.execute(
+        """
+        UPDATE special_candidate
+        SET match_status = 'MATCH_PENDING'
+        WHERE special_candidate_id = %s
+        """,
+        (special_candidate_id,),
+    )
+
+    return {
+        'special_candidate_id': special_candidate_id,
+        'match_status': 'MATCH_PENDING',
+    }
+
 def _parse_event_payload(event):
     if not isinstance(event, dict):
         return {}
@@ -1868,6 +1895,7 @@ def lambda_handler(event, context):
         'delete_special_candidate_run',
         'update_special_candidate_approval',
         'confirm_special_candidate_match',
+        'unmatch_special_candidate',
         'get_all_specials',
         'update_special',
         'delete_special',
@@ -1891,6 +1919,7 @@ def lambda_handler(event, context):
                         'remove_rejected_special_candidate, '
                         'delete_special_candidate_run, '
                         'update_special_candidate_approval, confirm_special_candidate_match, get_all_specials, update_special, delete_special, reject_special, insert_special, '
+                        'unmatch_special_candidate, '
                         'update_special_candidate, get_all_bars, get_bar_details, update_bar, update_open_hours'
                     )
                 }
@@ -1926,6 +1955,11 @@ def lambda_handler(event, context):
                 if not special_candidate_id or not special_ids:
                     raise ValueError('special_candidate_id and special_ids are required for confirm_special_candidate_match')
                 result = confirm_special_candidate_match(cursor, int(special_candidate_id), special_ids)
+            elif mode == 'unmatch_special_candidate':
+                special_candidate_id = event.get('special_candidate_id')
+                if special_candidate_id in (None, ''):
+                    raise ValueError('special_candidate_id is required for unmatch_special_candidate')
+                result = unmatch_special_candidate(cursor, int(special_candidate_id))
             elif mode == 'remove_rejected_special_candidate':
                 special_candidate_id = event.get('special_candidate_id')
                 if not special_candidate_id:


### PR DESCRIPTION
### Motivation
- Provide a safe revert for accidentally confirmed candidate matches by allowing admins to set a candidate back to `MATCH_PENDING` while keeping match candidates visible.

### Description
- Added `unmatch_special_candidate(cursor, special_candidate_id)` in `functions/dbAdminSync/db_admin_sync.py` which validates the candidate exists and updates `match_status` to `MATCH_PENDING` without deleting match rows.
- Registered the new `unmatch_special_candidate` mode in the Lambda mode allowlist and added routing to call it from the admin UI.
- Added `unmatchCandidate(specialCandidateId)` to `admin/admin.js` which calls the new backend mode and reloads unapproved specials.
- Rendered an `Unmatch` button in the matched-special card when a candidate's `match_status` is `MATCHED`, and wired the button handler to invoke the `unmatch` action.

### Testing
- Ran `node --check admin/admin.js` to validate the updated admin JS (passed).
- Ran `python -m py_compile functions/dbAdminSync/db_admin_sync.py` to validate the updated Python Lambda code (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf0b311388330b4a7d30c93dbc87e)