### PR TITLE
Move Google Maps API key to client-side config and remove from startup payload

### DIFF
--- a/functions/getStartupData/get_startup_data.py
+++ b/functions/getStartupData/get_startup_data.py
@@ -10,7 +10,6 @@ DB_USER = os.environ['DB_USER']
 DB_PASSWORD = os.environ['DB_PASSWORD']
 DB_NAME = os.environ['DB_NAME']
 BAR_IMAGE_FOLDER_URL = os.environ['BAR_IMAGE_FOLDER_URL'].rstrip('/')
-GOOGLE_API_KEY = os.environ['GOOGLE_API_KEY']
 GOOGLE_MAP_ID = os.environ.get('GOOGLE_MAP_ID', 'DEMO_MAP_ID')
 
 DAY_KEYS = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
@@ -446,7 +445,6 @@ def build_startup_payload(device_id=None):
                 'general_data': {
                     'current_day': current_day_key,
                     'generated_at': now.isoformat(),
-                    'google_api_key': GOOGLE_API_KEY,
                     'google_map_id': GOOGLE_MAP_ID
                 },
                 'bars': bars_lookup,

--- a/mobile/app/map.tsx
+++ b/mobile/app/map.tsx
@@ -3,6 +3,7 @@ import { Text } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { SectionCard } from '../components/SectionCard';
 import { theme } from '../constants/theme';
