### PR TITLE
Prefetch and dedupe startup payload fetch on mobile and web

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,6 +1,9 @@
 import { Tabs } from 'expo-router';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { theme } from '../constants/theme';
+import { prefetchStartupPayload } from '../services/api';
+
+prefetchStartupPayload().catch(() => null);
 
 export default function RootLayout() {
   return (

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -60,13 +60,33 @@ function buildStartupUrl(deviceId?: string) {
   return url.toString();
 }
 
-export async function fetchStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
-  const response = await fetch(buildStartupUrl(deviceId));
-  if (!response.ok) {
-    throw new Error(`Startup request failed: ${response.status}`);
-  }
 
-  const data = await response.json();
-  const parsed = typeof data?.body === 'string' ? JSON.parse(data.body) : data;
-  return parsed?.startup_payload ?? null;
+// Shared in-flight startup request to avoid duplicate calls during app boot.
+let startupPayloadPromise: Promise<StartupPayload | null> | null = null;
+
+function requestStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
+  return fetch(buildStartupUrl(deviceId))
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Startup request failed: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      const parsed = typeof data?.body === 'string' ? JSON.parse(data.body) : data;
+      return parsed?.startup_payload ?? null;
+    });
+}
+
+export function prefetchStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
+  if (!startupPayloadPromise) {
+    startupPayloadPromise = requestStartupPayload(deviceId).catch((err) => {
+      startupPayloadPromise = null;
+      throw err;
+    });
+  }
+  return startupPayloadPromise;
+}
+export async function fetchStartupPayload(deviceId?: string): Promise<StartupPayload | null> {
+  return prefetchStartupPayload(deviceId);
 }

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -61,12 +61,19 @@ function buildBarDetailsUrl(barId) {
   return url.toString();
 }
 
+
+function requestStartupPayload() {
+  return fetch(buildStartupUrl())
+    .then((response) => response.json())
+    .then((data) => (typeof data.body === 'string' ? JSON.parse(data.body) : data))
+    .then((parsed) => parsed.startup_payload || null);
+}
+
+// Start startup payload fetch immediately and reuse it during initial load.
+let startupPayloadPromise = requestStartupPayload();
 async function loadBars() {
   try {
-    const response = await fetch(buildStartupUrl());
-    const data = await response.json();
-    const parsed = typeof data.body === 'string' ? JSON.parse(data.body) : data;
-    startupPayload = parsed.startup_payload || null;
+    startupPayload = await startupPayloadPromise;
     barDetailsById = {};
     mapSelectedDayKey = startupPayload?.general_data?.current_day || null;
 


### PR DESCRIPTION
### Motivation
- Avoid duplicate startup HTTP requests during app boot and improve initial load performance by initiating a single shared fetch for the startup payload.

### Description
- Introduced a shared in-flight startup promise in `mobile/services/api.ts` with `requestStartupPayload` and `prefetchStartupPayload` to dedupe calls and kept `fetchStartupPayload` as an alias to the prefetched promise.
- Triggered early prefetch in the mobile app by importing and calling `prefetchStartupPayload()` from `mobile/app/_layout.tsx` and swallowing errors to avoid blocking render.
- Mirrored the behavior in `web/js/api.js` by starting `requestStartupPayload` immediately as `startupPayloadPromise` and reusing it inside `loadBars`.
- Retained existing URL builders and payload parsing while switching to a promise-based flow to centralize error handling and reuse results.

### Testing
- Ran TypeScript type check with `tsc --noEmit`, which completed successfully.
- Ran linter with `eslint` against modified files and no errors were reported.
- Executed the unit test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cbb29f4c833084508b4108b8b88d)