### PR TITLE
Hide active/upcoming divider when no cards precede it

### DIFF
--- a/js/render-home.js
+++ b/js/render-home.js
@@ -189,7 +189,8 @@ function renderBarsWeek() {
 
         withoutActiveOrUpcoming.forEach((entry) => container.appendChild(entry.card));
 
-        if (withoutActiveOrUpcoming.length > 0 && withActiveOrUpcoming.length > 0) {
+        const hasBarCardsAboveDivider = container.querySelector('.bar-card') !== null;
+        if (hasBarCardsAboveDivider && withoutActiveOrUpcoming.length > 0 && withActiveOrUpcoming.length > 0) {
           const divider = document.createElement('div');
           divider.className = 'active-upcoming-divider';
           container.appendChild(divider);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -759,6 +759,45 @@ test('buildSpecialItem clickable rows stop parent click handling and navigate to
   assert.equal(onClickCalled, true, 'clickable specials still execute their own navigation handler');
 });
 
+test('renderBarsWeek does not render active/upcoming divider when there are no bar cards above it', async () => {
+  const document = new DocumentMock();
+  mountBaseNodes(document);
+  const ctx = loadAppWithoutBoot(document);
+
+  vm.runInContext(`
+    startupData = {
+      bars: {
+        '2': { id: 2, name: 'Upcoming Specials Bar', neighborhood: 'Downtown', image_url: null, currently_open: true, is_open_now: true, has_special_this_week: true }
+      },
+      open_hours: {
+        '2': { MON: { display_text: '4:00 PM - 2:00 AM' } }
+      },
+      specials: {
+        '22': { bar_id: 2, description: '$6 IPA', special_type: 'drink', all_day: false, start_time: '19:00', end_time: '21:00', current_status: 'upcoming' }
+      },
+      specials_by_day: {
+        MON: [{ bar_id: 2, specials: ['22'] }],
+        TUE: [],
+        WED: [],
+        THU: [],
+        FRI: [],
+        SAT: [],
+        SUN: []
+      }
+    };
+    currentTab = 'specials';
+    activeFilters.types = [];
+    activeFilters.neighborhoods = [];
+    activeFilters.favoritesOnly = false;
+  `, ctx);
+
+  ctx.renderBarsWeek();
+  await new Promise((resolve) => setTimeout(resolve, 1));
+
+  const divider = document.querySelector('.active-upcoming-divider');
+  assert.equal(divider, null, 'does not render divider with only active/upcoming cards');
+});
+
 test('combo specials render both icons and pass food/drink type filters', () => {
   const document = new DocumentMock();
   mountBaseNodes(document);

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -766,6 +766,7 @@ test('renderBarsWeek does not render active/upcoming divider when there are no b
 
   vm.runInContext(`
     startupPayload = {
+      general_data: { current_day: 'MON' },
       bars: {
         '2': { id: 2, name: 'Upcoming Specials Bar', neighborhood: 'Downtown', image_url: null, currently_open: true, is_open_now: true, has_special_this_week: true }
       },

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -765,7 +765,7 @@ test('renderBarsWeek does not render active/upcoming divider when there are no b
   const ctx = loadAppWithoutBoot(document);
 
   vm.runInContext(`
-    startupData = {
+    startupPayload = {
       bars: {
         '2': { id: 2, name: 'Upcoming Specials Bar', neighborhood: 'Downtown', image_url: null, currently_open: true, is_open_now: true, has_special_this_week: true }
       },


### PR DESCRIPTION
### Motivation
- Prevent rendering an empty `active-upcoming-divider` when there are no `.bar-card` elements above it to avoid a misleading visual divider.
- Fixes a regression where the divider could appear at the top of the list when only active/upcoming cards exist for the day.

### Description
- Added a guard in `renderBarsWeek` (`js/render-home.js`) that checks `container.querySelector('.bar-card') !== null` before inserting the `active-upcoming-divider`.
- Added a regression test `renderBarsWeek does not render active/upcoming divider when there are no bar cards above it` in `tests/app.test.js` to ensure the divider is not rendered for days with only active/upcoming cards.

### Testing
- Ran the test suite with `npm test` (runs `node --test tests/*.test.js`).
- All tests passed: `23` tests, `0` failures, including the new regression test which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b36d79d483308e72d450632d19fd)