### PR TITLE
Smooth scroll-to-top when tapping Specials tab or header toolbar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -201,11 +201,25 @@ function initTaskbar() {
   tabs.forEach((tab) => {
     tab.addEventListener('click', () => {
       const tabName = tab.dataset.tab;
+      const isRepeatSpecialsTap = tabName === 'specials' && currentTab === 'specials';
       document.getElementById('detail-screen').style.display = 'none';
       document.getElementById('special-screen').style.display = 'none';
       showTab(tabName);
       setScreenLayout(true);
+      if (isRepeatSpecialsTap) {
+        smoothScrollHomeToTop();
+      }
     });
+  });
+}
+
+function smoothScrollHomeToTop() {
+  const homeScreen = document.getElementById('home-screen');
+  if (!homeScreen) return;
+  if (currentTab !== 'specials') return;
+  homeScreen.scrollTo({
+    top: 0,
+    behavior: 'smooth'
   });
 }
 
@@ -232,10 +246,6 @@ function initAdminTitleTapEntry() {
     tapCount += 1;
     if (tapTimer) clearTimeout(tapTimer);
     tapTimer = setTimeout(() => {
-      if (tapCount === 1 && currentTab === 'specials') {
-        const homeScreen = document.getElementById('home-screen');
-        if (homeScreen) homeScreen.scrollTop = 0;
-      }
       tapCount = 0;
     }, tapResetMs);
 
@@ -247,6 +257,15 @@ function initAdminTitleTapEntry() {
   };
 
   appTitle.addEventListener('pointerup', handleTitleTap);
+}
+
+function initToolbarSingleTapScroll() {
+  const toolbar = document.querySelector('.home-toolbar');
+  if (!toolbar) return;
+
+  toolbar.addEventListener('click', () => {
+    smoothScrollHomeToTop();
+  });
 }
 
 function initHomeScrollCapture() {
@@ -382,6 +401,7 @@ initSidebarFilters();
 initTaskbar();
 initBarsSearch();
 initAdminTitleTapEntry();
+initToolbarSingleTapScroll();
 initHomeScrollCapture();
 initZoomLock();
 if (typeof initMapDayController === 'function') {

--- a/js/app.js
+++ b/js/app.js
@@ -202,13 +202,15 @@ function initTaskbar() {
     tab.addEventListener('click', () => {
       const tabName = tab.dataset.tab;
       const isRepeatSpecialsTap = tabName === 'specials' && currentTab === 'specials';
+      const detailScreen = document.getElementById('detail-screen');
+      const specialScreen = document.getElementById('special-screen');
+      if (detailScreen) detailScreen.style.display = 'none';
+      if (specialScreen) specialScreen.style.display = 'none';
       if (isRepeatSpecialsTap) {
         setScreenLayout(true);
         smoothScrollHomeToTop();
         return;
       }
-      document.getElementById('detail-screen').style.display = 'none';
-      document.getElementById('special-screen').style.display = 'none';
       showTab(tabName);
       setScreenLayout(true);
     });

--- a/js/app.js
+++ b/js/app.js
@@ -202,11 +202,13 @@ function initTaskbar() {
     tab.addEventListener('click', () => {
       const tabName = tab.dataset.tab;
       const isRepeatSpecialsTap = tabName === 'specials' && currentTab === 'specials';
+      const homeScreen = document.getElementById('home-screen');
       const detailScreen = document.getElementById('detail-screen');
       const specialScreen = document.getElementById('special-screen');
+      const isHomeScreenVisible = homeScreen ? homeScreen.style.display !== 'none' : false;
       if (detailScreen) detailScreen.style.display = 'none';
       if (specialScreen) specialScreen.style.display = 'none';
-      if (isRepeatSpecialsTap) {
+      if (isRepeatSpecialsTap && isHomeScreenVisible) {
         setScreenLayout(true);
         smoothScrollHomeToTop();
         return;

--- a/js/app.js
+++ b/js/app.js
@@ -202,13 +202,15 @@ function initTaskbar() {
     tab.addEventListener('click', () => {
       const tabName = tab.dataset.tab;
       const isRepeatSpecialsTap = tabName === 'specials' && currentTab === 'specials';
+      if (isRepeatSpecialsTap) {
+        setScreenLayout(true);
+        smoothScrollHomeToTop();
+        return;
+      }
       document.getElementById('detail-screen').style.display = 'none';
       document.getElementById('special-screen').style.display = 'none';
       showTab(tabName);
       setScreenLayout(true);
-      if (isRepeatSpecialsTap) {
-        smoothScrollHomeToTop();
-      }
     });
   });
 }

--- a/js/app.js
+++ b/js/app.js
@@ -263,7 +263,10 @@ function initToolbarSingleTapScroll() {
   const toolbar = document.querySelector('.home-toolbar');
   if (!toolbar) return;
 
-  toolbar.addEventListener('click', () => {
+  toolbar.addEventListener('click', (event) => {
+    const clickTarget = event.target;
+    if (!(clickTarget instanceof Element)) return;
+    if (clickTarget.closest('button, a, input, select, textarea, label')) return;
     smoothScrollHomeToTop();
   });
 }


### PR DESCRIPTION
### Motivation
- Reduce the jarring immediate jump to the top of the Specials list by animating the scroll instead of setting `scrollTop` directly.
- Enable the same smooth scroll behavior when the user single-taps the header toolbar so repeated taps provide a predictable UX.

### Description
- Added a shared helper `smoothScrollHomeToTop()` that calls `homeScreen.scrollTo({ top: 0, behavior: 'smooth' })` to animate the Specials list.
- Updated tab handling in `initTaskbar()` to detect a re-tap of the active `specials` tab and call `smoothScrollHomeToTop()` instead of jumping.
- Removed the previous single-tap immediate scroll from the admin title tap path and retained the multi-tap admin entry behavior.
- Added `initToolbarSingleTapScroll()` and wired it into initialization so a single click on `.home-toolbar` triggers the smooth scroll when on Specials.

### Testing
- Ran `npm test -- --runInBand` and the test suite completed with all automated tests passing (22 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b54ccb5c8330833a1d09812cda24)