### PR TITLE
Fix app title tap behavior: preserve admin five-tap and add Specials single-tap scroll reset

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -228,10 +228,14 @@ function initAdminTitleTapEntry() {
 
   if (!appTitle) return;
 
-  appTitle.addEventListener('click', () => {
+  const handleTitleTap = () => {
     tapCount += 1;
     if (tapTimer) clearTimeout(tapTimer);
     tapTimer = setTimeout(() => {
+      if (tapCount === 1 && currentTab === 'specials') {
+        const homeScreen = document.getElementById('home-screen');
+        if (homeScreen) homeScreen.scrollTop = 0;
+      }
       tapCount = 0;
     }, tapResetMs);
 
@@ -240,7 +244,9 @@ function initAdminTitleTapEntry() {
       if (tapTimer) clearTimeout(tapTimer);
       window.location.assign('/admin');
     }
-  });
+  };
+
+  appTitle.addEventListener('pointerup', handleTitleTap);
 }
 
 function initHomeScrollCapture() {


### PR DESCRIPTION
### Motivation
- The hidden five-tap admin entry stopped working reliably on touch due to interaction with the zoom-lock/touch prevention handlers. 
- The app should still prevent pinch/zoom gestures while restoring reliable multi-tap detection. 
- Users want a quick way to reset the Specials list scroll position by tapping the app title.

### Description
- Replaced the `click` listener on the `.app-title` element with a `pointerup` listener and extracted the handler to `handleTitleTap`. 
- Added a single-tap behavior inside the existing tap timer so that when `tapCount === 1` and `currentTab === 'specials'`, the `home-screen` scroll is reset with `homeScreen.scrollTop = 0`. 
- Preserved the existing five-tap threshold logic that redirects to `/admin`. 
- Did not modify the zoom-lock logic in `initZoomLock`, so pinch/gesture prevention remains active.

### Testing
- Ran `node --check js/app.js` which completed successfully. 
- Attempted `npm test --silent` but the project has no `package.json`, so no test runner was available to run unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b08944288330b5b5e808526fbd50)