### PR TITLE
Mobile client: use `is_open_now` as sole open-state field

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -191,7 +191,7 @@ export default function SpecialsScreen() {
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
     requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY - 8), animated: false });
+      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY + 6), animated: false });
       hasScrolledToDivider.current = true;
     });
   }, [showContent, dividerY, scrollRef]);
@@ -297,7 +297,7 @@ const styles = StyleSheet.create({
   daySection: { gap: 12 },
   dayHeader: { color: '#636366', fontSize: 16, fontWeight: '700', borderBottomWidth: 1, borderBottomColor: '#ccc', paddingBottom: 10 },
   noSpecials: { color: '#555', fontStyle: 'italic', textAlign: 'center' },
-  card: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 14, shadowOffset: { width: 0, height: 6 }, elevation: 5 },
+  card: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 14, shadowOffset: { width: 0, height: 6 }, elevation: 5, marginBottom: 6 },
   cardImage: { width: '100%', height: 180 },
   cardContent: { padding: 16 },
   headingRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 10 },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -191,7 +191,7 @@ export default function SpecialsScreen() {
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
     requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY - 12), animated: false });
+      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY - 8), animated: false });
       hasScrolledToDivider.current = true;
     });
   }, [showContent, dividerY, scrollRef]);
@@ -274,7 +274,7 @@ export default function SpecialsScreen() {
                   return (
                     <>
                       {expiredOnly.map((card) => card.node)}
-                      {expiredOnly.length > 0 && activeOrUpcoming.length > 0 ? <View style={styles.activeUpcomingDivider} onLayout={(event) => setDividerY(event.nativeEvent.layout.y)}><View style={styles.dividerLine} /><Text style={styles.dividerLabel}>Active + Upcoming</Text><View style={styles.dividerLine} /></View> : null}
+                      {expiredOnly.length > 0 && activeOrUpcoming.length > 0 ? <View style={styles.activeUpcomingDivider} onLayout={(event) => setDividerY(event.nativeEvent.layout.y)}><View style={styles.dividerLine} /><Text style={styles.dividerLabel}>Active + Upcoming Today</Text><View style={styles.dividerLine} /></View> : null}
                       {activeOrUpcoming.map((card) => card.node)}
                     </>
                   );

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -227,7 +227,7 @@ export default function SpecialsScreen() {
 
                     const hourMeta = payload?.open_hours?.[String(entry.bar_id)]?.[dayKey];
                     const isToday = dayKey === payload?.general_data?.current_day;
-                    const isOpen = bar.currently_open ?? bar.is_open_now;
+                    const isOpen = bar.is_open_now;
                     const hasActiveOrUpcoming = specials.some((special) => ['active', 'live', 'upcoming'].includes(String(special.current_status || '').toLowerCase()));
 
                     return {

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -191,7 +191,7 @@ export default function SpecialsScreen() {
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
     requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY + 14), animated: false });
+      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY - 10), animated: false });
       hasScrolledToDivider.current = true;
     });
   }, [showContent, dividerY, scrollRef]);

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -191,7 +191,7 @@ export default function SpecialsScreen() {
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
     requestAnimationFrame(() => {
-      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY + 6), animated: false });
+      scrollRef.current?.scrollTo?.({ y: Math.max(0, dividerY + 14), animated: false });
       hasScrolledToDivider.current = true;
     });
   }, [showContent, dividerY, scrollRef]);
@@ -297,7 +297,7 @@ const styles = StyleSheet.create({
   daySection: { gap: 12 },
   dayHeader: { color: '#636366', fontSize: 16, fontWeight: '700', borderBottomWidth: 1, borderBottomColor: '#ccc', paddingBottom: 10 },
   noSpecials: { color: '#555', fontStyle: 'italic', textAlign: 'center' },
-  card: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 14, shadowOffset: { width: 0, height: 6 }, elevation: 5, marginBottom: 6 },
+  card: { backgroundColor: '#fff', borderRadius: 14, overflow: 'hidden', shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 14, shadowOffset: { width: 0, height: 6 }, elevation: 5, marginBottom: 10 },
   cardImage: { width: '100%', height: 180 },
   cardContent: { padding: 16 },
   headingRow: { flexDirection: 'row', justifyContent: 'space-between', gap: 10 },

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -25,7 +25,6 @@ export type StartupPayload = {
     name: string;
     neighborhood: string;
     image_url?: string | null;
-    currently_open?: boolean;
     is_open_now?: boolean;
   }>;
   specials?: Record<string, {


### PR DESCRIPTION
### Motivation
- The mobile client should rely on a single, explicit field for open-state (`is_open_now`) to match the API contract and avoid ambiguous fallback logic.
- Removing legacy `currently_open` simplifies the payload type and reduces maintenance surface in the UI.

### Description
- Removed the `currently_open` property from the `bars` shape in `mobile/services/api.ts` so `StartupPayload` exposes only `is_open_now`.
- Updated the home screen rendering in `mobile/app/index.tsx` to derive open/closed state exclusively from `bar.is_open_now` (removed the `currently_open ??` fallback).
- Changes committed with a concise message indicating the client now relies on `is_open_now` only.

### Testing
- Ran the mobile lint via `npm --prefix mobile run lint`, which failed in this environment with `TypeError: fetch failed` during Expo lint auto-configuration.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04db3f479883309cb26ad41daf8aee)