### PR TITLE
Align mobile theme and tab icons with web styling

### DIFF
--- a/mobile/__tests__/RootTabs.test.js
+++ b/mobile/__tests__/RootTabs.test.js
@@ -2,9 +2,9 @@ import { TAB_CONFIG } from '../src/navigation/RootTabs';
 
 describe('RootTabs config', () => {
   it('maps each tab to the intended icon inspired by web taskbar', () => {
-    expect(TAB_CONFIG.Home.icon).toBe('cash-multiple');
+    expect(TAB_CONFIG.Home.icon).toBe('cash');
     expect(TAB_CONFIG.Bars.icon).toBe('beer');
     expect(TAB_CONFIG.Favorites.icon).toBe('star');
-    expect(TAB_CONFIG.Map.icon).toBe('map-marker');
+    expect(TAB_CONFIG.Map.icon).toBe('map-marker-outline');
   });
 });

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "test": "jest"
+    "test": "jest",
+    "build": "expo export --platform web --output-dir dist"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",

--- a/mobile/src/constants/colors.js
+++ b/mobile/src/constants/colors.js
@@ -1,10 +1,10 @@
 export const colors = {
-  background: '#0F1115',
-  surface: '#1B2029',
-  card: '#232A36',
-  primary: '#F59E0B',
-  textPrimary: '#F8FAFC',
-  textSecondary: '#9CA3AF',
-  border: '#374151',
-  success: '#22C55E'
+  background: '#F5F5F5',
+  surface: 'rgba(248, 248, 248, 0.92)',
+  card: '#FFFFFF',
+  primary: '#007AFF',
+  textPrimary: '#333333',
+  textSecondary: '#8E8E93',
+  border: 'rgba(60, 60, 67, 0.2)',
+  success: '#34C759'
 };

--- a/mobile/src/navigation/RootTabs.js
+++ b/mobile/src/navigation/RootTabs.js
@@ -12,7 +12,7 @@ const Tab = createBottomTabNavigator();
 export const TAB_CONFIG = {
   Home: {
     component: HomeScreen,
-    icon: 'cash-multiple'
+    icon: 'cash'
   },
   Bars: {
     component: BarsScreen,
@@ -24,7 +24,7 @@ export const TAB_CONFIG = {
   },
   Map: {
     component: MapScreen,
-    icon: 'map-marker'
+    icon: 'map-marker-outline'
   }
 };
 
@@ -38,6 +38,7 @@ export function RootTabs() {
         tabBarStyle: {
           backgroundColor: colors.surface,
           borderTopColor: colors.border,
+          borderTopWidth: 1,
           height: 64,
           paddingTop: 6,
           paddingBottom: 10


### PR DESCRIPTION
### Motivation
- Make the mobile app visually match the web app's light theme and use tab icons that are very similar to the web icons without modifying any web files.

### Description
- Updated `mobile/src/constants/colors.js` to a web-like light palette including background, surface, card, primary, text, inactive text, border, and success colors.
- Modified `mobile/src/navigation/RootTabs.js` to change the `TAB_CONFIG` icon mappings to `cash`, `beer`, `star`, and `map-marker-outline` and added `borderTopWidth: 1` to the tab bar style to better mirror the web divider appearance.
- Updated the unit test in `mobile/__tests__/RootTabs.test.js` to assert the new icon names so tests reflect the updated icon choices.
- Left all web files unchanged and only adjusted mobile files to achieve parity.

### Testing
- Ran `npm test -- --runInBand` from the `mobile/` directory which initially failed due to outdated test expectations for icon names.
- After updating the tests, re-ran `npm test -- --runInBand` and all mobile test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032956ecd08330839b451a81263497)