### PR TITLE
Add Expo mobile scaffold with bottom-tab navigation and placeholder screens

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,20 +1,11 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import TabNavigator from './src/navigation/TabNavigator';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <>
+      <StatusBar style='light' />
+      <TabNavigator />
+    </>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,7 +13,12 @@
     "expo": "~54.0.33",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.5",
+    "@expo/vector-icons": "^14.1.0",
+    "@react-navigation/bottom-tabs": "^7.2.0",
+    "@react-navigation/native": "^7.1.0",
+    "react-native-safe-area-context": "^5.4.0",
+    "react-native-screens": "^4.11.1"
   },
   "private": true
 }

--- a/mobile/src/components/PlaceholderCard.js
+++ b/mobile/src/components/PlaceholderCard.js
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS, SPACING, TYPOGRAPHY } from '../constants/theme';
+
+export default function PlaceholderCard({ label, description }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.description}>{description}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: COLORS.surface,
+    borderColor: COLORS.border,
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: SPACING.md,
+    marginBottom: SPACING.sm,
+  },
+  label: {
+    color: COLORS.textPrimary,
+    fontSize: TYPOGRAPHY.body,
+    fontWeight: '600',
+    marginBottom: SPACING.xs,
+  },
+  description: {
+    color: COLORS.textSecondary,
+    fontSize: TYPOGRAPHY.caption,
+    lineHeight: 18,
+  },
+});

--- a/mobile/src/components/ScreenContainer.js
+++ b/mobile/src/components/ScreenContainer.js
@@ -1,0 +1,22 @@
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { COLORS, SPACING } from '../constants/theme';
+
+export default function ScreenContainer({ children }) {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.content}>{children}</View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: SPACING.md,
+    paddingTop: SPACING.sm,
+  },
+});

--- a/mobile/src/components/SectionHeader.js
+++ b/mobile/src/components/SectionHeader.js
@@ -1,0 +1,27 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS, SPACING, TYPOGRAPHY } from '../constants/theme';
+
+export default function SectionHeader({ title, subtitle }) {
+  return (
+    <View style={styles.wrapper}>
+      <Text style={styles.title}>{title}</Text>
+      {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginBottom: SPACING.md,
+  },
+  title: {
+    color: COLORS.textPrimary,
+    fontSize: TYPOGRAPHY.title,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: COLORS.textSecondary,
+    fontSize: TYPOGRAPHY.body,
+    marginTop: SPACING.xs,
+  },
+});

--- a/mobile/src/constants/theme.js
+++ b/mobile/src/constants/theme.js
@@ -1,0 +1,26 @@
+export const COLORS = {
+  background: '#0F1115',
+  surface: '#181B22',
+  surfaceAlt: '#202531',
+  textPrimary: '#F4F7FF',
+  textSecondary: '#AAB2C5',
+  accent: '#F2A649',
+  accentMuted: '#835E2A',
+  border: '#2E3442',
+  success: '#3BC97B',
+};
+
+export const SPACING = {
+  xs: 6,
+  sm: 10,
+  md: 16,
+  lg: 24,
+  xl: 32,
+};
+
+export const TYPOGRAPHY = {
+  title: 26,
+  heading: 22,
+  body: 16,
+  caption: 13,
+};

