### PR TITLE
Align mobile theme and tab icons with web style

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -9,7 +9,7 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <NavigationContainer theme={theme.navigationTheme}>
-        <StatusBar style="light" />
+        <StatusBar style="dark" />
         <RootTabs />
       </NavigationContainer>
     </SafeAreaProvider>

--- a/mobile/__tests__/RootTabs.test.js
+++ b/mobile/__tests__/RootTabs.test.js
@@ -2,9 +2,9 @@ import { TAB_CONFIG } from '../src/navigation/RootTabs';
 
 describe('RootTabs config', () => {
   it('maps each tab to the intended icon inspired by web taskbar', () => {
-    expect(TAB_CONFIG.Home.icon).toBe('cash-multiple');
+    expect(TAB_CONFIG.Home.icon).toBe('cash');
     expect(TAB_CONFIG.Bars.icon).toBe('beer');
-    expect(TAB_CONFIG.Favorites.icon).toBe('star');
-    expect(TAB_CONFIG.Map.icon).toBe('map-marker');
+    expect(TAB_CONFIG.Favorites.icon).toBe('star-outline');
+    expect(TAB_CONFIG.Map.icon).toBe('map-marker-outline');
   });
 });

--- a/mobile/src/constants/colors.js
+++ b/mobile/src/constants/colors.js
@@ -1,10 +1,10 @@
 export const colors = {
-  background: '#0F1115',
-  surface: '#1B2029',
-  card: '#232A36',
-  primary: '#F59E0B',
-  textPrimary: '#F8FAFC',
-  textSecondary: '#9CA3AF',
-  border: '#374151',
+  background: '#F5F5F5',
+  surface: '#FFFFFF',
+  card: '#FFFFFF',
+  primary: '#007AFF',
+  textPrimary: '#333333',
+  textSecondary: '#777777',
+  border: '#E1E1E6',
   success: '#22C55E'
 };

--- a/mobile/src/constants/theme.js
+++ b/mobile/src/constants/theme.js
@@ -4,7 +4,7 @@ import { colors } from './colors';
 export const theme = {
   navigationTheme: {
     ...DefaultTheme,
-    dark: true,
+    dark: false,
     colors: {
       ...DefaultTheme.colors,
       primary: colors.primary,

--- a/mobile/src/navigation/RootTabs.js
+++ b/mobile/src/navigation/RootTabs.js
@@ -12,7 +12,7 @@ const Tab = createBottomTabNavigator();
 export const TAB_CONFIG = {
   Home: {
     component: HomeScreen,
-    icon: 'cash-multiple'
+    icon: 'cash'
   },
   Bars: {
     component: BarsScreen,
@@ -20,11 +20,11 @@ export const TAB_CONFIG = {
   },
   Favorites: {
     component: FavoritesScreen,
-    icon: 'star'
+    icon: 'star-outline'
   },
   Map: {
     component: MapScreen,
-    icon: 'map-marker'
+    icon: 'map-marker-outline'
   }
 };
 


### PR DESCRIPTION
### Motivation
- Bring the mobile app visual style in line with the web app by switching the mobile color tokens and navigation chrome from a dark theme to a light theme. 
- Use mobile tab icons that are visually closer to the web taskbar icons without altering any web code. 

### Description
- Updated color tokens in `mobile/src/constants/colors.js` to light-background values and neutral text/border palettes to match the web look. 
- Updated the navigation theme in `mobile/src/constants/theme.js` to `dark: false` so the navigator uses the new light theme. 
- Changed mobile tab icons in `mobile/src/navigation/RootTabs.js` to `cash`, `beer`, `star-outline`, and `map-marker-outline` for Home, Bars, Favorites, and Map respectively. 
- Adjusted the status bar in `mobile/App.js` to use dark content and updated the test expectations in `mobile/__tests__/RootTabs.test.js` to match the new icons. 

### Testing
- Ran `cd mobile && npm test -- --runInBand`, which initially failed because `jest` was not installed in the environment. 
- Ran `cd mobile && npm install` to install dependencies. 
- Re-ran `cd mobile && npm test -- --runInBand` and all test suites passed (2 passed, 3 total tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02ade09cd88330a6a7e95caf58e739)