### PR TITLE
Fix upcoming timed-special ordering in startup payload

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -253,8 +253,34 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
 
     # 3: at least one upcoming timed special, or only all-day and not yet opened
     if has_upcoming_timed or (all_day and not timed and not_yet_opened):
-        sort_start = min(upcoming_start_minutes) if has_upcoming_timed and upcoming_start_minutes else (open_minutes if open_minutes is not None else 10 ** 9)
-        sort_end = min(upcoming_end_minutes) if has_upcoming_timed and upcoming_end_minutes else (close_minutes if close_minutes is not None else 10 ** 9)
+        if has_upcoming_timed:
+            # Keep upcoming sorting anchored to upcoming specials only. Normalize starts/ends
+            # relative to now so overnight windows still sort by nearest upcoming relevance.
+            upcoming_sort_windows = []
+            for special in upcoming_timed:
+                start_minutes = to_minutes(special.get('start_time'))
+                end_minutes = to_minutes(special.get('end_time'))
+                if start_minutes is None or end_minutes is None:
+                    continue
+                normalized_start = start_minutes
+                normalized_end = end_minutes
+                if end_minutes < start_minutes:
+                    normalized_end += 24 * 60
+                    if normalized_start <= current_minutes:
+                        normalized_start += 24 * 60
+                if normalized_start <= current_minutes:
+                    normalized_start += 24 * 60
+                    normalized_end += 24 * 60
+                upcoming_sort_windows.append((normalized_start, normalized_end))
+
+            if upcoming_sort_windows:
+                sort_start, sort_end = min(upcoming_sort_windows, key=lambda window: (window[0], window[1]))
+            else:
+                sort_start = min(upcoming_start_minutes) if upcoming_start_minutes else (open_minutes if open_minutes is not None else 10 ** 9)
+                sort_end = min(upcoming_end_minutes) if upcoming_end_minutes else (close_minutes if close_minutes is not None else 10 ** 9)
+        else:
+            sort_start = open_minutes if open_minutes is not None else 10 ** 9
+            sort_end = close_minutes if close_minutes is not None else 10 ** 9
         return (3, sort_start, sort_end)
 
     # 1: past timed + all-day (with no active/upcoming timed), or only all-day while closed, sorted by closing time


### PR DESCRIPTION
### Motivation
- Prevent past timed specials from skewing today’s bar ordering by ensuring upcoming-sort keys are derived from upcoming timed specials only. 
- Handle specials that cross midnight so upcoming windows sort by nearest upcoming relevance. 
- Preserve existing all-day and fallback behavior when upcoming windows are not fully sortable.

### Description
- Updated `classify_today_bar_order` in `functions/getStartupData/get_startup_data.py` to compute `upcoming` sort keys from the `upcoming_timed` specials rather than from all timed special start/end lists. 
- Added normalization of upcoming special start/end minutes relative to `current_minutes` so overnight windows are adjusted to their next occurrence before sorting. 
- Selects the earliest normalized upcoming window by `(start, end)` and falls back to `open_minutes`/`close_minutes` when no fully-normalizable upcoming window exists. 
- Kept existing category semantics and all-day fallbacks intact.

### Testing
- Ran `python -m py_compile functions/getStartupData/get_startup_data.py` which succeeded. 
- Ran targeted JS tests with `npm test -- --runInBand tests/app.test.js -t "renderBarsWeek inserts divider"` which passed (tests in `tests/app.test.js` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b4f875b48330ad47984cdb3e1f4c)