--- a/mobile/src/navigation/TabNavigator.js
+++ b/mobile/src/navigation/TabNavigator.js
@@ -1,0 +1,57 @@
+import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { MaterialIcons } from '@expo/vector-icons';
+import HomeScreen from '../screens/HomeScreen';
+import BarsScreen from '../screens/BarsScreen';
+import FavoritesScreen from '../screens/FavoritesScreen';
+import MapScreen from '../screens/MapScreen';
+import { COLORS } from '../constants/theme';
+
+const Tab = createBottomTabNavigator();
+
+const navTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: COLORS.background,
+    card: COLORS.surface,
+    text: COLORS.textPrimary,
+    border: COLORS.border,
+  },
+};
+
+const screenOptions = ({ route }) => ({
+  headerShown: false,
+  tabBarActiveTintColor: COLORS.accent,
+  tabBarInactiveTintColor: COLORS.textSecondary,
+  tabBarStyle: {
+    backgroundColor: COLORS.surface,
+    borderTopColor: COLORS.border,
+    height: 62,
+    paddingBottom: 8,
+    paddingTop: 6,
+  },
+  tabBarIcon: ({ color, size }) => {
+    const iconNameByRoute = {
+      Home: 'home-filled',
+      Bars: 'local-bar',
+      Favorites: 'favorite',
+      Map: 'map',
+    };
+
+    return <MaterialIcons name={iconNameByRoute[route.name]} size={size} color={color} />;
+  },
+});
+
+export default function TabNavigator() {
+  return (
+    <NavigationContainer theme={navTheme}>
+      <Tab.Navigator initialRouteName='Home' screenOptions={screenOptions}>
+        <Tab.Screen name='Home' component={HomeScreen} />
+        <Tab.Screen name='Bars' component={BarsScreen} />
+        <Tab.Screen name='Favorites' component={FavoritesScreen} />
+        <Tab.Screen name='Map' component={MapScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/src/screens/BarsScreen.js
+++ b/mobile/src/screens/BarsScreen.js
@@ -1,0 +1,22 @@
+import ScreenContainer from '../components/ScreenContainer';
+import SectionHeader from '../components/SectionHeader';
+import PlaceholderCard from '../components/PlaceholderCard';
+
+export default function BarsScreen() {
+  return (
+    <ScreenContainer>
+      <SectionHeader
+        title='Bars'
+        subtitle='Browse bars by neighborhood, open status, and special type.'
+      />
+      <PlaceholderCard
+        label='Search and filters'
+        description='List filtering controls for neighborhoods, tags, and open-now state.'
+      />
+      <PlaceholderCard
+        label='Bar list'
+        description='Scrollable list of bars with quick access to details and favorites.'
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/FavoritesScreen.js
+++ b/mobile/src/screens/FavoritesScreen.js
@@ -1,0 +1,22 @@
+import ScreenContainer from '../components/ScreenContainer';
+import SectionHeader from '../components/SectionHeader';
+import PlaceholderCard from '../components/PlaceholderCard';
+
+export default function FavoritesScreen() {
+  return (
+    <ScreenContainer>
+      <SectionHeader
+        title='Favorites'
+        subtitle='Your saved bars and specials in one place.'
+      />
+      <PlaceholderCard
+        label='Saved bars'
+        description='Persisted favorites synced to API or local storage for quick recall.'
+      />
+      <PlaceholderCard
+        label='Notifications (future)'
+        description='Optional reminders when your favorite spots begin happy hour.'
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/HomeScreen.js
+++ b/mobile/src/screens/HomeScreen.js
@@ -1,0 +1,22 @@
+import ScreenContainer from '../components/ScreenContainer';
+import SectionHeader from '../components/SectionHeader';
+import PlaceholderCard from '../components/PlaceholderCard';
+
+export default function HomeScreen() {
+  return (
+    <ScreenContainer>
+      <SectionHeader
+        title="Tonight's Specials"
+        subtitle='A quick view of featured bars and happy hour highlights.'
+      />
+      <PlaceholderCard
+        label='Featured neighborhood'
+        description='Show top specials for a selected neighborhood and time window.'
+      />
+      <PlaceholderCard
+        label='Trending deals'
+        description='Display currently popular specials with save and map shortcuts.'
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/MapScreen.js
+++ b/mobile/src/screens/MapScreen.js
@@ -1,0 +1,22 @@
+import ScreenContainer from '../components/ScreenContainer';
+import SectionHeader from '../components/SectionHeader';
+import PlaceholderCard from '../components/PlaceholderCard';
+
+export default function MapScreen() {
+  return (
+    <ScreenContainer>
+      <SectionHeader
+        title='Map'
+        subtitle='Discover nearby bars and specials geographically.'
+      />
+      <PlaceholderCard
+        label='Map viewport'
+        description='Map markers for bars and cluster handling in dense areas.'
+      />
+      <PlaceholderCard
+        label='Location actions'
+        description='Current-location button and route launch to selected bar details.'
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/services/api.js
+++ b/mobile/src/services/api.js
@@ -1,0 +1,35 @@
+const API_BASE_URL = 'https://example.com/api';
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const message = `API request failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  return response.json();
+}
+
+export function fetchStartupData() {
+  return request('/startup');
+}
+
+export function fetchBars(params = {}) {
+  const query = new URLSearchParams(params).toString();
+  const suffix = query ? `?${query}` : '';
+  return request(`/bars${suffix}`);
+}
+
+export function toggleFavoriteBar(payload) {
+  return request('/favorites/toggle', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-first Expo app scaffold for the bar specials product so feature work can iterate on a consistent bottom-tab navigation and shared UI primitives.

### Description
- Add a bottom-tab navigator in `mobile/src/navigation/TabNavigator.js` that registers four tabs: `Home`, `Bars`, `Favorites`, and `Map`, including icon mapping and themed tab bar styling.
- Replace the default `mobile/App.js` to mount the new `TabNavigator` and `StatusBar`, and update `mobile/package.json` to include navigation and icon dependencies needed for tabs.
- Introduce placeholder screens in `mobile/src/screens/` and reusable UI components `ScreenContainer`, `SectionHeader`, and `PlaceholderCard` under `mobile/src/components/` for consistent screen composition.
- Add centralized theme constants in `mobile/src/constants/theme.js` and a services layer stub `mobile/src/services/api.js` exposing `fetchStartupData`, `fetchBars`, and `toggleFavoriteBar` to organize future API calls.

### Testing
- Ran `cd mobile && npm run start -- --help` to validate the start script, which failed in this environment because the `expo` CLI is not available (`sh: 1: expo: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f426758883308bf6a446e28da5d5)