### PR TITLE
Align mobile tab defaults and icons with web tabs

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -25,9 +25,9 @@ export default function RootLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
+          title: 'Specials',
           tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="home-variant" size={size} color={color} />
+            <MaterialCommunityIcons name="ticket-percent" size={size} color={color} />
           ),
         }}
       />
@@ -36,7 +36,7 @@ export default function RootLayout() {
         options={{
           title: 'Bars',
           tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="glass-cocktail" size={size} color={color} />
+            <MaterialCommunityIcons name="beer" size={size} color={color} />
           ),
         }}
       />
@@ -45,7 +45,7 @@ export default function RootLayout() {
         options={{
           title: 'Favorites',
           tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="heart" size={size} color={color} />
+            <MaterialCommunityIcons name="star" size={size} color={color} />
           ),
         }}
       />
@@ -54,7 +54,7 @@ export default function RootLayout() {
         options={{
           title: 'Map',
           tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="map-marker" size={size} color={color} />
+            <MaterialCommunityIcons name="map-marker-outline" size={size} color={color} />
           ),
         }}
       />


### PR DESCRIPTION
### Motivation
- Make the mobile app's default/index tab match the web app's primary Specials tab and harmonize the bottom-tab icons between platforms.

### Description
- Updated `mobile/app/_layout.tsx` to change the `index` tab title from `Home` to `Specials` and replaced the bottom-tab icons to `ticket-percent`, `beer`, `star`, and `map-marker-outline` to better mirror the web app.

### Testing
- No automated tests were run for this UI-only tab label/icon configuration update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0352329314833086bb77ac5155ed79)