### PR TITLE
Set all_day during special candidate creation when times match open hours

### DIFF
--- a/functions/dbSpecialSync/db_special_sync.py
+++ b/functions/dbSpecialSync/db_special_sync.py
@@ -389,6 +389,17 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                     else missing_day_notes_suffix.lstrip()
                 )
 
+        candidate_all_day = _normalize_yn_flag(candidate.get('all_day'))
+        candidate_start = _normalize_time_value(candidate.get('start_time'))
+        candidate_end = _normalize_time_value(candidate.get('end_time'))
+        if candidate_days_raw and all(
+            _should_convert_to_all_day(day, candidate_all_day, candidate_start, candidate_end, open_hours_lookup)
+            for day in candidate_days_raw
+        ):
+            candidate_all_day = 'Y'
+            candidate_start = None
+            candidate_end = None
+
         cursor.execute(
             """
             INSERT INTO special_candidate
@@ -403,9 +414,9 @@ def insert_special_candidate(cursor, run: Dict, candidates: List[Dict]) -> Dict[
                 candidate['description'],
                 candidate['type'],
                 json.dumps(candidate.get('days_of_week', [])),
-                candidate.get('start_time'),
-                candidate.get('end_time'),
-                candidate.get('all_day'),
+                candidate_start,
+                candidate_end,
+                candidate_all_day,
                 candidate.get('is_recurring'),
                 candidate.get('date'),
                 candidate.get('fetch_method'),


### PR DESCRIPTION
### Motivation
- Ensure special candidates are stored as all-day when their start/end times equal the bar's open-hours window for every listed day so downstream logic sees the correct `all_day` state immediately. 
- Avoid deferring the all-day conversion until publish time to improve consistency for matching, merging, and reporting.

### Description
- Normalize candidate time fields early by applying `_normalize_yn_flag` to `all_day` and `_normalize_time_value` to `start_time`/`end_time` during candidate insertion in `functions/dbSpecialSync/db_special_sync.py`. 
- If `_should_convert_to_all_day` returns true for every candidate day, set `candidate_all_day = 'Y'` and clear `candidate_start`/`candidate_end` before insertion. 
- Persist the resolved `candidate_all_day`, `candidate_start`, and `candidate_end` values into the `INSERT INTO special_candidate` call instead of raw payload values.

### Testing
- Ran `python -m py_compile functions/dbSpecialSync/db_special_sync.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b64321ec8330b24a64a78f0cfebe)