### PR TITLE
Add filters side menu (favorites & neighborhood) to Bars screen

### DIFF
--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
-import { Image, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Modal, Image, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { fetchStartupPayload, StartupPayload } from '../services/api';
 
@@ -17,6 +17,11 @@ export default function BarsScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [selectedNeighborhood, setSelectedNeighborhood] = useState<string>('');
+  const [draftFavoritesOnly, setDraftFavoritesOnly] = useState(false);
+  const [draftSelectedNeighborhood, setDraftSelectedNeighborhood] = useState<string>('');
 
   useEffect(() => {
     (async () => {
@@ -33,56 +38,123 @@ export default function BarsScreen() {
   }, []);
 
   const bars = useMemo(() => toSortedBars(payload), [payload]);
+  const neighborhoods = useMemo(
+    () => Array.from(new Set(bars.map((bar) => bar.neighborhood).filter(Boolean))).sort((a, b) => a.localeCompare(b)),
+    [bars]
+  );
+
   const filteredBars = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
-    return bars.filter((bar) => (!normalizedQuery ? true : (bar.name || '').toLowerCase().includes(normalizedQuery)));
-  }, [bars, query]);
+    return bars.filter((bar) => {
+      const queryMatch = !normalizedQuery ? true : (bar.name || '').toLowerCase().includes(normalizedQuery);
+      const favoriteMatch = !favoritesOnly || bar.favorite === true;
+      const neighborhoodMatch = !selectedNeighborhood || bar.neighborhood === selectedNeighborhood;
+      return queryMatch && favoriteMatch && neighborhoodMatch;
+    });
+  }, [bars, query, favoritesOnly, selectedNeighborhood]);
 
   const toolbar = (
     <View style={styles.toolbar}>
       <View style={styles.toolbarInner}>
         <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
-        <Text style={styles.hamburgerButton}>☰</Text>
+        <Text
+          style={styles.hamburgerButton}
+          onPress={() => {
+            setDraftFavoritesOnly(favoritesOnly);
+            setDraftSelectedNeighborhood(selectedNeighborhood);
+            setIsMenuOpen(true);
+          }}
+        >
+          ☰
+        </Text>
       </View>
     </View>
   );
 
   return (
-    <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
-      <View style={styles.searchWrap}>
-        <TextInput
-          placeholder="Search bars"
-          placeholderTextColor="#9aa0aa"
-          value={query}
-          onChangeText={setQuery}
-          style={styles.input}
-          autoCorrect={false}
-          autoCapitalize="none"
-        />
-      </View>
-
-      {loading ? <Text style={styles.statusText}>Loading bars…</Text> : null}
-      {error ? <Text style={styles.errorText}>{error}</Text> : null}
-      {!loading && !error && filteredBars.length === 0 ? <Text style={styles.statusText}>No bars found.</Text> : null}
-
-      {!loading && !error ? (
-        <View style={styles.listWrap}>
-          {filteredBars.map((bar) => (
-            <View key={`${bar.bar_id}-${bar.name}`} style={styles.card}>
-              <Image
-                source={{ uri: bar.image_url && bar.image_url !== 'null' ? bar.image_url : 'https://placehold.co/144x144?text=Bar' }}
-                style={styles.thumb}
-              />
-              <View style={styles.content}>
-                <Text style={styles.name}>{bar.name}</Text>
-                <Text style={styles.neighborhood}>{bar.neighborhood}</Text>
-              </View>
-              <Text style={styles.chevron}>›</Text>
-            </View>
-          ))}
+    <>
+      <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
+        <View style={styles.searchWrap}>
+          <TextInput
+            placeholder="Search bars"
+            placeholderTextColor="#9aa0aa"
+            value={query}
+            onChangeText={setQuery}
+            style={styles.input}
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
         </View>
-      ) : null}
-    </ScreenContainer>
+
+        {loading ? <Text style={styles.statusText}>Loading bars…</Text> : null}
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+        {!loading && !error && filteredBars.length === 0 ? <Text style={styles.statusText}>No bars found.</Text> : null}
+
+        {!loading && !error ? (
+          <View style={styles.listWrap}>
+            {filteredBars.map((bar) => (
+              <View key={`${bar.bar_id}-${bar.name}`} style={styles.card}>
+                <Image
+                  source={{ uri: bar.image_url && bar.image_url !== 'null' ? bar.image_url : 'https://placehold.co/144x144?text=Bar' }}
+                  style={styles.thumb}
+                />
+                <View style={styles.content}>
+                  <Text style={styles.name}>{bar.name}</Text>
+                  <Text style={styles.neighborhood}>{bar.neighborhood}</Text>
+                </View>
+                <Text style={styles.chevron}>›</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </ScreenContainer>
+
+      <Modal visible={isMenuOpen} animationType="slide" transparent onRequestClose={() => setIsMenuOpen(false)}>
+        <Pressable style={styles.overlay} onPress={() => setIsMenuOpen(false)}>
+          <Pressable style={styles.sideMenu} onPress={() => {}}>
+            <Text style={styles.sideHeader}>Filters</Text>
+
+            <Text style={styles.sectionTitle}>Bar Options</Text>
+            <Pressable style={[styles.filterRow, draftFavoritesOnly ? styles.filterRowSelected : null]} onPress={() => setDraftFavoritesOnly((current) => !current)}>
+              <Text style={styles.filterText}>Favorites only</Text>
+              <Text style={styles.checkbox}>{draftFavoritesOnly ? '☑' : '☐'}</Text>
+            </Pressable>
+
+            <Text style={styles.sectionTitle}>Neighborhood</Text>
+            <Pressable
+              style={[styles.filterRow, draftSelectedNeighborhood === '' ? styles.filterRowSelected : null]}
+              onPress={() => setDraftSelectedNeighborhood('')}
+            >
+              <Text style={styles.filterText}>All neighborhoods</Text>
+              <Text style={styles.checkbox}>{draftSelectedNeighborhood === '' ? '◉' : '○'}</Text>
+            </Pressable>
+            {neighborhoods.map((neighborhood) => (
+              <Pressable
+                key={neighborhood}
+                style={[styles.filterRow, draftSelectedNeighborhood === neighborhood ? styles.filterRowSelected : null]}
+                onPress={() => setDraftSelectedNeighborhood(neighborhood)}
+              >
+                <Text style={styles.filterText}>{neighborhood}</Text>
+                <Text style={styles.checkbox}>{draftSelectedNeighborhood === neighborhood ? '◉' : '○'}</Text>
+              </Pressable>
+            ))}
+
+            <View style={styles.sideFooter}>
+              <Pressable
+                style={styles.applyButton}
+                onPress={() => {
+                  setFavoritesOnly(draftFavoritesOnly);
+                  setSelectedNeighborhood(draftSelectedNeighborhood);
+                  setIsMenuOpen(false);
+                }}
+              >
+                <Text style={styles.applyText}>Apply Filters</Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
   );
 }
 
@@ -125,4 +197,15 @@ const styles = StyleSheet.create({
   name: { color: '#222', fontSize: 15, fontWeight: '700' },
   neighborhood: { color: '#777', fontSize: 11, marginTop: 2, textTransform: 'uppercase', letterSpacing: 0.8 },
   chevron: { color: '#b0b0b7', fontSize: 24, paddingHorizontal: 4 },
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', alignItems: 'flex-end' },
+  sideMenu: { width: 300, height: '100%', backgroundColor: '#fff', paddingBottom: 24 },
+  sideHeader: { height: 60, textAlign: 'center', textAlignVertical: 'center', paddingTop: 18, fontWeight: '700', fontSize: 18, borderBottomWidth: 1, borderColor: '#e6ecf5', backgroundColor: '#f7f9fc' },
+  sectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 },
+  filterRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 12, paddingHorizontal: 14, borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, marginBottom: 10 },
+  filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
+  filterText: { color: '#222', fontSize: 14 },
+  checkbox: { color: '#8e8e93', fontSize: 18 },
+  sideFooter: { marginTop: 'auto', paddingHorizontal: 16 },
+  applyButton: { backgroundColor: '#007bff', borderRadius: 8, height: 56, alignItems: 'center', justifyContent: 'center' },
+  applyText: { color: '#fff', fontSize: 20, fontWeight: '700' },
 });

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -152,8 +152,10 @@ export default function BarsScreen() {
 
             <Text style={styles.sectionTitle}>Favorites</Text>
             <Pressable style={[styles.filterRow, draftFavoritesOnly ? styles.filterRowSelected : null]} onPress={() => setDraftFavoritesOnly((current) => !current)}>
-              <Text style={styles.iconText}>★</Text>
-              <Text style={styles.filterText}>Favorites only</Text>
+              <View style={styles.filterLabelGroup}>
+                <Text style={styles.iconText}>★</Text>
+                <Text style={styles.filterText}>Favorites only</Text>
+              </View>
               <Text style={styles.checkbox}>{draftFavoritesOnly ? '☑' : '☐'}</Text>
             </Pressable>
 
@@ -232,8 +234,9 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 },
   filterRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 12, paddingHorizontal: 14, borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, marginBottom: 10 },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
+  filterLabelGroup: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   filterText: { color: '#222', fontSize: 14 },
-  iconText: { color: '#8e8e93', fontSize: 16, marginRight: 10 },
+  iconText: { color: '#8e8e93', fontSize: 16 },
   checkbox: { color: '#8e8e93', fontSize: 18 },
   pickerWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, backgroundColor: '#fff', marginBottom: 8 },
   sideFooter: { marginTop: 'auto', paddingHorizontal: 16 },

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
 import { Animated, Easing, Modal, Image, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { fetchStartupPayload, StartupPayload } from '../services/api';
 
@@ -18,7 +19,6 @@ export default function BarsScreen() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isNeighborhoodDropdownOpen, setIsNeighborhoodDropdownOpen] = useState(false);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [selectedNeighborhood, setSelectedNeighborhood] = useState<string>('');
   const [draftFavoritesOnly, setDraftFavoritesOnly] = useState(false);
