### PR TITLE
Create Expo mobile scaffold with bottom tab navigation

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,20 +1,17 @@
+import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+import RootTabs from './src/navigation/RootTabs';
+import { theme } from './src/constants/theme';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <SafeAreaProvider>
+      <NavigationContainer theme={theme.navigation}>
+        <StatusBar style="light" />
+        <RootTabs />
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,10 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/ngrok": "^4.1.3",
+        "@react-navigation/bottom-tabs": "^6.6.1",
+        "@react-navigation/native": "^6.1.18",
         "expo": "~53.0.27",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
-        "react-native": "0.79.6"
+        "react-native": "0.79.6",
+        "react-native-safe-area-context": "^4.14.1",
+        "react-native-screens": "^3.37.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -2709,6 +2713,84 @@
       "integrity": "sha512-0v2/ruY7eeKun4BeKu+GcfO+SHBdl0LJn4ZFzTzjHdWES0Cn+ONqKljYaIv8p9MV2Hx/kcdEvbY4lWI34jC/mQ==",
       "license": "MIT"
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.6.1.tgz",
+      "integrity": "sha512-9oD4cypEBjPuaMiu9tevWGiQ4w/d6l3HNhcJ1IjXZ24xvYDSs0mqjUcdt8SWUolCvRrYc/DmNBLlT83bk0bHTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.31",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/core": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.17.tgz",
+      "integrity": "sha512-Nd76EpomzChWAosGqWOYE3ItayhDzIEzzZsT7PfGcRFDgW5miHV2t4MZcq9YIK4tzxZjVVpYbIynOOQQd1e0Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/routers": "^6.1.9",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.23",
+        "query-string": "^7.1.3",
+        "react-is": "^16.13.0",
+        "use-latest-callback": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-navigation/elements": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.31.tgz",
+      "integrity": "sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0"
+      }
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "6.1.18",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.18.tgz",
+      "integrity": "sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^6.4.17",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.1.23"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/routers": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.9.tgz",
+      "integrity": "sha512-lTM8gSFHSfkJvQkxacGM6VJtBt61ip2XO54aNfswD+KMw6eeZ4oehl7m0me3CR9hnDE4+60iAZR8sAhvCiI3NA==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.1.23"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -3732,6 +3814,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3749,6 +3844,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -3943,6 +4048,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
@@ -4382,6 +4496,12 @@
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4407,6 +4527,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -6805,6 +6934,24 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
@@ -6890,6 +7037,18 @@
         }
       }
     },
+    "node_modules/react-freeze": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
+      "integrity": "sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -6970,6 +7129,30 @@
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
       "integrity": "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.14.1.tgz",
