### PR TITLE
Rename Home tab to Specials and render startup specials feed

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
+          title: 'Specials',
           tabBarIcon: ({ color, size }) => (
             <MaterialCommunityIcons name="tag" size={size} color={color} />
           ),

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,10 +1,44 @@
-import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Text, StyleSheet, View } from 'react-native';
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
-import { SectionCard } from '../components/SectionCard';
 import { theme } from '../constants/theme';
+import { fetchStartupPayload, StartupPayload } from '../services/api';
 
-export default function HomeScreen() {
+const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+function orderedDayKeys(currentDay?: string) {
+  const configuredStartIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === currentDay);
+  const startIndex = configuredStartIndex >= 0 ? configuredStartIndex : new Date().getDay();
+  return Array.from({ length: 7 }, (_, offset) => {
+    const dayName = DAYS_FULL[(startIndex + offset + 7) % 7];
+    return {
+      dayKey: dayName.slice(0, 3).toUpperCase(),
+      dayLabel: offset === 0 ? `${dayName} (Today)` : dayName,
+    };
+  });
+}
+
+export default function SpecialsScreen() {
+  const [payload, setPayload] = useState<StartupPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await fetchStartupPayload();
+        setPayload(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load specials.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const weekDays = useMemo(() => orderedDayKeys(payload?.general_data?.current_day), [payload?.general_data?.current_day]);
+
   return (
     <ScreenContainer>
       <View style={styles.header}>
@@ -12,12 +46,47 @@ export default function HomeScreen() {
         <Text style={styles.subtitle}>Discover happy hours and late-night deals near you.</Text>
       </View>
 
-      <SectionCard
-        title="Featured Spot"
-        subtitle="A placeholder card for your top bar and its best specials."
-        ctaLabel="View Details"
-        icon={<MaterialCommunityIcons name="star-circle" color={theme.colors.accent} size={20} />}
-      />
+      {loading ? <ActivityIndicator color={theme.colors.accent} size="large" /> : null}
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+      {!loading && !error && weekDays.map(({ dayKey, dayLabel }) => {
+        const entries = payload?.specials_by_day?.[dayKey] ?? [];
+        return (
+          <View key={dayKey} style={styles.daySection}>
+            <Text style={styles.dayHeader}>{dayLabel}</Text>
+            {entries.length === 0 ? <Text style={styles.noSpecials}>No specials available.</Text> : null}
+
+            {entries.map((entry) => {
+              const bar = payload?.bars?.[String(entry.bar_id)];
+              if (!bar) return null;
+
+              const specialDescriptions = (entry.specials ?? [])
+                .map((specialId) => payload?.specials?.[String(specialId)])
+                .filter((special): special is NonNullable<typeof special> => Boolean(special && special.description));
+
+              if (specialDescriptions.length === 0) return null;
+
+              const hoursText = payload?.open_hours?.[String(entry.bar_id)]?.[dayKey]?.display_text ?? 'Hours unavailable';
+
+              return (
+                <View key={`${dayKey}-${entry.bar_id}`} style={styles.card}>
+                  {bar.image_url ? <Image source={{ uri: bar.image_url }} style={styles.cardImage} /> : null}
+                  <Text style={styles.barName}>{bar.name}</Text>
+                  <Text style={styles.neighborhood}>{bar.neighborhood}</Text>
+
+                  {specialDescriptions.map((special, index) => (
+                    <Text key={`${dayKey}-${entry.bar_id}-${index}`} style={styles.specialText}>
+                      • {special.description}
+                    </Text>
+                  ))}
+
+                  <Text style={styles.hours}>Hours: {hoursText}</Text>
+                </View>
+              );
+            })}
+          </View>
+        );
+      })}
     </ScreenContainer>
   );
 }
@@ -26,4 +95,21 @@ const styles = StyleSheet.create({
   header: { gap: 8 },
   title: { color: theme.colors.text, fontSize: 28, fontWeight: '800' },
   subtitle: { color: theme.colors.subtleText, fontSize: 15, lineHeight: 21 },
+  daySection: { gap: 10 },
+  dayHeader: { color: theme.colors.text, fontSize: 20, fontWeight: '700', marginTop: 6 },
+  noSpecials: { color: theme.colors.subtleText, fontStyle: 'italic' },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    padding: 14,
+    gap: 6,
+  },
+  cardImage: { width: '100%', height: 150, borderRadius: 10, marginBottom: 4 },
+  barName: { color: theme.colors.text, fontSize: 19, fontWeight: '700' },
+  neighborhood: { color: theme.colors.subtleText, fontSize: 14, marginBottom: 4 },
+  specialText: { color: theme.colors.text, fontSize: 15, lineHeight: 20 },
+  hours: { color: theme.colors.subtleText, fontSize: 13, marginTop: 4 },
+  errorText: { color: '#fca5a5', fontSize: 14 },
 });

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,4 +1,6 @@
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://example.com/api';
+const STARTUP_API_URL = process.env.EXPO_PUBLIC_STARTUP_API_URL
+  ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
@@ -16,6 +18,51 @@ export type BarSummary = {
   neighborhood: string;
 };
 
+export type StartupPayload = {
+  general_data?: { current_day?: string };
+  bars?: Record<string, {
+    bar_id?: number;
+    name: string;
+    neighborhood: string;
+    image_url?: string | null;
+    currently_open?: boolean;
+    is_open_now?: boolean;
+  }>;
+  specials?: Record<string, {
+    bar_id: number;
+    day: string;
+    description: string;
+    special_type?: string;
+    type?: string;
+    all_day?: boolean;
+    start_time?: string | null;
+    end_time?: string | null;
+    current_status?: string;
+  }>;
+  specials_by_day?: Record<string, Array<{ bar_id: number; specials: number[] }>>;
+  open_hours?: Record<string, Record<string, {
+    display_text?: string;
+    open_time?: string | null;
+    close_time?: string | null;
+  }>>;
+};
+
 export async function fetchBars() {
   return getJson<BarSummary[]>('/bars');
+}
+
+export async function fetchStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
+  const url = new URL(STARTUP_API_URL);
+  if (deviceId) {
+    url.searchParams.set('device_id', deviceId);
+  }
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error(`Startup request failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const parsed = typeof data?.body === 'string' ? JSON.parse(data.body) : data;
+  return parsed?.startup_payload ?? null;
 }


### PR DESCRIPTION
### Motivation
- Rename the mobile app's Home tab to match the web UX and surface the Specials feed in the primary tab. 
- Replace the placeholder home UI with a real Specials view that consumes the backend `startup_payload` so mobile mirrors web behavior.

### Description
- Updated the Expo tab layout label in `mobile/app/_layout.tsx` by changing the `index` screen `title` from `Home` to `Specials`.
- Replaced the placeholder screen with a `SpecialsScreen` in `mobile/app/index.tsx` that fetches the backend startup payload using `fetchStartupPayload`, derives the week order from `general_data.current_day`, and renders `specials_by_day` as day sections with per-bar cards showing image, name, neighborhood, special descriptions, and open-hours text.
- Added `mobile/services/api.ts` support including `STARTUP_API_URL`, a `StartupPayload` TypeScript type, and `fetchStartupPayload` which accepts an optional `device_id` and handles Lambda-style responses where `body` may be a JSON string.
- Added basic loading and error UI states and some layout styles for day headers and bar cards in the mobile Specials screen.

### Testing
- Ran a TypeScript check via `cd mobile && npm run -s tsc -- --noEmit`, which exited non-zero (failed) in this environment.
- Ran the project linter via `cd mobile && npm run lint`, which failed due to Expo lint setup encountering a network `TypeError: fetch failed` in this environment.
- No automated unit/integration tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036a705ddc83309761d86e7cb1faec)