+import { GOOGLE_MAPS_MOBILE_API_KEY } from '../services/config';
 
 export default function MapScreen() {
   return (
@@ -10,7 +11,9 @@ export default function MapScreen() {
       <Text style={{ color: theme.colors.text, fontSize: 28, fontWeight: '800' }}>Map</Text>
       <SectionCard
         title="Nearby Map"
-        subtitle="Placeholder map experience. A web-safe map can be added with a compatible Expo library later."
+        subtitle={GOOGLE_MAPS_MOBILE_API_KEY
+          ? 'Mobile Maps API key detected from environment. Map UI wiring can use this key when the map library is enabled.'
+          : 'Set EXPO_PUBLIC_GOOGLE_MAPS_MOBILE_API_KEY in environment to enable mobile map provider setup.'}
         ctaLabel="Enable Location"
         icon={<MaterialCommunityIcons name="map-marker-radius" color={theme.colors.accent} size={20} />}
       />

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,6 +1,4 @@
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://example.com/api';
-const STARTUP_API_URL = process.env.EXPO_PUBLIC_STARTUP_API_URL
-  ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
+import { API_BASE_URL, STARTUP_API_URL } from './config';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);

--- a/mobile/services/config.ts
+++ b/mobile/services/config.ts
@@ -1,0 +1,6 @@
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://example.com/api';
+
+export const STARTUP_API_URL = process.env.EXPO_PUBLIC_STARTUP_API_URL
+  ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
+
+export const GOOGLE_MAPS_MOBILE_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_MOBILE_API_KEY ?? '';

--- a/web/index.html
+++ b/web/index.html
@@ -217,6 +217,7 @@
 <script src="https://cdn.jsdelivr.net/npm/lucide@0.575.0/dist/umd/lucide.js"></script>
 <script> lucide.createIcons();</script>
 <!-- Link to external JS -->
+<script src="js/config.js"></script>
 <script src="js/state.js"></script>
 <script src="js/utils.js"></script>
 <script src="js/render-home.js"></script>

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -1,0 +1,4 @@
+window.WEB_CONFIG = {
+  GOOGLE_MAPS_WEB_API_KEY: 'REPLACE_WITH_GOOGLE_MAPS_WEB_API_KEY',
+  ...(window.WEB_CONFIG || {})
+};

--- a/web/js/render-bar-detail.js
+++ b/web/js/render-bar-detail.js
@@ -155,8 +155,8 @@ function updateBarLocationSection(selectedBar) {
   if (!section || !mapFrame) return;
 
   const placeId = selectedBar?.google_place_id;
-  const googleApiKey = startupPayload?.general_data?.google_api_key;
-  if (!placeId || !googleApiKey) {
+  const googleApiKey = window.WEB_CONFIG?.GOOGLE_MAPS_WEB_API_KEY;
+  if (!placeId || !googleApiKey || googleApiKey === 'REPLACE_WITH_GOOGLE_MAPS_WEB_API_KEY') {
     section.style.display = 'none';
     mapFrame.removeAttribute('src');
     if (detailLocationMapState.mapContainer) {

--- a/web/js/render-map.js
+++ b/web/js/render-map.js
@@ -82,9 +82,9 @@ function loadGoogleMapsApi() {
     return googleMapsLoaderPromise;
   }
 
-  const apiKey = startupPayload?.general_data?.google_api_key;
-  if (!apiKey) {
-    return Promise.reject(new Error('Google Maps API key is missing from startup payload.'));
+  const apiKey = window.WEB_CONFIG?.GOOGLE_MAPS_WEB_API_KEY;
+  if (!apiKey || apiKey === 'REPLACE_WITH_GOOGLE_MAPS_WEB_API_KEY') {
+    return Promise.reject(new Error('Google Maps API key is missing from web config.'));
   }
 
   googleMapsLoaderPromise = new Promise((resolve, reject) => {

--- a/web/tests/app.test.js
+++ b/web/tests/app.test.js
@@ -147,6 +147,7 @@ class DocumentMock {
 
 function loadAppWithoutBoot(document) {
   const scriptFiles = [
+    'js/config.js',
     'js/state.js',
     'js/utils.js',
     'js/render-home.js',
@@ -169,7 +170,7 @@ function loadAppWithoutBoot(document) {
   const context = {
     console,
     document,
-    window: { document, localStorage },
+    window: { document, localStorage, WEB_CONFIG: { GOOGLE_MAPS_WEB_API_KEY: 'client-google-key' } },
     URL,
     localStorage,
     lucide: { createIcons() {} },
@@ -879,7 +880,7 @@ test('showDetail reuses startup payload details when has_special_this_week is tr
 
   vm.runInContext(`
     startupPayload = {
-      general_data: { current_day: 'MON', google_api_key: 'client-google-key' },
+      general_data: { current_day: 'MON' },
       bars: {
         '1': { name: 'Startup Bar', neighborhood: 'Downtown', image_url: 'bar.jpg', google_place_id: 'abc123', is_open_now: false, has_special_this_week: true }
       },
@@ -921,10 +922,11 @@ test('showDetail reuses startup payload details when has_special_this_week is tr
   assert.equal(mapSrc, 'https://www.google.com/maps/embed/v1/place?key=client-google-key&q=place_id%3Aabc123');
 });
 
-test('showDetail hides location map when google_api_key is missing from startup general_data', async () => {
+test('showDetail hides location map when web config google maps key is missing', async () => {
   const document = new DocumentMock();
   mountBaseNodes(document);
   const ctx = loadAppWithoutBoot(document);
+  ctx.window.WEB_CONFIG.GOOGLE_MAPS_WEB_API_KEY = 'REPLACE_WITH_GOOGLE_MAPS_WEB_API_KEY';
 
   vm.runInContext(`
     startupPayload = {


### PR DESCRIPTION
### Motivation

- Prevent the server from exposing the Google Maps API key in the startup payload and centralize client-side configuration for the web UI.
- Make the frontend load the Maps API from a client-controlled config so builds or deployments can inject the web key without changing backend behavior.

### Description

- Removed `GOOGLE_API_KEY` exposure from the startup payload generation in `functions/getStartupData/get_startup_data.py` by no longer including it in `general_data` and by removing the environment variable usage.
- Added a client-side config file `web/js/config.js` that defines `window.WEB_CONFIG.GOOGLE_MAPS_WEB_API_KEY` with a placeholder value `REPLACE_WITH_GOOGLE_MAPS_WEB_API_KEY`.
- Updated `web/index.html` to load `js/config.js` before the application scripts.
- Updated frontend code in `web/js/render-map.js` and `web/js/render-bar-detail.js` to read the API key from `window.WEB_CONFIG.GOOGLE_MAPS_WEB_API_KEY` and to treat the placeholder value as “missing”, hiding map UI or failing to load the Maps script accordingly.
- Updated tests and test harness in `web/tests/app.test.js` to include `js/config.js` in the test boot and to assert behavior based on `WEB_CONFIG` instead of `startupPayload.general_data.google_api_key`.

### Testing

- Ran the frontend unit tests covering `web/tests/app.test.js` (the test runner executed the updated tests that exercise map loading and detail rendering). All updated tests completed successfully.
- Verified the modified tests that assert map iframe `src` and map visibility pass under both present and missing `WEB_CONFIG.GOOGLE_MAPS_WEB_API_KEY` scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06248ee1048330b77447f5ab9be635)