+      "integrity": "sha512-+tUhT5WBl8nh5+P+chYhAjR470iCByf9z5EYdCEbPaAK3Yfzw+o8VRPnUgmPAKlSccOgQBxx3NOl/Wzckn9ujg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-screens": {
+      "version": "3.37.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.37.0.tgz",
+      "integrity": "sha512-vEi4qZqWYoGuVGuHTv1K2XA90rgSydksmR5+tb5uhL93whl6Bch6EEXzC+8eEfj4SimiCgXBPY7r/xTXJxvnUg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -7540,6 +7723,21 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7599,6 +7797,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/sprintf-js": {
@@ -7662,6 +7869,15 @@
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/string-width": {
@@ -8152,6 +8368,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -8203,6 +8428,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,10 +10,14 @@
   },
   "dependencies": {
     "@expo/ngrok": "^4.1.3",
+    "@react-navigation/bottom-tabs": "^6.6.1",
+    "@react-navigation/native": "^6.1.18",
     "expo": "~53.0.27",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
-    "react-native": "0.79.6"
+    "react-native": "0.79.6",
+    "react-native-safe-area-context": "^4.14.1",
+    "react-native-screens": "^3.37.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/mobile/src/components/PlaceholderSection.js
+++ b/mobile/src/components/PlaceholderSection.js
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors, spacing } from '../constants/theme';
+
+export default function PlaceholderSection({ title, subtitle }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.subtitle}>{subtitle}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: spacing.lg,
+    gap: spacing.sm,
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  subtitle: {
+    color: colors.textSecondary,
+    fontSize: 15,
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/components/ScreenContainer.js
+++ b/mobile/src/components/ScreenContainer.js
@@ -1,0 +1,24 @@
+import { StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { colors, spacing } from '../constants/theme';
+
+export default function ScreenContainer({ children }) {
+  return (
+    <SafeAreaView edges={['top']} style={styles.safeArea}>
+      <View style={styles.content}>{children}</View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.xl,
+  },
+});

--- a/mobile/src/constants/theme.js
+++ b/mobile/src/constants/theme.js
@@ -1,0 +1,35 @@
+import { DefaultTheme } from '@react-navigation/native';
+
+export const colors = {
+  background: '#0B0F1A',
+  surface: '#151B2A',
+  surfaceMuted: '#1E2639',
+  textPrimary: '#F5F7FF',
+  textSecondary: '#A7B0C8',
+  accent: '#FF8A3D',
+  border: '#2A3248',
+  tabInactive: '#7D88A6',
+  success: '#4FD88A',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+};
+
+export const theme = {
+  navigation: {
+    ...DefaultTheme,
+    colors: {
+      ...DefaultTheme.colors,
+      background: colors.background,
+      card: colors.surface,
+      text: colors.textPrimary,
+      border: colors.border,
+      primary: colors.accent,
+    },
+  },
+};

--- a/mobile/src/navigation/RootTabs.js
+++ b/mobile/src/navigation/RootTabs.js
@@ -1,0 +1,48 @@
+import { Ionicons } from '@expo/vector-icons';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+import { colors } from '../constants/theme';
+import BarsScreen from '../screens/BarsScreen';
+import FavoritesScreen from '../screens/FavoritesScreen';
+import HomeScreen from '../screens/HomeScreen';
+import MapScreen from '../screens/MapScreen';
+
+const Tab = createBottomTabNavigator();
+
+const iconsByRoute = {
+  Home: 'home',
+  Bars: 'wine',
+  Favorites: 'heart',
+  Map: 'map',
+};
+
+export default function RootTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        headerShown: false,
+        tabBarActiveTintColor: colors.accent,
+        tabBarInactiveTintColor: colors.tabInactive,
+        tabBarStyle: {
+          backgroundColor: colors.surface,
+          borderTopColor: colors.border,
+          height: 64,
+          paddingBottom: 6,
+          paddingTop: 6,
+        },
+        tabBarLabelStyle: {
+          fontSize: 12,
+          fontWeight: '600',
+        },
+        tabBarIcon: ({ color, size }) => (
+          <Ionicons name={iconsByRoute[route.name]} size={size} color={color} />
+        ),
+      })}
+    >
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Bars" component={BarsScreen} />
+      <Tab.Screen name="Favorites" component={FavoritesScreen} />
+      <Tab.Screen name="Map" component={MapScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/mobile/src/screens/BarsScreen.js
+++ b/mobile/src/screens/BarsScreen.js
@@ -1,0 +1,13 @@
+import PlaceholderSection from '../components/PlaceholderSection';
+import ScreenContainer from '../components/ScreenContainer';
+
+export default function BarsScreen() {
+  return (
+    <ScreenContainer>
+      <PlaceholderSection
+        title="Browse Bars"
+        subtitle="Bar list, filters, and neighborhood views will live in this tab."
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/FavoritesScreen.js
+++ b/mobile/src/screens/FavoritesScreen.js
@@ -1,0 +1,13 @@
+import PlaceholderSection from '../components/PlaceholderSection';
+import ScreenContainer from '../components/ScreenContainer';
+
+export default function FavoritesScreen() {
+  return (
+    <ScreenContainer>
+      <PlaceholderSection
+        title="Your Favorites"
+        subtitle="Saved bars and specials can be managed from this tab."
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/HomeScreen.js
+++ b/mobile/src/screens/HomeScreen.js
@@ -1,0 +1,13 @@
+import PlaceholderSection from '../components/PlaceholderSection';
+import ScreenContainer from '../components/ScreenContainer';
+
+export default function HomeScreen() {
+  return (
+    <ScreenContainer>
+      <PlaceholderSection
+        title="Tonight's Specials"
+        subtitle="Home feed goes here: featured bars, happy hour countdowns, and nearby deals."
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/screens/MapScreen.js
+++ b/mobile/src/screens/MapScreen.js
@@ -1,0 +1,13 @@
+import PlaceholderSection from '../components/PlaceholderSection';
+import ScreenContainer from '../components/ScreenContainer';
+
+export default function MapScreen() {
+  return (
+    <ScreenContainer>
+      <PlaceholderSection
+        title="Map"
+        subtitle="Interactive map and location-based specials will be shown here."
+      />
+    </ScreenContainer>
+  );
+}

--- a/mobile/src/services/api.js
+++ b/mobile/src/services/api.js
@@ -1,0 +1,29 @@
+const API_BASE_URL = 'https://api.example.com';
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function fetchHomeFeed() {
+  return request('/home');
+}
+
+export function fetchBars() {
+  return request('/bars');
+}
+
+export function fetchFavorites(deviceId) {
+  return request(`/favorites?deviceId=${encodeURIComponent(deviceId)}`);
+}


### PR DESCRIPTION
### Motivation
- Establish a mobile-first Expo React Native scaffold for the bar specials app with a clear navigation surface and reusable patterns to build on.
- Provide a bottom tab layout that mirrors the web app's visual/behavior inspiration (not copied code) so mobile UX can be iterated independently.

### Description
- Replace the default Expo starter with a mobile app shell using `SafeAreaProvider`, a themed `NavigationContainer`, and the `RootTabs` entrypoint (`mobile/App.js`).
- Add `src/navigation/RootTabs.js` implementing bottom tab navigation with four tabs: `Home`, `Bars`, `Favorites`, and `Map`, including icon mapping and mobile-friendly tab styles.
- Add placeholder screens (`mobile/src/screens/*`) and reusable UI components `ScreenContainer` and `PlaceholderSection` under `mobile/src/components` to keep screens composable.
- Add a theme/constants module (`mobile/src/constants/theme.js`) and a basic API service scaffold (`mobile/src/services/api.js`) and update `mobile/package.json` to include React Navigation and related native deps.

### Testing
- Ran `cd mobile && npm install`, which completed successfully and updated `package-lock.json` with the added dependencies.
- Ran `npx expo export --platform web --output-dir dist-test`, which failed in this environment with a network/compatibility lookup error (`TypeError: fetch failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0219021c4c8330b2f4d4584cba35af)