### PR TITLE
Remove redundant upcoming timed-window filtering in startup sort order

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -243,6 +243,10 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
     if timed and not all_day and not has_active_timed and not has_upcoming_timed:
         return (0, min(timed_end_minutes) if timed_end_minutes else 10 ** 9, 10 ** 9)
 
+    # 1: past timed + all-day (with no active/upcoming timed), or only all-day while closed, sorted by closing time
+    if (has_past_timed and all_day) or (all_day and not timed and not is_open_now and not not_yet_opened):
+        return (1, close_minutes if close_minutes is not None else 10 ** 9, 10 ** 9)
+
     # 2: at least one active timed special, sorted by start then end
     if has_active_timed:
         return (
@@ -275,10 +279,6 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
             sort_start = open_minutes if open_minutes is not None else 10 ** 9
             sort_end = close_minutes if close_minutes is not None else 10 ** 9
         return (3, sort_start, sort_end)
-
-    # 1: past timed + all-day (with no active/upcoming timed), or only all-day while closed, sorted by closing time
-    if (has_past_timed and all_day) or (all_day and not timed and not is_open_now and not not_yet_opened):
-        return (1, close_minutes if close_minutes is not None else 10 ** 9, 10 ** 9)
 
     # 4: only all-day while currently open, sorted by closing time
     if all_day and not timed and is_open_now:

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -243,10 +243,6 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
     if timed and not all_day and not has_active_timed and not has_upcoming_timed:
         return (0, min(timed_end_minutes) if timed_end_minutes else 10 ** 9, 10 ** 9)
 
-    # 1: past timed + all-day (with no active/upcoming timed), or only all-day while closed, sorted by closing time
-    if (has_past_timed and all_day) or (all_day and not timed and not is_open_now and not not_yet_opened):
-        return (1, close_minutes if close_minutes is not None else 10 ** 9, 10 ** 9)
-
     # 2: at least one active timed special, sorted by start then end
     if has_active_timed:
         return (
@@ -262,11 +258,11 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
             for special in upcoming_timed:
                 start_minutes = to_minutes(special.get('start_time'))
                 end_minutes = to_minutes(special.get('end_time'))
-                if start_minutes is None and end_minutes is None:
+                if start_minutes is None or end_minutes is None:
                     continue
-                normalized_start = start_minutes if start_minutes is not None else (open_minutes if open_minutes is not None else 10 ** 9)
-                normalized_end = end_minutes if end_minutes is not None else (close_minutes if close_minutes is not None else 10 ** 9)
-                if start_minutes is not None and end_minutes is not None and end_minutes < start_minutes:
+                normalized_start = start_minutes
+                normalized_end = end_minutes
+                if end_minutes < start_minutes:
                     normalized_end += 24 * 60
                 upcoming_sort_windows.append((normalized_start, normalized_end))
 
@@ -279,6 +275,10 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
             sort_start = open_minutes if open_minutes is not None else 10 ** 9
             sort_end = close_minutes if close_minutes is not None else 10 ** 9
         return (3, sort_start, sort_end)
+
+    # 1: past timed + all-day (with no active/upcoming timed), or only all-day while closed, sorted by closing time
+    if (has_past_timed and all_day and not has_active_timed and not has_upcoming_timed) or (all_day and not timed and not is_open_now and not not_yet_opened):
+        return (1, close_minutes if close_minutes is not None else 10 ** 9, 10 ** 9)
 
     # 4: only all-day while currently open, sorted by closing time
     if all_day and not timed and is_open_now:

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -254,8 +254,21 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
     # 3: at least one upcoming timed special, or only all-day and not yet opened
     if has_upcoming_timed or (all_day and not timed and not_yet_opened):
         if has_upcoming_timed:
-            sort_start = min(upcoming_start_minutes) if upcoming_start_minutes else (open_minutes if open_minutes is not None else 10 ** 9)
-            sort_end = min(upcoming_end_minutes) if upcoming_end_minutes else (close_minutes if close_minutes is not None else 10 ** 9)
+            upcoming_sort_windows = []
+            for special in upcoming_timed:
+                start_minutes = to_minutes(special.get('start_time'))
+                end_minutes = to_minutes(special.get('end_time'))
+                if start_minutes is None and end_minutes is None:
+                    continue
+                normalized_start = start_minutes if start_minutes is not None else (open_minutes if open_minutes is not None else 10 ** 9)
+                normalized_end = end_minutes if end_minutes is not None else (close_minutes if close_minutes is not None else 10 ** 9)
+                upcoming_sort_windows.append((normalized_start, normalized_end))
+
+            if upcoming_sort_windows:
+                sort_start, sort_end = min(upcoming_sort_windows, key=lambda window: (window[0], window[1]))
+            else:
+                sort_start = open_minutes if open_minutes is not None else 10 ** 9
+                sort_end = close_minutes if close_minutes is not None else 10 ** 9
         else:
             sort_start = open_minutes if open_minutes is not None else 10 ** 9
             sort_end = close_minutes if close_minutes is not None else 10 ** 9

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -262,6 +262,8 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
                     continue
                 normalized_start = start_minutes if start_minutes is not None else (open_minutes if open_minutes is not None else 10 ** 9)
                 normalized_end = end_minutes if end_minutes is not None else (close_minutes if close_minutes is not None else 10 ** 9)
+                if start_minutes is not None and end_minutes is not None and end_minutes < start_minutes:
+                    normalized_end += 24 * 60
                 upcoming_sort_windows.append((normalized_start, normalized_end))
 
             if upcoming_sort_windows:

--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -254,30 +254,8 @@ def classify_today_bar_order(entry, specials_lookup, bar_day_hours, current_minu
     # 3: at least one upcoming timed special, or only all-day and not yet opened
     if has_upcoming_timed or (all_day and not timed and not_yet_opened):
         if has_upcoming_timed:
-            # Keep upcoming sorting anchored to upcoming specials only. Normalize starts/ends
-            # relative to now so overnight windows still sort by nearest upcoming relevance.
-            upcoming_sort_windows = []
-            for special in upcoming_timed:
-                start_minutes = to_minutes(special.get('start_time'))
-                end_minutes = to_minutes(special.get('end_time'))
-                if start_minutes is None or end_minutes is None:
-                    continue
-                normalized_start = start_minutes
-                normalized_end = end_minutes
-                if end_minutes < start_minutes:
-                    normalized_end += 24 * 60
-                    if normalized_start <= current_minutes:
-                        normalized_start += 24 * 60
-                if normalized_start <= current_minutes:
-                    normalized_start += 24 * 60
-                    normalized_end += 24 * 60
-                upcoming_sort_windows.append((normalized_start, normalized_end))
-
-            if upcoming_sort_windows:
-                sort_start, sort_end = min(upcoming_sort_windows, key=lambda window: (window[0], window[1]))
-            else:
-                sort_start = min(upcoming_start_minutes) if upcoming_start_minutes else (open_minutes if open_minutes is not None else 10 ** 9)
-                sort_end = min(upcoming_end_minutes) if upcoming_end_minutes else (close_minutes if close_minutes is not None else 10 ** 9)
+            sort_start = min(upcoming_start_minutes) if upcoming_start_minutes else (open_minutes if open_minutes is not None else 10 ** 9)
+            sort_end = min(upcoming_end_minutes) if upcoming_end_minutes else (close_minutes if close_minutes is not None else 10 ** 9)
         else:
             sort_start = open_minutes if open_minutes is not None else 10 ** 9
             sort_end = close_minutes if close_minutes is not None else 10 ** 9


### PR DESCRIPTION
### Motivation
- A previous change added normalization and filtering of upcoming timed-special windows which skipped any upcoming special missing `start_time` or `end_time`, risking different sort behavior for partial specials. 
- The codebase already treats missing times as valid in other places and partial timed specials are a supported case, so the extra filtering is redundant and can misorder bars. 

### Description
- Removed the block in `classify_today_bar_order` that normalized and filtered `upcoming_timed` windows and that skipped entries with missing `start_time` or `end_time`. 
- Restored direct derivation of `sort_start` and `sort_end` from the precomputed `upcoming_start_minutes` and `upcoming_end_minutes` lists. 
- Left fallback behavior (use of `open_minutes`/`close_minutes` when upcoming data is absent) unchanged. 

### Testing
- Ran `python -m py_compile functions/getStartupData/get_startup_data.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00b853a88c8330b14497e93bde8b3b)