### PR TITLE
Switch to light theme and update bottom tab styling and icons

### DIFF
--- a/mobile/__tests__/README.md
+++ b/mobile/__tests__/README.md
@@ -1,0 +1,33 @@
+# Mobile test and screenshot workflow
+
+This folder contains Jest tests for the Expo mobile app.
+
+## Reliable local/CI test run
+
+From repo root:
+
+```bash
+npm --prefix mobile ci
+npm --prefix mobile test -- --runInBand
+```
+
+Why this sequence:
+- `npm ci` guarantees devDependencies (including `jest`) are installed.
+- `--runInBand` avoids worker parallelism issues in constrained CI containers.
+
+## Quick troubleshooting
+
+- `sh: 1: jest: not found` -> run `npm --prefix mobile ci` first.
+- Expo web startup fetch/proxy failures -> prefer static export for screenshots.
+
+## Deterministic screenshot path (without running dev server)
+
+From `mobile/`:
+
+```bash
+CI=1 npx expo export --platform web
+python3 -m http.server 4173 --directory dist
+wkhtmltoimage --width 390 --height 844 http://127.0.0.1:4173 /tmp/mobile-preview.png
+```
+
+This uses a built web bundle, so it is less flaky than relying on live Metro startup in restricted environments.

--- a/mobile/__tests__/RootTabs.test.js
+++ b/mobile/__tests__/RootTabs.test.js
@@ -1,7 +1,7 @@
 import { TAB_CONFIG } from '../src/navigation/RootTabs';
 
 describe('RootTabs config', () => {
-  it('maps each tab to the intended icon inspired by web taskbar', () => {
+  it('maps each tab to the current web-inspired icon contract', () => {
     expect(TAB_CONFIG.Home.icon).toBe('cash');
     expect(TAB_CONFIG.Bars.icon).toBe('beer');
     expect(TAB_CONFIG.Favorites.icon).toBe('star-outline');

--- a/mobile/__tests__/RootTabs.test.js
+++ b/mobile/__tests__/RootTabs.test.js
@@ -2,9 +2,9 @@ import { TAB_CONFIG } from '../src/navigation/RootTabs';
 
 describe('RootTabs config', () => {
   it('maps each tab to the intended icon inspired by web taskbar', () => {
-    expect(TAB_CONFIG.Home.icon).toBe('cash-multiple');
+    expect(TAB_CONFIG.Home.icon).toBe('cash');
     expect(TAB_CONFIG.Bars.icon).toBe('beer');
-    expect(TAB_CONFIG.Favorites.icon).toBe('star');
-    expect(TAB_CONFIG.Map.icon).toBe('map-marker');
+    expect(TAB_CONFIG.Favorites.icon).toBe('star-outline');
+    expect(TAB_CONFIG.Map.icon).toBe('map-marker-outline');
   });
 });

--- a/mobile/src/constants/colors.js
+++ b/mobile/src/constants/colors.js
@@ -1,10 +1,10 @@
 export const colors = {
-  background: '#0F1115',
-  surface: '#1B2029',
-  card: '#232A36',
-  primary: '#F59E0B',
-  textPrimary: '#F8FAFC',
-  textSecondary: '#9CA3AF',
-  border: '#374151',
+  background: '#F5F5F5',
+  surface: 'rgba(248, 248, 248, 0.92)',
+  card: '#FFFFFF',
+  primary: '#007AFF',
+  textPrimary: '#333333',
+  textSecondary: '#8E8E93',
+  border: 'rgba(60, 60, 67, 0.2)',
   success: '#22C55E'
 };

--- a/mobile/src/constants/theme.js
+++ b/mobile/src/constants/theme.js
@@ -4,7 +4,7 @@ import { colors } from './colors';
 export const theme = {
   navigationTheme: {
     ...DefaultTheme,
-    dark: true,
+    dark: false,
     colors: {
       ...DefaultTheme.colors,
       primary: colors.primary,

--- a/mobile/src/navigation/RootTabs.js
+++ b/mobile/src/navigation/RootTabs.js
@@ -12,7 +12,7 @@ const Tab = createBottomTabNavigator();
 export const TAB_CONFIG = {
   Home: {
     component: HomeScreen,
-    icon: 'cash-multiple'
+    icon: 'cash'
   },
   Bars: {
     component: BarsScreen,
@@ -20,11 +20,11 @@ export const TAB_CONFIG = {
   },
   Favorites: {
     component: FavoritesScreen,
-    icon: 'star'
+    icon: 'star-outline'
   },
   Map: {
     component: MapScreen,
-    icon: 'map-marker'
+    icon: 'map-marker-outline'
   }
 };
 
@@ -38,9 +38,9 @@ export function RootTabs() {
         tabBarStyle: {
           backgroundColor: colors.surface,
           borderTopColor: colors.border,
-          height: 64,
-          paddingTop: 6,
-          paddingBottom: 10
+          height: 68,
+          paddingTop: 4,
+          paddingBottom: 8
         },
         tabBarLabelStyle: {
           fontSize: 12,


### PR DESCRIPTION
### Motivation
- Move the app from a dark to a light visual style by updating the color palette and navigation theme.
- Ensure the bottom tab bar matches the new light surface and spacing conventions.
- Replace a few filled tab icons with outline variants to better suit the updated visual language.

### Description
- Updated color definitions in `mobile/src/constants/colors.js` to a light palette (background, surface, card, `primary`, `textPrimary`, `textSecondary`, and `border`).
- Switched the navigation theme to light by setting `dark: false` in `mobile/src/constants/theme.js` and wiring theme color mappings to the new color constants.
- Adjusted tab icons in `mobile/src/navigation/RootTabs.js` (`cash-multiple` -> `cash`, `star` -> `star-outline`, `map-marker` -> `map-marker-outline`) and left `Bars` as `beer`.
- Tweaked bottom tab bar sizing and padding in `RootTabs` (height changed to `68`, `paddingTop` to `4`, `paddingBottom` to `8`) and kept active/inactive tinting sourced from the color constants.

### Testing
- Ran `yarn lint` and the linting run passed successfully.
- Ran `yarn test` (unit tests) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02408d987483309bb904919ecdf10c)