### PR TITLE
Lock mobile zoom (disable pinch and double-tap) and fix viewport scaling

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,7 +1,30 @@
 const DB_ADMIN_SYNC_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/dbAdminSync';
 const GENERATE_CANDIDATE_SPECIALS_API_URL = 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/generateCandidateSpecials';
 
+function initZoomLock() {
+  let lastTouchEnd = 0;
+
+  document.addEventListener('gesturestart', (event) => {
+    event.preventDefault();
+  }, { passive: false });
+
+  document.addEventListener('touchmove', (event) => {
+    if (event.touches.length > 1) {
+      event.preventDefault();
+    }
+  }, { passive: false });
+
+  document.addEventListener('touchend', (event) => {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 300) {
+      event.preventDefault();
+    }
+    lastTouchEnd = now;
+  }, { passive: false });
+}
+
 (function initAdminPage() {
+  initZoomLock();
   const backButton = document.getElementById('admin-back-button');
   const homeButton = document.getElementById('admin-home-button');
   const titleElement = document.getElementById('admin-title');

--- a/admin/index.html
+++ b/admin/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Admin</title>
 <link rel="stylesheet" href="/admin/admin.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Bar App</title>
 
 <!-- Link to external CSS -->

--- a/js/app.js
+++ b/js/app.js
@@ -270,6 +270,29 @@ function initHomeScrollCapture() {
   }, { passive: false });
 }
 
+
+function initZoomLock() {
+  let lastTouchEnd = 0;
+
+  document.addEventListener('gesturestart', (event) => {
+    event.preventDefault();
+  }, { passive: false });
+
+  document.addEventListener('touchmove', (event) => {
+    if (event.touches.length > 1) {
+      event.preventDefault();
+    }
+  }, { passive: false });
+
+  document.addEventListener('touchend', (event) => {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 300) {
+      event.preventDefault();
+    }
+    lastTouchEnd = now;
+  }, { passive: false });
+}
+
 function initSidebarFilters() {
   const hamburgerButton = document.querySelector('.hamburger-button');
   const sideMenu = document.getElementById('side-menu');
@@ -354,6 +377,7 @@ initTaskbar();
 initBarsSearch();
 initAdminTitleTapEntry();
 initHomeScrollCapture();
+initZoomLock();
 if (typeof initMapDayController === 'function') {
   initMapDayController();
 }


### PR DESCRIPTION
### Motivation

- Prevent accidental zooming on mobile that breaks the app layout and scrolling behavior by locking pinch and double-tap zoom.

### Description

- Updated the `index.html` viewport meta to `width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no` to lock scaling on mobile devices.
- Added `initZoomLock()` in `js/app.js` which registers handlers for `gesturestart`, `touchmove`, and `touchend` (with `{ passive: false }`) to prevent pinch-to-zoom and double-tap zooming.
- Invoked `initZoomLock()` during initialization so the zoom lock is active when the app starts.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff59d85154833086580b86dc7558a7)