### PR TITLE
Add Specials screen with startup payload, skeleton loader, responsive layout and light theme

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -13,6 +13,9 @@ export default function RootLayout() {
           height: 74,
           paddingBottom: 8,
           paddingTop: 8,
+          width: '100%',
+          maxWidth: 520,
+          alignSelf: 'center',
         },
         tabBarActiveTintColor: theme.colors.accent,
         tabBarInactiveTintColor: theme.colors.muted,
@@ -25,7 +28,7 @@ export default function RootLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
+          title: 'Specials',
           tabBarIcon: ({ color, size }) => (
             <MaterialCommunityIcons name="tag" size={size} color={color} />
           ),

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,29 +1,316 @@
-import { MaterialCommunityIcons } from '@expo/vector-icons';
-import { Text, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { useScrollToTop } from '@react-navigation/native';
+import { Animated, Easing, Image, StyleSheet, Text, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
-import { SectionCard } from '../components/SectionCard';
 import { theme } from '../constants/theme';
+import { fetchStartupPayload, StartupPayload } from '../services/api';
 
-export default function HomeScreen() {
+const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+type SpecialItem = NonNullable<StartupPayload['specials']>[string];
+
+function orderedDayKeys(currentDay?: string) {
+  const configuredStartIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === currentDay);
+  const startIndex = configuredStartIndex >= 0 ? configuredStartIndex : new Date().getDay();
+  return Array.from({ length: 7 }, (_, offset) => {
+    const dayName = DAYS_FULL[(startIndex + offset + 7) % 7];
+    return { dayKey: dayName.slice(0, 3).toUpperCase(), dayLabel: offset === 0 ? `${dayName} (Today)` : dayName };
+  });
+}
+
+function format12Hour(timeValue?: string | null) {
+  if (!timeValue) return null;
+  const [hourRaw, minuteRaw] = timeValue.split(':');
+  let hour = Number.parseInt(hourRaw, 10);
+  const minute = Number.parseInt(minuteRaw, 10);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+  if (hour === 24) hour = 0;
+  const suffix = hour >= 12 ? 'PM' : 'AM';
+  const normalizedHour = hour % 12 === 0 ? 12 : hour % 12;
+  return `${normalizedHour}:${String(minute).padStart(2, '0')} ${suffix}`;
+}
+
+function groupSpecialsForUI(specials: SpecialItem[]) {
+  const groups = new Map<string, SpecialItem[]>();
+  specials.forEach((special) => {
+    const specialType = special.special_type || special.type || '';
+    const key = [specialType, special.all_day ? 'all-day' : 'timed', special.start_time || '', special.end_time || ''].join('|');
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)?.push(special);
+  });
+
+  return Array.from(groups.values()).map((group) => {
+    const base = { ...group[0] };
+    const uniqueDescriptions = Array.from(new Set(group.map((s) => (s.description || '').trim()).filter(Boolean)));
+    base.description = uniqueDescriptions.join(' • ');
+    const hasLive = group.some((s) => s.current_status === 'live' || s.current_status === 'active');
+    const hasUpcoming = group.some((s) => s.current_status === 'upcoming');
+    const hasPast = group.some((s) => s.current_status === 'past');
+    if (hasLive) base.current_status = 'live';
+    else if (hasUpcoming) base.current_status = 'upcoming';
+    else if (hasPast) base.current_status = 'past';
+    return base;
+  });
+}
+
+function iconForType(type?: string) {
+  const normalized = String(type || '').toLowerCase();
+  if (normalized === 'food') return ['restaurant-outline'];
+  if (normalized === 'drink') return ['wine-outline'];
+  if (normalized === 'combo') return ['restaurant-outline', 'wine-outline'];
+  return [];
+}
+
+
+
+function LoadingSkeleton() {
+  const shimmer = useRef(new Animated.Value(-1)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(shimmer, {
+          toValue: 1,
+          duration: 950,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(shimmer, {
+          toValue: -1,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shimmer]);
+
+  const translateX = shimmer.interpolate({
+    inputRange: [-1, 1],
+    outputRange: [-620, 760],
+  });
+
+  const skeletonCards = Array.from({ length: 3 });
+
   return (
-    <ScreenContainer>
-      <View style={styles.header}>
-        <Text style={styles.title}>Tonight&apos;s Specials</Text>
-        <Text style={styles.subtitle}>Discover happy hours and late-night deals near you.</Text>
-      </View>
+    <View style={styles.skeletonList}>
+      {skeletonCards.map((_, index) => (
+        <View key={`skeleton-${index}`} style={styles.skeletonCard}>
+          <View style={styles.skeletonImage} />
+          <View style={styles.skeletonContent}>
+            <View style={[styles.skeletonLine, { width: '58%', height: 20 }]} />
+            <View style={[styles.skeletonLine, { width: '34%', height: 12, marginTop: 8 }]} />
+            <View style={[styles.skeletonLine, { width: '100%', height: 52, marginTop: 12 }]} />
+            <View style={[styles.skeletonLine, { width: '72%', height: 14, marginTop: 12 }]} />
+          </View>
+          <Animated.View style={[styles.skeletonShimmer, { transform: [{ translateX }, { rotate: '18deg' }] }]} />
+        </View>
+      ))}
+    </View>
+  );
+}
 
-      <SectionCard
-        title="Featured Spot"
-        subtitle="A placeholder card for your top bar and its best specials."
-        ctaLabel="View Details"
-        icon={<MaterialCommunityIcons name="star-circle" color={theme.colors.accent} size={20} />}
-      />
+function ActiveDot() {
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 1, duration: 600, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0, duration: 600, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacity]);
+
+  return <Animated.View style={[styles.activeDot, { opacity }]} />;
+}
+
+export default function SpecialsScreen() {
+  const scrollRef = useRef<any>(null);
+  useScrollToTop(scrollRef);
+
+  const [payload, setPayload] = useState<StartupPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showSkeleton, setShowSkeleton] = useState(true);
+  const contentOpacity = useRef(new Animated.Value(0.05)).current;
+  const skeletonOpacity = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setPayload(await fetchStartupPayload());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load specials.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+
+  useEffect(() => {
+    if (!loading) {
+      contentOpacity.setValue(0);
+      skeletonOpacity.setValue(1);
+      setShowSkeleton(true);
+      Animated.sequence([
+        Animated.timing(skeletonOpacity, {
+          toValue: 0,
+          duration: 900,
+          easing: Easing.inOut(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(contentOpacity, {
+          toValue: 1,
+          duration: 1200,
+          easing: Easing.inOut(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]).start(() => {
+        setShowSkeleton(false);
+      });
+    }
+  }, [loading, contentOpacity, skeletonOpacity]);
+
+  const weekDays = useMemo(() => orderedDayKeys(payload?.general_data?.current_day), [payload?.general_data?.current_day]);
+
+  const toolbar = (
+    <View style={styles.toolbar}>
+      <View style={styles.toolbarInner}>
+        <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
+        <Text style={styles.hamburgerButton}>☰</Text>
+      </View>
+    </View>
+  );
+
+  return (
+    <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
+      {showSkeleton ? <Animated.View style={{ opacity: skeletonOpacity }}><LoadingSkeleton /></Animated.View> : null}
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+      {!loading && !error ? (
+        <Animated.View style={{ opacity: contentOpacity }}>
+          {weekDays.map(({ dayKey, dayLabel }) => {
+            const entries = payload?.specials_by_day?.[dayKey] ?? [];
+            return (
+              <View key={dayKey} style={styles.daySection}>
+                <Text style={styles.dayHeader}>{dayLabel}</Text>
+                {entries.length === 0 ? <Text style={styles.noSpecials}>No specials available.</Text> : null}
+                {(() => {
+                  const cards = entries.map((entry) => {
+                    const bar = payload?.bars?.[String(entry.bar_id)];
+                    if (!bar) return null;
+                    const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
+                    const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
+                    if (specials.length === 0) return null;
+
+                    const hourMeta = payload?.open_hours?.[String(entry.bar_id)]?.[dayKey];
+                    const isToday = dayKey === payload?.general_data?.current_day;
+                    const isOpen = bar.currently_open ?? bar.is_open_now;
+                    const hasActiveOrUpcoming = specials.some((special) => ['active', 'live', 'upcoming'].includes(String(special.current_status || '').toLowerCase()));
+
+                    return {
+                      key: `${dayKey}-${entry.bar_id}`,
+                      hasActiveOrUpcoming,
+                      node: (
+                        <View key={`${dayKey}-${entry.bar_id}`} style={styles.card}>
+                          {bar.image_url ? <Image source={{ uri: bar.image_url }} style={styles.cardImage} /> : null}
+                          <View style={styles.cardContent}>
+                            <View style={styles.headingRow}><Text style={styles.barName}>{bar.name}</Text><Text style={styles.neighborhood}>{bar.neighborhood}</Text></View>
+                            <View style={styles.specialsList}>
+                              {specials.map((special, index) => {
+                                const status = (special.current_status ?? '').toLowerCase();
+                                const isLive = status === 'active' || status === 'live';
+                                return (
+                                  <View key={`${index}-${special.description}`} style={[styles.specialItem, isLive ? styles.specialItemLive : null]}>
+                                    <View style={[styles.timeBadge, status === 'past' ? styles.timeBadgePast : null]}>
+                                      <Text style={[styles.timeBadgeText, status === 'past' ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
+                                    </View>
+                                    <Text style={styles.specialDescription}>{special.description}</Text>
+                                    <View style={styles.typeIconWrap}>{iconForType(special.special_type || special.type).map((icon) => <Ionicons key={icon} name={icon as any} size={24} color="#8e8e93" />)}</View>
+                                    {isLive ? <ActiveDot /> : null}
+                                  </View>
+                                );
+                              })}
+                            </View>
+                            {hourMeta?.display_text
+                              ? isToday
+                                ? <Text style={styles.hours}><Text style={isOpen ? styles.openText : styles.closedText}>{isOpen ? 'Open' : 'Closed'}</Text>{isOpen ? ` • Closes ${format12Hour(hourMeta.close_time) || ''}` : ` • Opens ${format12Hour(hourMeta.open_time) || ''}`}</Text>
+                                : <Text style={styles.hours}>Hours: {hourMeta.display_text}</Text>
+                              : <Text style={[styles.hours, styles.futureHours]}>Hours unavailable</Text>}
+                          </View>
+                        </View>
+                      )
+                    };
+                  }).filter(Boolean) as Array<{ key: string; hasActiveOrUpcoming: boolean; node: ReactElement }>;
+
+                  const isFirstDay = dayKey === (weekDays[0]?.dayKey || '');
+                  if (!isFirstDay) return cards.map((card) => card.node);
+
+                  const expiredOnly = cards.filter((card) => !card.hasActiveOrUpcoming);
+                  const activeOrUpcoming = cards.filter((card) => card.hasActiveOrUpcoming);
+
+                  return (
+                    <>
+                      {expiredOnly.map((card) => card.node)}
+                      {expiredOnly.length > 0 && activeOrUpcoming.length > 0 ? <View style={styles.activeUpcomingDivider}><View style={styles.dividerLine} /><Text style={styles.dividerLabel}>Upcoming Specials</Text><View style={styles.dividerLine} /></View> : null}
+                      {activeOrUpcoming.map((card) => card.node)}
+                    </>
+                  );
+                })()}
+              </View>
+            );
+          })}
+        </Animated.View>
+      ) : null}
     </ScreenContainer>
   );
 }
 
 const styles = StyleSheet.create({
-  header: { gap: 8 },
-  title: { color: theme.colors.text, fontSize: 28, fontWeight: '800' },
-  subtitle: { color: theme.colors.subtleText, fontSize: 15, lineHeight: 21 },
+
+  toolbar: { backgroundColor: '#007bff', shadowColor: '#000', shadowOpacity: 0.15, shadowRadius: 6, shadowOffset: { width: 0, height: 2 }, elevation: 3 },
+  toolbarInner: { height: 48, paddingHorizontal: 16, alignItems: 'center', justifyContent: 'center' },
+  toolbarTitle: { color: '#fff', fontSize: 16, fontWeight: '700', textTransform: 'uppercase' },
+  hamburgerButton: { position: 'absolute', right: 16, top: 10, color: '#fff', fontSize: 24, lineHeight: 28 },
+  daySection: { gap: 12 },
+  dayHeader: { color: '#636366', fontSize: 16, fontWeight: '700', borderBottomWidth: 1, borderBottomColor: '#ccc', paddingBottom: 10 },
+  noSpecials: { color: '#555', fontStyle: 'italic', textAlign: 'center' },
+  card: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 14, shadowOffset: { width: 0, height: 6 }, elevation: 5 },
+  cardImage: { width: '100%', height: 180 },
+  cardContent: { padding: 16 },
+  headingRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 10 },
+  barName: { color: '#111827', fontSize: 21, fontWeight: '700', flex: 1 },
+  neighborhood: { color: '#777', fontSize: 11, textTransform: 'uppercase', letterSpacing: 1, maxWidth: '45%', textAlign: 'right' },
+  specialsList: { gap: 8, marginTop: 12 },
+  specialItem: { position: 'relative', backgroundColor: '#f7f9fc', borderWidth: 1, borderColor: '#e6ecf5', borderRadius: 10, paddingVertical: 8, paddingHorizontal: 8, flexDirection: 'row', alignItems: 'center', gap: 8 },
+  specialItemLive: { shadowColor: '#ff4d4f', shadowOpacity: 0.55, shadowRadius: 10, shadowOffset: { width: 0, height: 0 }, elevation: 2 },
+  activeDot: { position: 'absolute', top: 6, right: 6, width: 6, height: 6, borderRadius: 999, backgroundColor: '#ff4d4f' },
+  timeBadge: { width: 72, minWidth: 72, height: 36, backgroundColor: '#007bff', borderRadius: 6, alignItems: 'center', justifyContent: 'center' },
+  timeBadgeText: { color: '#fff', fontSize: 11, fontWeight: '700', textAlign: 'center', lineHeight: 12, includeFontPadding: false },
+  timeBadgePast: { backgroundColor: '#ccc' },
+  timeBadgeTextPast: { color: '#666' },
+  specialDescription: { flex: 1, color: '#111827', fontSize: 13, lineHeight: 18 },
+  typeIconWrap: { minWidth: 50, height: 40, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: 6 },
+  hours: { color: '#333', fontSize: 13, marginTop: 10 },
+  openText: { color: 'green', fontWeight: '700' },
+  closedText: { color: 'red', fontWeight: '700' },
+  futureHours: { fontWeight: '400' },
+
+  skeletonList: { gap: 14 },
+  skeletonCard: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', borderWidth: 1, borderColor: '#e5e7eb', position: 'relative' },
+  skeletonImage: { height: 180, backgroundColor: '#eef2f7' },
+  skeletonContent: { padding: 16 },
+  skeletonLine: { backgroundColor: '#eef2f7', borderRadius: 8 },
+  skeletonShimmer: { position: 'absolute', top: -140, bottom: -140, width: 220, backgroundColor: 'rgba(255,255,255,0.32)' },
+  errorText: { color: '#ef4444', fontSize: 14 },
+  activeUpcomingDivider: { marginTop: 12, marginBottom: 12, flexDirection: 'row', alignItems: 'center', gap: 10 },
+  dividerLine: { flex: 1, height: 1, backgroundColor: '#d1d5db' },
+  dividerLabel: { color: '#6b7280', fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.4 },
 });

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -31,6 +31,25 @@ function format12Hour(timeValue?: string | null) {
   return `${normalizedHour}:${String(minute).padStart(2, '0')} ${suffix}`;
 }
 
+
+function shouldUsePastBadge(status: string, special: SpecialItem, isToday: boolean) {
+  if (status !== 'past') return false;
+  if (!isToday || special.all_day || !special.start_time || !special.end_time) return true;
+
+  const [startHour, startMinute] = special.start_time.split(':').map(Number);
+  const [endHour, endMinute] = special.end_time.split(':').map(Number);
+  const startTotal = (startHour * 60) + startMinute;
+  const endTotal = (endHour * 60) + endMinute;
+  const crossesMidnight = endTotal < startTotal;
+  if (!crossesMidnight) return true;
+
+  const now = new Date();
+  const nowMinutes = (now.getHours() * 60) + now.getMinutes();
+  if (nowMinutes < 120) return false;
+  if (nowMinutes < endTotal) return false;
+  return true;
+}
+
 function groupSpecialsForUI(specials: SpecialItem[]) {
   const groups = new Map<string, SpecialItem[]>();
   specials.forEach((special) => {
@@ -136,6 +155,8 @@ export default function SpecialsScreen() {
   const [payload, setPayload] = useState<StartupPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dividerY, setDividerY] = useState<number | null>(null);
+  const hasScrolledToDivider = useRef(false);
   const [showSkeleton, setShowSkeleton] = useState(true);
   const [showContent, setShowContent] = useState(false);
   const contentOpacity = useRef(new Animated.Value(0)).current;
@@ -145,6 +166,7 @@ export default function SpecialsScreen() {
     (async () => {
       try {
         setLoading(true);
+        hasScrolledToDivider.current = false;
         setError(null);
         setPayload(await fetchStartupPayload());
       } catch (err) {
@@ -182,6 +204,13 @@ export default function SpecialsScreen() {
   }, [loading, contentOpacity, skeletonOpacity]);
 
   const weekDays = useMemo(() => orderedDayKeys(payload?.general_data?.current_day), [payload?.general_data?.current_day]);
+
+
+  useEffect(() => {
+    if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
+    scrollRef.current?.scrollTo?.({ top: Math.max(0, dividerY - 12), animated: false });
+    hasScrolledToDivider.current = true;
+  }, [showContent, dividerY, scrollRef]);
 
   const toolbar = (
     <View style={styles.toolbar}>
@@ -229,10 +258,11 @@ export default function SpecialsScreen() {
                               {specials.map((special, index) => {
                                 const status = (special.current_status ?? '').toLowerCase();
                                 const isLive = status === 'active' || status === 'live';
+                                const isPastBadge = shouldUsePastBadge(status, special, isToday);
                                 return (
                                   <View key={`${index}-${special.description}`} style={[styles.specialItem, isLive ? styles.specialItemLive : null]}>
-                                    <View style={[styles.timeBadge, status === 'past' ? styles.timeBadgePast : null]}>
-                                      <Text style={[styles.timeBadgeText, status === 'past' ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
+                                    <View style={[styles.timeBadge, isPastBadge ? styles.timeBadgePast : null]}>
+                                      <Text style={[styles.timeBadgeText, isPastBadge ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
                                     </View>
                                     <Text style={styles.specialDescription}>{special.description}</Text>
                                     <View style={styles.typeIconWrap}>{iconForType(special.special_type || special.type).map((icon) => <Ionicons key={icon} name={icon as any} size={24} color="#8e8e93" />)}</View>
@@ -261,7 +291,7 @@ export default function SpecialsScreen() {
                   return (
                     <>
                       {expiredOnly.map((card) => card.node)}
-                      {expiredOnly.length > 0 && activeOrUpcoming.length > 0 ? <View style={styles.activeUpcomingDivider}><View style={styles.dividerLine} /><Text style={styles.dividerLabel}>Upcoming Specials</Text><View style={styles.dividerLine} /></View> : null}
+                      {expiredOnly.length > 0 && activeOrUpcoming.length > 0 ? <View style={styles.activeUpcomingDivider} onLayout={(event) => setDividerY(event.nativeEvent.layout.y)}><View style={styles.dividerLine} /><Text style={styles.dividerLabel}>Active + Upcoming</Text><View style={styles.dividerLine} /></View> : null}
                       {activeOrUpcoming.map((card) => card.node)}
                     </>
                   );

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -165,7 +165,7 @@ export default function SpecialsScreen() {
 
       Animated.timing(skeletonOpacity, {
         toValue: 0,
-        duration: 900,
+        duration: 500,
         easing: Easing.inOut(Easing.cubic),
         useNativeDriver: true,
       }).start(() => {
@@ -173,7 +173,7 @@ export default function SpecialsScreen() {
         setShowContent(true);
         Animated.timing(contentOpacity, {
           toValue: 1,
-          duration: 1300,
+          duration: 700,
           easing: Easing.inOut(Easing.cubic),
           useNativeDriver: true,
         }).start();

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -190,8 +190,10 @@ export default function SpecialsScreen() {
 
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
-    scrollRef.current?.scrollTo?.({ top: Math.max(0, dividerY - 12), animated: false });
-    hasScrolledToDivider.current = true;
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY - 12), animated: false });
+      hasScrolledToDivider.current = true;
+    });
   }, [showContent, dividerY, scrollRef]);
 
   const toolbar = (

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -32,24 +32,6 @@ function format12Hour(timeValue?: string | null) {
 }
 
 
-function shouldUsePastBadge(status: string, special: SpecialItem, isToday: boolean) {
-  if (status !== 'past') return false;
-  if (!isToday || special.all_day || !special.start_time || !special.end_time) return true;
-
-  const [startHour, startMinute] = special.start_time.split(':').map(Number);
-  const [endHour, endMinute] = special.end_time.split(':').map(Number);
-  const startTotal = (startHour * 60) + startMinute;
-  const endTotal = (endHour * 60) + endMinute;
-  const crossesMidnight = endTotal < startTotal;
-  if (!crossesMidnight) return true;
-
-  const now = new Date();
-  const nowMinutes = (now.getHours() * 60) + now.getMinutes();
-  if (nowMinutes < 120) return false;
-  if (nowMinutes < endTotal) return false;
-  return true;
-}
-
 function groupSpecialsForUI(specials: SpecialItem[]) {
   const groups = new Map<string, SpecialItem[]>();
   specials.forEach((special) => {
@@ -258,11 +240,10 @@ export default function SpecialsScreen() {
                               {specials.map((special, index) => {
                                 const status = (special.current_status ?? '').toLowerCase();
                                 const isLive = status === 'active' || status === 'live';
-                                const isPastBadge = shouldUsePastBadge(status, special, isToday);
                                 return (
                                   <View key={`${index}-${special.description}`} style={[styles.specialItem, isLive ? styles.specialItemLive : null]}>
-                                    <View style={[styles.timeBadge, isPastBadge ? styles.timeBadgePast : null]}>
-                                      <Text style={[styles.timeBadgeText, isPastBadge ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
+                                    <View style={[styles.timeBadge, status === 'past' ? styles.timeBadgePast : null]}>
+                                      <Text style={[styles.timeBadgeText, status === 'past' ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
                                     </View>
                                     <Text style={styles.specialDescription}>{special.description}</Text>
                                     <View style={styles.typeIconWrap}>{iconForType(special.special_type || special.type).map((icon) => <Ionicons key={icon} name={icon as any} size={24} color="#8e8e93" />)}</View>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -137,7 +137,8 @@ export default function SpecialsScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showSkeleton, setShowSkeleton] = useState(true);
-  const contentOpacity = useRef(new Animated.Value(0.05)).current;
+  const [showContent, setShowContent] = useState(false);
+  const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -160,21 +161,22 @@ export default function SpecialsScreen() {
       contentOpacity.setValue(0);
       skeletonOpacity.setValue(1);
       setShowSkeleton(true);
-      Animated.sequence([
-        Animated.timing(skeletonOpacity, {
-          toValue: 0,
-          duration: 900,
-          easing: Easing.inOut(Easing.cubic),
-          useNativeDriver: true,
-        }),
+      setShowContent(false);
+
+      Animated.timing(skeletonOpacity, {
+        toValue: 0,
+        duration: 900,
+        easing: Easing.inOut(Easing.cubic),
+        useNativeDriver: true,
+      }).start(() => {
+        setShowSkeleton(false);
+        setShowContent(true);
         Animated.timing(contentOpacity, {
           toValue: 1,
-          duration: 1200,
+          duration: 1300,
           easing: Easing.inOut(Easing.cubic),
           useNativeDriver: true,
-        }),
-      ]).start(() => {
-        setShowSkeleton(false);
+        }).start();
       });
     }
   }, [loading, contentOpacity, skeletonOpacity]);
@@ -194,7 +196,7 @@ export default function SpecialsScreen() {
     <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
       {showSkeleton ? <Animated.View style={{ opacity: skeletonOpacity }}><LoadingSkeleton /></Animated.View> : null}
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
-      {!loading && !error ? (
+      {!loading && !error && showContent ? (
         <Animated.View style={{ opacity: contentOpacity }}>
           {weekDays.map(({ dayKey, dayLabel }) => {
             const entries = payload?.specials_by_day?.[dayKey] ?? [];

--- a/mobile/components/ScreenContainer.tsx
+++ b/mobile/components/ScreenContainer.tsx
@@ -1,12 +1,20 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode, RefObject } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ScrollView, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { theme } from '../constants/theme';
 
-export function ScreenContainer({ children }: PropsWithChildren) {
+type ScreenContainerProps = PropsWithChildren<{
+  scrollViewRef?: RefObject<ScrollView | null>;
+  stickyHeader?: ReactNode;
+}>;
+
+export function ScreenContainer({ children, scrollViewRef, stickyHeader }: ScreenContainerProps) {
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView contentContainerStyle={styles.content}>{children}</ScrollView>
+      {stickyHeader ? <View style={styles.stickyHeader}>{stickyHeader}</View> : null}
+      <ScrollView ref={scrollViewRef} contentContainerStyle={styles.scrollContent}>
+        <View style={styles.content}>{children}</View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -16,10 +24,20 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: theme.colors.background,
   },
+  stickyHeader: {
+    width: '100%',
+    alignSelf: 'stretch',
+    zIndex: 10,
+  },
+  scrollContent: {
+    paddingBottom: 32,
+  },
   content: {
+    width: '100%',
+    maxWidth: 520,
+    alignSelf: 'center',
     paddingHorizontal: 16,
     paddingTop: 16,
-    paddingBottom: 32,
     gap: 16,
   },
 });

--- a/mobile/constants/theme.ts
+++ b/mobile/constants/theme.ts
@@ -1,11 +1,11 @@
 export const theme = {
   colors: {
-    background: '#0B0E14',
-    surface: '#151A23',
-    border: '#2B3444',
-    text: '#F3F4F6',
-    subtleText: '#9AA3B2',
-    muted: '#6B7280',
-    accent: '#7DD3FC',
+    background: '#F2F4F8',
+    surface: '#FFFFFF',
+    border: '#E5E7EB',
+    text: '#111827',
+    subtleText: '#6B7280',
+    muted: '#9CA3AF',
+    accent: '#007BFF',
   },
 };

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,4 +1,6 @@
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://example.com/api';
+const STARTUP_API_URL = process.env.EXPO_PUBLIC_STARTUP_API_URL
+  ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
@@ -16,6 +18,56 @@ export type BarSummary = {
   neighborhood: string;
 };
 
+export type StartupPayload = {
+  general_data?: { current_day?: string };
+  bars?: Record<string, {
+    bar_id?: number;
+    name: string;
+    neighborhood: string;
+    image_url?: string | null;
+    currently_open?: boolean;
+    is_open_now?: boolean;
+  }>;
+  specials?: Record<string, {
+    bar_id: number;
+    day: string;
+    description: string;
+    special_type?: string;
+    type?: string;
+    all_day?: boolean;
+    start_time?: string | null;
+    end_time?: string | null;
+    current_status?: string;
+  }>;
+  specials_by_day?: Record<string, Array<{ bar_id: number; specials: number[] }>>;
+  open_hours?: Record<string, Record<string, {
+    display_text?: string;
+    open_time?: string | null;
+    close_time?: string | null;
+  }>>;
+};
+
 export async function fetchBars() {
   return getJson<BarSummary[]>('/bars');
+}
+
+
+function buildStartupUrl(deviceId?: string) {
+  const base = API_BASE_URL.endsWith('/') ? API_BASE_URL : `${API_BASE_URL}/`;
+  const url = new URL(STARTUP_API_URL, base);
+  if (deviceId) {
+    url.searchParams.set('device_id', deviceId);
+  }
+  return url.toString();
+}
+
+export async function fetchStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
+  const response = await fetch(buildStartupUrl(deviceId));
+  if (!response.ok) {
+    throw new Error(`Startup request failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const parsed = typeof data?.body === 'string' ? JSON.parse(data.body) : data;
+  return parsed?.startup_payload ?? null;
 }


### PR DESCRIPTION
### Motivation

- Replace the old home placeholder with a fully-featured "Specials" screen that loads startup payload data and displays daily grouped specials with better UX and responsive layout.
- Provide a graceful loading state and animated transitions from skeleton to content to improve perceived performance while fetching remote data.
- Unify container and tab styling and switch the app theme from a dark to a light palette to match the new visuals.

### Description

- Implement a new `SpecialsScreen` in `mobile/app/index.tsx` that fetches startup payload via `fetchStartupPayload`, groups specials for UI, orders weekday sections, formats times, and renders cards with active/upcoming/past state and icons, plus `LoadingSkeleton` and `ActiveDot` animated components. 
- Add `fetchStartupPayload`, `StartupPayload` types, and URL building logic to `mobile/services/api.ts` and keep existing `fetchBars` unchanged. 
- Update `ScreenContainer` (`mobile/components/ScreenContainer.tsx`) to accept `scrollViewRef` and `stickyHeader` props, expose a centered max width for content, and render sticky header support. 
- Update root tabs layout in `mobile/app/_layout.tsx` to center the tab bar, constrain its max width, and rename the first tab title from `Home` to `Specials`. 
- Replace dark theme with a light theme and update `mobile/constants/theme.ts` color tokens to new values, and add many new styles to support the new screen layout and components. 

### Testing

- Ran a local TypeScript typecheck with `yarn tsc` and it completed without type errors. 
- Ran linting with `yarn lint` and there were no lint failures for the changed files. 
- No new automated unit tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036a705ddc83309761d86e7cb1faec)