@@ -58,7 +58,6 @@ export default function BarsScreen() {
   const openMenu = () => {
     setDraftFavoritesOnly(favoritesOnly);
     setDraftSelectedNeighborhood(selectedNeighborhood);
-    setIsNeighborhoodDropdownOpen(false);
     setIsMenuOpen(true);
     Animated.timing(drawerProgress, {
       toValue: 1,
@@ -75,7 +74,6 @@ export default function BarsScreen() {
       easing: Easing.in(Easing.cubic),
       useNativeDriver: true,
     }).start(() => {
-      setIsNeighborhoodDropdownOpen(false);
       setIsMenuOpen(false);
     });
   };
@@ -154,41 +152,20 @@ export default function BarsScreen() {
 
             <Text style={styles.sectionTitle}>Favorites</Text>
             <Pressable style={[styles.filterRow, draftFavoritesOnly ? styles.filterRowSelected : null]} onPress={() => setDraftFavoritesOnly((current) => !current)}>
-              <Text style={styles.filterText}>Favorites only</Text>
               <Text style={styles.iconText}>★</Text>
+              <Text style={styles.filterText}>Favorites only</Text>
               <Text style={styles.checkbox}>{draftFavoritesOnly ? '☑' : '☐'}</Text>
             </Pressable>
 
             <Text style={styles.sectionTitle}>Neighborhood</Text>
-            <Pressable style={styles.dropdownButton} onPress={() => setIsNeighborhoodDropdownOpen((current) => !current)}>
-              <Text style={styles.dropdownText}>{draftSelectedNeighborhood || 'All neighborhoods'}</Text>
-              <Text style={styles.dropdownChevron}>{isNeighborhoodDropdownOpen ? '▴' : '▾'}</Text>
-            </Pressable>
-            {isNeighborhoodDropdownOpen ? (
-              <View style={styles.dropdownMenu}>
-                <Pressable
-                  style={[styles.dropdownOption, draftSelectedNeighborhood === '' ? styles.dropdownOptionSelected : null]}
-                  onPress={() => {
-                    setDraftSelectedNeighborhood('');
-                    setIsNeighborhoodDropdownOpen(false);
-                  }}
-                >
-                  <Text style={styles.filterText}>All neighborhoods</Text>
-                </Pressable>
+            <View style={styles.pickerWrap}>
+              <Picker selectedValue={draftSelectedNeighborhood} onValueChange={(nextValue) => setDraftSelectedNeighborhood(String(nextValue))}>
+                <Picker.Item label="All neighborhoods" value="" />
                 {neighborhoods.map((neighborhood) => (
-                  <Pressable
-                    key={neighborhood}
-                    style={[styles.dropdownOption, draftSelectedNeighborhood === neighborhood ? styles.dropdownOptionSelected : null]}
-                    onPress={() => {
-                      setDraftSelectedNeighborhood(neighborhood);
-                      setIsNeighborhoodDropdownOpen(false);
-                    }}
-                  >
-                    <Text style={styles.filterText}>{neighborhood}</Text>
-                  </Pressable>
+                  <Picker.Item key={neighborhood} label={neighborhood} value={neighborhood} />
                 ))}
-              </View>
-            ) : null}
+              </Picker>
+            </View>
 
             <View style={styles.sideFooter}>
               <Pressable
@@ -258,12 +235,7 @@ const styles = StyleSheet.create({
   filterText: { color: '#222', fontSize: 14 },
   iconText: { color: '#8e8e93', fontSize: 16, marginRight: 10 },
   checkbox: { color: '#8e8e93', fontSize: 18 },
-  dropdownButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, paddingHorizontal: 12, height: 44, backgroundColor: '#fff' },
-  dropdownText: { color: '#222', fontSize: 14 },
-  dropdownChevron: { color: '#8e8e93', fontSize: 14 },
-  dropdownMenu: { marginHorizontal: 16, borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, backgroundColor: '#fff', marginTop: 8, maxHeight: 230 },
-  dropdownOption: { paddingVertical: 10, paddingHorizontal: 12, borderBottomWidth: 1, borderBottomColor: '#ececf1' },
-  dropdownOptionSelected: { backgroundColor: '#e6f0ff' },
+  pickerWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, backgroundColor: '#fff', marginBottom: 8 },
   sideFooter: { marginTop: 'auto', paddingHorizontal: 16 },
   applyButton: { backgroundColor: '#007bff', borderRadius: 8, height: 56, alignItems: 'center', justifyContent: 'center' },
   applyText: { color: '#fff', fontSize: 20, fontWeight: '700' },

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
-import { Modal, Image, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Animated, Easing, Modal, Image, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { fetchStartupPayload, StartupPayload } from '../services/api';
 
@@ -18,10 +18,12 @@ export default function BarsScreen() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isNeighborhoodDropdownOpen, setIsNeighborhoodDropdownOpen] = useState(false);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [selectedNeighborhood, setSelectedNeighborhood] = useState<string>('');
   const [draftFavoritesOnly, setDraftFavoritesOnly] = useState(false);
   const [draftSelectedNeighborhood, setDraftSelectedNeighborhood] = useState<string>('');
+  const drawerProgress = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     (async () => {
@@ -53,17 +55,38 @@ export default function BarsScreen() {
     });
   }, [bars, query, favoritesOnly, selectedNeighborhood]);
 
+  const openMenu = () => {
+    setDraftFavoritesOnly(favoritesOnly);
+    setDraftSelectedNeighborhood(selectedNeighborhood);
+    setIsNeighborhoodDropdownOpen(false);
+    setIsMenuOpen(true);
+    Animated.timing(drawerProgress, {
+      toValue: 1,
+      duration: 230,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const closeMenu = () => {
+    Animated.timing(drawerProgress, {
+      toValue: 0,
+      duration: 190,
+      easing: Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => {
+      setIsNeighborhoodDropdownOpen(false);
+      setIsMenuOpen(false);
+    });
+  };
+
   const toolbar = (
     <View style={styles.toolbar}>
       <View style={styles.toolbarInner}>
         <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
         <Text
           style={styles.hamburgerButton}
-          onPress={() => {
-            setDraftFavoritesOnly(favoritesOnly);
-            setDraftSelectedNeighborhood(selectedNeighborhood);
-            setIsMenuOpen(true);
-          }}
+          onPress={openMenu}
         >
           ☰
         </Text>
@@ -109,9 +132,24 @@ export default function BarsScreen() {
         ) : null}
       </ScreenContainer>
 
-      <Modal visible={isMenuOpen} animationType="slide" transparent onRequestClose={() => setIsMenuOpen(false)}>
-        <Pressable style={styles.overlay} onPress={() => setIsMenuOpen(false)}>
-          <Pressable style={styles.sideMenu} onPress={() => {}}>
+      <Modal visible={isMenuOpen} animationType="none" transparent onRequestClose={closeMenu}>
+        <Animated.View style={[styles.overlay, { opacity: drawerProgress }]}>
+          <Pressable style={styles.overlayTapArea} onPress={closeMenu} />
+          <Animated.View
+            style={[
+              styles.sideMenu,
+              {
+                transform: [
+                  {
+                    translateX: drawerProgress.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [300, 0],
+                    }),
+                  },
+                ],
+              },
+            ]}
+          >
             <Text style={styles.sideHeader}>Filters</Text>
 
             <Text style={styles.sectionTitle}>Bar Options</Text>
@@ -121,23 +159,35 @@ export default function BarsScreen() {
             </Pressable>
 
             <Text style={styles.sectionTitle}>Neighborhood</Text>
-            <Pressable
-              style={[styles.filterRow, draftSelectedNeighborhood === '' ? styles.filterRowSelected : null]}
-              onPress={() => setDraftSelectedNeighborhood('')}
-            >
-              <Text style={styles.filterText}>All neighborhoods</Text>
-              <Text style={styles.checkbox}>{draftSelectedNeighborhood === '' ? '◉' : '○'}</Text>
+            <Pressable style={styles.dropdownButton} onPress={() => setIsNeighborhoodDropdownOpen((current) => !current)}>
+              <Text style={styles.dropdownText}>{draftSelectedNeighborhood || 'All neighborhoods'}</Text>
+              <Text style={styles.dropdownChevron}>{isNeighborhoodDropdownOpen ? '▴' : '▾'}</Text>
             </Pressable>
-            {neighborhoods.map((neighborhood) => (
-              <Pressable
-                key={neighborhood}
-                style={[styles.filterRow, draftSelectedNeighborhood === neighborhood ? styles.filterRowSelected : null]}
-                onPress={() => setDraftSelectedNeighborhood(neighborhood)}
-              >
-                <Text style={styles.filterText}>{neighborhood}</Text>
-                <Text style={styles.checkbox}>{draftSelectedNeighborhood === neighborhood ? '◉' : '○'}</Text>
-              </Pressable>
-            ))}
+            {isNeighborhoodDropdownOpen ? (
+              <View style={styles.dropdownMenu}>
+                <Pressable
+                  style={[styles.dropdownOption, draftSelectedNeighborhood === '' ? styles.dropdownOptionSelected : null]}
+                  onPress={() => {
+                    setDraftSelectedNeighborhood('');
+                    setIsNeighborhoodDropdownOpen(false);
+                  }}
+                >
+                  <Text style={styles.filterText}>All neighborhoods</Text>
+                </Pressable>
+                {neighborhoods.map((neighborhood) => (
+                  <Pressable
+                    key={neighborhood}
+                    style={[styles.dropdownOption, draftSelectedNeighborhood === neighborhood ? styles.dropdownOptionSelected : null]}
+                    onPress={() => {
+                      setDraftSelectedNeighborhood(neighborhood);
+                      setIsNeighborhoodDropdownOpen(false);
+                    }}
+                  >
+                    <Text style={styles.filterText}>{neighborhood}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            ) : null}
 
             <View style={styles.sideFooter}>
               <Pressable
@@ -145,14 +195,14 @@ export default function BarsScreen() {
                 onPress={() => {
                   setFavoritesOnly(draftFavoritesOnly);
                   setSelectedNeighborhood(draftSelectedNeighborhood);
-                  setIsMenuOpen(false);
+                  closeMenu();
                 }}
               >
                 <Text style={styles.applyText}>Apply Filters</Text>
               </Pressable>
             </View>
-          </Pressable>
-        </Pressable>
+          </Animated.View>
+        </Animated.View>
       </Modal>
     </>
   );
@@ -197,7 +247,8 @@ const styles = StyleSheet.create({
   name: { color: '#222', fontSize: 15, fontWeight: '700' },
   neighborhood: { color: '#777', fontSize: 11, marginTop: 2, textTransform: 'uppercase', letterSpacing: 0.8 },
   chevron: { color: '#b0b0b7', fontSize: 24, paddingHorizontal: 4 },
-  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', alignItems: 'flex-end' },
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', flexDirection: 'row' },
+  overlayTapArea: { flex: 1 },
   sideMenu: { width: 300, height: '100%', backgroundColor: '#fff', paddingBottom: 24 },
   sideHeader: { height: 60, textAlign: 'center', textAlignVertical: 'center', paddingTop: 18, fontWeight: '700', fontSize: 18, borderBottomWidth: 1, borderColor: '#e6ecf5', backgroundColor: '#f7f9fc' },
   sectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 },
@@ -205,6 +256,12 @@ const styles = StyleSheet.create({
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterText: { color: '#222', fontSize: 14 },
   checkbox: { color: '#8e8e93', fontSize: 18 },
+  dropdownButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, paddingHorizontal: 12, height: 44, backgroundColor: '#fff' },
+  dropdownText: { color: '#222', fontSize: 14 },
+  dropdownChevron: { color: '#8e8e93', fontSize: 14 },
+  dropdownMenu: { marginHorizontal: 16, borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, backgroundColor: '#fff', marginTop: 8, maxHeight: 230 },
+  dropdownOption: { paddingVertical: 10, paddingHorizontal: 12, borderBottomWidth: 1, borderBottomColor: '#ececf1' },
+  dropdownOptionSelected: { backgroundColor: '#e6f0ff' },
   sideFooter: { marginTop: 'auto', paddingHorizontal: 16 },
   applyButton: { backgroundColor: '#007bff', borderRadius: 8, height: 56, alignItems: 'center', justifyContent: 'center' },
   applyText: { color: '#fff', fontSize: 20, fontWeight: '700' },

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -158,7 +158,7 @@ export default function BarsScreen() {
               <View style={styles.filterLabelGroup}>
                 <Text style={styles.filterText}>Favorites only</Text>
               </View>
-              <Text style={styles.iconText}>★</Text>
+              <Text style={styles.iconText}>☆</Text>
             </Pressable>
 
             <Text style={styles.sectionTitle}>Neighborhood</Text>

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -56,6 +56,7 @@ export default function BarsScreen() {
   }, [bars, query, favoritesOnly, selectedNeighborhood]);
 
   const openMenu = () => {
+    drawerProgress.stopAnimation();
     setDraftFavoritesOnly(favoritesOnly);
     setDraftSelectedNeighborhood(selectedNeighborhood);
     setIsMenuOpen(true);
@@ -68,12 +69,14 @@ export default function BarsScreen() {
   };
 
   const closeMenu = () => {
+    drawerProgress.stopAnimation();
     Animated.timing(drawerProgress, {
       toValue: 0,
       duration: 190,
       easing: Easing.in(Easing.cubic),
       useNativeDriver: true,
-    }).start(() => {
+    }).start(({ finished }) => {
+      if (!finished) return;
       setIsMenuOpen(false);
     });
   };

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -156,10 +156,9 @@ export default function BarsScreen() {
             <Text style={styles.sectionTitle}>Favorites</Text>
             <Pressable style={[styles.filterRow, draftFavoritesOnly ? styles.filterRowSelected : null]} onPress={() => setDraftFavoritesOnly((current) => !current)}>
               <View style={styles.filterLabelGroup}>
-                <Text style={styles.iconText}>★</Text>
                 <Text style={styles.filterText}>Favorites only</Text>
               </View>
-              <Text style={styles.checkbox}>{draftFavoritesOnly ? '☑' : '☐'}</Text>
+              <Text style={styles.iconText}>★</Text>
             </Pressable>
 
             <Text style={styles.sectionTitle}>Neighborhood</Text>
@@ -240,8 +239,7 @@ const styles = StyleSheet.create({
   filterLabelGroup: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   filterText: { color: '#222', fontSize: 14 },
   iconText: { color: '#8e8e93', fontSize: 16 },
-  checkbox: { color: '#8e8e93', fontSize: 18 },
-  pickerWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, backgroundColor: '#fff', marginBottom: 8 },
+  pickerWrap: { marginHorizontal: 16, backgroundColor: '#fff', marginBottom: 8 },
   sideFooter: { marginTop: 'auto', paddingHorizontal: 16 },
   applyButton: { backgroundColor: '#007bff', borderRadius: 8, height: 56, alignItems: 'center', justifyContent: 'center' },
   applyText: { color: '#fff', fontSize: 20, fontWeight: '700' },

--- a/mobile/app/bars.tsx
+++ b/mobile/app/bars.tsx
@@ -152,9 +152,10 @@ export default function BarsScreen() {
           >
             <Text style={styles.sideHeader}>Filters</Text>
 
-            <Text style={styles.sectionTitle}>Bar Options</Text>
+            <Text style={styles.sectionTitle}>Favorites</Text>
             <Pressable style={[styles.filterRow, draftFavoritesOnly ? styles.filterRowSelected : null]} onPress={() => setDraftFavoritesOnly((current) => !current)}>
               <Text style={styles.filterText}>Favorites only</Text>
+              <Text style={styles.iconText}>★</Text>
               <Text style={styles.checkbox}>{draftFavoritesOnly ? '☑' : '☐'}</Text>
             </Pressable>
 
@@ -255,6 +256,7 @@ const styles = StyleSheet.create({
   filterRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingVertical: 12, paddingHorizontal: 14, borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, marginBottom: 10 },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterText: { color: '#222', fontSize: 14 },
+  iconText: { color: '#8e8e93', fontSize: 16, marginRight: 10 },
   checkbox: { color: '#8e8e93', fontSize: 18 },
   dropdownButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, marginHorizontal: 16, paddingHorizontal: 12, height: 44, backgroundColor: '#fff' },
   dropdownText: { color: '#222', fontSize: 14 },

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-picker/picker": "^2.11.1",
         "@react-navigation/bottom-tabs": "^7.4.2",
         "@react-navigation/native": "^7.1.17",
         "@types/react": "~19.0.10",
@@ -2326,6 +2327,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.4.tgz",
+      "integrity": "sha512-Kf8h1AMnBo54b1fdiVylP2P/iFcZqzpMYcglC28EEFB1DEnOjsNr6Ucqc+3R9e91vHxEDnhZFbYDmAe79P2gjA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -16,6 +16,7 @@
     "@expo/vector-icons": "^14.1.0",
     "@react-navigation/bottom-tabs": "^7.4.2",
     "@react-navigation/native": "^7.1.17",
+    "@react-native-picker/picker": "^2.11.1",
     "@types/react": "~19.0.10",
     "expo": "~53.0.12",
     "expo-asset": "~11.1.7",


### PR DESCRIPTION
### Motivation

- Provide in-app filtering for the Bars list so users can restrict results to favorites or by neighborhood.
- Surface a compact, persistent UI for filters via a slide-in side menu accessed from the toolbar.
- Keep filter changes draftable so users can preview/select options before applying them to the list.

### Description

- Added a modal side menu implemented with `Modal` and `Pressable` that slides in from the right and is opened from the toolbar hamburger button. 
- Introduced filter state with draft values: `favoritesOnly`, `selectedNeighborhood`, `draftFavoritesOnly`, and `draftSelectedNeighborhood`, and compute `neighborhoods` from `payload` bars for the neighborhood list. 
- Updated the bars filter logic (`filteredBars`) to respect `favoritesOnly` and `selectedNeighborhood` alongside the search `query`. 
- Wrapped the existing `ScreenContainer` in a fragment to render the `Modal`, added UI rows for toggling favorites and selecting neighborhood, and applied selected drafts when the user taps `Apply Filters`.
- Added multiple style entries for the overlay, side menu, filter rows, and apply button to match the new UI.

### Testing

- No unit tests were added as part of this change. 
- Performed project type checking with `yarn tsc` which completed successfully. 
- Performed a local app build/run smoke check (Metro bundler) to verify the new modal and filter interactions render and behave as expected, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06347b217c83309924cad9f9687919)