### PR TITLE
Mobile: Add Specials side-menu filters (types, neighborhoods, favorites)

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -155,6 +155,7 @@ export default function SpecialsScreen() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [selectedTypesDraft, setSelectedTypesDraft] = useState<string[]>([]);
   const [selectedNeighborhoodDraft, setSelectedNeighborhoodDraft] = useState<string>('');
+  const [neighborhoodDropdownOpen, setNeighborhoodDropdownOpen] = useState(false);
   const [selectedTypesApplied, setSelectedTypesApplied] = useState<string[]>([]);
   const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
   const contentOpacity = useRef(new Animated.Value(0)).current;
@@ -220,12 +221,14 @@ export default function SpecialsScreen() {
   function closeMenuDiscardDraft() {
     setSelectedTypesDraft(selectedTypesApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
+    setNeighborhoodDropdownOpen(false);
     setMenuOpen(false);
   }
 
   function openMenuWithAppliedDrafts() {
     setSelectedTypesDraft(selectedTypesApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
+    setNeighborhoodDropdownOpen(false);
     setMenuOpen(true);
   }
 
@@ -264,10 +267,26 @@ export default function SpecialsScreen() {
 
             <Text style={styles.filterSectionTitle}>Neighborhood</Text>
             <View style={styles.dropdownWrap}>
-              <Text style={styles.dropdownOption} onPress={() => setSelectedNeighborhoodDraft('')}>📍 All neighborhoods</Text>
-              {neighborhoods.map((neighborhood) => (
-                <Text key={neighborhood} style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]} onPress={() => setSelectedNeighborhoodDraft(neighborhood)}>📍 {neighborhood}</Text>
-              ))}
+              <Pressable style={styles.dropdownTrigger} onPress={() => setNeighborhoodDropdownOpen((open) => !open)}>
+                <Text style={styles.dropdownTriggerText}>
+                  {selectedNeighborhoodDraft ? `📍 ${selectedNeighborhoodDraft}` : '📍 All neighborhoods'}
+                </Text>
+                <Ionicons name={neighborhoodDropdownOpen ? 'chevron-up' : 'chevron-down'} size={16} color="#6b7280" />
+              </Pressable>
+              {neighborhoodDropdownOpen ? (
+                <View>
+                  <Text style={[styles.dropdownOption, !selectedNeighborhoodDraft ? styles.dropdownOptionSelected : null]} onPress={() => { setSelectedNeighborhoodDraft(''); setNeighborhoodDropdownOpen(false); }}>📍 All neighborhoods</Text>
+                  {neighborhoods.map((neighborhood) => (
+                    <Text
+                      key={neighborhood}
+                      style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]}
+                      onPress={() => { setSelectedNeighborhoodDraft(neighborhood); setNeighborhoodDropdownOpen(false); }}
+                    >
+                      📍 {neighborhood}
+                    </Text>
+                  ))}
+                </View>
+              ) : null}
             </View>
 
             <View style={styles.sideMenuFooter}>
@@ -413,6 +432,8 @@ const styles = StyleSheet.create({
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
   dropdownWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, overflow: 'hidden' },
+  dropdownTrigger: { paddingHorizontal: 12, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', backgroundColor: '#fff' },
+  dropdownTriggerText: { color: '#111827', fontSize: 14 },
   dropdownOption: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: '#eef2f7', color: '#111827' },
   dropdownOptionSelected: { backgroundColor: '#e6f0ff' },
   sideMenuFooter: { marginTop: 10, gap: 12 },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -217,6 +217,18 @@ export default function SpecialsScreen() {
     setMenuOpen(false);
   }
 
+  function closeMenuDiscardDraft() {
+    setSelectedTypesDraft(selectedTypesApplied);
+    setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
+    setMenuOpen(false);
+  }
+
+  function openMenuWithAppliedDrafts() {
+    setSelectedTypesDraft(selectedTypesApplied);
+    setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
+    setMenuOpen(true);
+  }
+
 
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
@@ -230,15 +242,15 @@ export default function SpecialsScreen() {
     <View style={styles.toolbar}>
       <View style={styles.toolbarInner}>
         <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
-        <Text style={styles.hamburgerButton} onPress={() => setMenuOpen(true)}>☰</Text>
+        <Text style={styles.hamburgerButton} onPress={openMenuWithAppliedDrafts}>☰</Text>
       </View>
     </View>
   );
 
   return (
     <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
-      <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={() => setMenuOpen(false)}>
-        <Pressable style={styles.sideMenuOverlay} onPress={() => setMenuOpen(false)} />
+      <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={closeMenuDiscardDraft}>
+        <Pressable style={styles.sideMenuOverlay} onPress={closeMenuDiscardDraft} />
         <View style={styles.sideMenu}>
           <Text style={styles.sideMenuHeader}>Filters</Text>
           <View style={styles.sideMenuContent}>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -163,6 +163,7 @@ export default function SpecialsScreen() {
   const [favoritesOnlyApplied, setFavoritesOnlyApplied] = useState(false);
   const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
   const sideMenuTranslateX = useRef(new Animated.Value(300)).current;
+  const [menuVisible, setMenuVisible] = useState(false);
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
 
@@ -221,20 +222,37 @@ export default function SpecialsScreen() {
     setSelectedTypesApplied(selectedTypesDraft);
     setFavoritesOnlyApplied(favoritesOnlyDraft);
     setSelectedNeighborhoodApplied(selectedNeighborhoodDraft);
-    setMenuOpen(false);
+    Animated.timing(sideMenuTranslateX, {
+      toValue: 300,
+      duration: 220,
+      easing: Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => {
+      setMenuOpen(false);
+      setMenuVisible(false);
+    });
   }
 
   function closeMenuDiscardDraft() {
     setSelectedTypesDraft(selectedTypesApplied);
     setFavoritesOnlyDraft(favoritesOnlyApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
-    setMenuOpen(false);
+    Animated.timing(sideMenuTranslateX, {
+      toValue: 300,
+      duration: 220,
+      easing: Easing.in(Easing.cubic),
+      useNativeDriver: true,
+    }).start(() => {
+      setMenuOpen(false);
+      setMenuVisible(false);
+    });
   }
 
   function openMenuWithAppliedDrafts() {
     setSelectedTypesDraft(selectedTypesApplied);
     setFavoritesOnlyDraft(favoritesOnlyApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
+    setMenuVisible(true);
     setMenuOpen(true);
   }
   useEffect(() => {
@@ -268,7 +286,7 @@ export default function SpecialsScreen() {
 
   return (
     <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
-      <Modal visible={menuOpen} transparent animationType="none" onRequestClose={closeMenuDiscardDraft}>
+      <Modal visible={menuVisible} transparent animationType="none" onRequestClose={closeMenuDiscardDraft}>
         <Pressable style={styles.sideMenuOverlay} onPress={closeMenuDiscardDraft} />
         <Animated.View style={[styles.sideMenu, { transform: [{ translateX: sideMenuTranslateX }] }]}>
           <Text style={styles.sideMenuHeader}>Filters</Text>
@@ -282,8 +300,8 @@ export default function SpecialsScreen() {
             ))}
             <Text style={styles.filterSectionTitle}>Favorites</Text>
             <Pressable style={[styles.filterRow, styles.filterRowCompact, favoritesOnlyDraft ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnlyDraft((v) => !v)}>
-              <Ionicons name="star-outline" size={18} color="#8e8e93" />
               <Text style={styles.filterLabelCompact}>Favorites only</Text>
+              <Ionicons name="star-outline" size={18} color="#8e8e93" />
             </Pressable>
 
             <Text style={styles.filterSectionTitle}>Neighborhood</Text>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -49,9 +49,11 @@ function groupSpecialsForUI(specials: SpecialItem[]) {
     const hasLive = group.some((s) => s.current_status === 'live' || s.current_status === 'active');
     const hasUpcoming = group.some((s) => s.current_status === 'upcoming');
     const hasPast = group.some((s) => s.current_status === 'past');
+    const hasFavorite = group.some((s) => s.favorite === true);
     if (hasLive) base.current_status = 'live';
     else if (hasUpcoming) base.current_status = 'upcoming';
     else if (hasPast) base.current_status = 'past';
+    if (hasFavorite) base.favorite = true;
     return base;
   });
 }

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -155,9 +155,12 @@ export default function SpecialsScreen() {
   const [showContent, setShowContent] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [selectedTypesDraft, setSelectedTypesDraft] = useState<string[]>([]);
+  const [favoritesOnlyDraft, setFavoritesOnlyDraft] = useState(false);
   const [selectedNeighborhoodDraft, setSelectedNeighborhoodDraft] = useState<string>('');
   const [selectedTypesApplied, setSelectedTypesApplied] = useState<string[]>([]);
+  const [favoritesOnlyApplied, setFavoritesOnlyApplied] = useState(false);
   const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
+  const sideMenuTranslateX = useRef(new Animated.Value(300)).current;
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
 
@@ -214,21 +217,34 @@ export default function SpecialsScreen() {
 
   function applyFilters() {
     setSelectedTypesApplied(selectedTypesDraft);
+    setFavoritesOnlyApplied(favoritesOnlyDraft);
     setSelectedNeighborhoodApplied(selectedNeighborhoodDraft);
     setMenuOpen(false);
   }
 
   function closeMenuDiscardDraft() {
     setSelectedTypesDraft(selectedTypesApplied);
+    setFavoritesOnlyDraft(favoritesOnlyApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
     setMenuOpen(false);
   }
 
   function openMenuWithAppliedDrafts() {
     setSelectedTypesDraft(selectedTypesApplied);
+    setFavoritesOnlyDraft(favoritesOnlyApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
     setMenuOpen(true);
   }
+  useEffect(() => {
+    if (!menuOpen) return;
+    sideMenuTranslateX.setValue(300);
+    Animated.timing(sideMenuTranslateX, {
+      toValue: 0,
+      duration: 240,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [menuOpen, sideMenuTranslateX]);
 
 
   useEffect(() => {
@@ -250,9 +266,9 @@ export default function SpecialsScreen() {
 
   return (
     <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
-      <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={closeMenuDiscardDraft}>
+      <Modal visible={menuOpen} transparent animationType="none" onRequestClose={closeMenuDiscardDraft}>
         <Pressable style={styles.sideMenuOverlay} onPress={closeMenuDiscardDraft} />
-        <View style={styles.sideMenu}>
+        <Animated.View style={[styles.sideMenu, { transform: [{ translateX: sideMenuTranslateX }] }]}>
           <Text style={styles.sideMenuHeader}>Filters</Text>
           <View style={styles.sideMenuContent}>
             <Text style={styles.filterSectionTitle}>Special Type</Text>
@@ -262,18 +278,23 @@ export default function SpecialsScreen() {
                 <Ionicons name={type === 'drink' ? 'wine-outline' : 'restaurant-outline'} size={18} color="#8e8e93" />
               </Pressable>
             ))}
+            <Text style={styles.filterSectionTitle}>Favorites</Text>
+            <Pressable style={[styles.filterRow, styles.filterRowCompact, favoritesOnlyDraft ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnlyDraft((v) => !v)}>
+              <Ionicons name="star-outline" size={18} color="#8e8e93" />
+              <Text style={styles.filterLabelCompact}>Favorites only</Text>
+            </Pressable>
 
             <Text style={styles.filterSectionTitle}>Neighborhood</Text>
             <View style={styles.dropdownWrap}>
               <Picker
                 selectedValue={selectedNeighborhoodDraft}
-                onValueChange={(value) => setSelectedNeighborhoodDraft(String(value || ''))}
+                onValueChange={(value: string | number) => setSelectedNeighborhoodDraft(String(value || ''))}
                 mode="dropdown"
                 style={styles.nativePicker}
               >
-                <Picker.Item label="📍 All neighborhoods" value="" />
+                <Picker.Item label="All neighborhoods" value="" />
                 {neighborhoods.map((neighborhood) => (
-                  <Picker.Item key={neighborhood} label={`📍 ${neighborhood}`} value={neighborhood} />
+                  <Picker.Item key={neighborhood} label={neighborhood} value={neighborhood} />
                 ))}
               </Picker>
             </View>
@@ -285,7 +306,7 @@ export default function SpecialsScreen() {
               </Pressable>
             </View>
           </View>
-        </View>
+        </Animated.View>
       </Modal>
       {showSkeleton ? <Animated.View style={{ opacity: skeletonOpacity }}><LoadingSkeleton /></Animated.View> : null}
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
@@ -303,9 +324,12 @@ export default function SpecialsScreen() {
                     if (!bar) return null;
                     if (selectedNeighborhoodApplied && selectedNeighborhoodApplied !== bar.neighborhood) return null;
                     const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
+                    const isBarFavorite = bar.favorite === true;
                                         const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
                     const filteredSpecials = specials.filter((special) => {
-                      return specialMatchesTypeFilters(special.special_type || special.type, selectedTypesApplied);
+                      const matchesType = specialMatchesTypeFilters(special.special_type || special.type, selectedTypesApplied);
+                      const matchesFavorite = !favoritesOnlyApplied || special.favorite === true || isBarFavorite;
+                      return matchesType && matchesFavorite;
                     });
                     if (filteredSpecials.length === 0) return null;
 
@@ -418,8 +442,10 @@ const styles = StyleSheet.create({
   sideMenuContent: { padding: 16, gap: 10 },
   filterSectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, marginTop: 8 },
   filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  filterRowCompact: { justifyContent: 'flex-start', gap: 8 },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
+  filterLabelCompact: { color: '#111827' },
   dropdownWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, overflow: 'hidden' },
   nativePicker: { backgroundColor: '#fff', color: '#111827' },
   sideMenuFooter: { marginTop: 10, gap: 12 },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -299,7 +299,7 @@ export default function SpecialsScreen() {
               </Pressable>
             ))}
             <Text style={styles.filterSectionTitle}>Favorites</Text>
-            <Pressable style={[styles.filterRow, styles.filterRowCompact, favoritesOnlyDraft ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnlyDraft((v) => !v)}>
+            <Pressable style={[styles.filterRow, favoritesOnlyDraft ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnlyDraft((v) => !v)}>
               <Text style={styles.filterLabelCompact}>Favorites only</Text>
               <Ionicons name="star-outline" size={18} color="#8e8e93" />
             </Pressable>
@@ -462,7 +462,6 @@ const styles = StyleSheet.create({
   sideMenuContent: { padding: 16, gap: 10 },
   filterSectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, marginTop: 8 },
   filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  filterRowCompact: { justifyContent: 'flex-start', gap: 8 },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
   filterLabelCompact: { color: '#111827' },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -142,9 +142,10 @@ export default function SpecialsScreen() {
   const [showSkeleton, setShowSkeleton] = useState(true);
   const [showContent, setShowContent] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [favoritesOnly, setFavoritesOnly] = useState(false);
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
-  const [selectedNeighborhoods, setSelectedNeighborhoods] = useState<string[]>([]);
+  const [selectedTypesDraft, setSelectedTypesDraft] = useState<string[]>([]);
+  const [selectedNeighborhoodDraft, setSelectedNeighborhoodDraft] = useState<string>('');
+  const [selectedTypesApplied, setSelectedTypesApplied] = useState<string[]>([]);
+  const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
 
@@ -199,6 +200,12 @@ export default function SpecialsScreen() {
     return current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
   }
 
+  function applyFilters() {
+    setSelectedTypesApplied(selectedTypesDraft);
+    setSelectedNeighborhoodApplied(selectedNeighborhoodDraft);
+    setMenuOpen(false);
+  }
+
 
   useEffect(() => {
     if (!showContent || dividerY === null || hasScrolledToDivider.current) return;
@@ -224,24 +231,27 @@ export default function SpecialsScreen() {
         <View style={styles.sideMenu}>
           <Text style={styles.sideMenuHeader}>Filters</Text>
           <View style={styles.sideMenuContent}>
-            <Text style={styles.filterSectionTitle}>Special Types</Text>
-            {['food', 'drink', 'combo'].map((type) => (
-              <Pressable key={type} style={[styles.filterRow, selectedTypes.includes(type) ? styles.filterRowSelected : null]} onPress={() => setSelectedTypes((prev) => toggleSelection(prev, type))}>
+            <Text style={styles.filterSectionTitle}>Special Type</Text>
+            {['drink', 'food'].map((type) => (
+              <Pressable key={type} style={[styles.filterRow, selectedTypesDraft.includes(type) ? styles.filterRowSelected : null]} onPress={() => setSelectedTypesDraft((prev) => toggleSelection(prev, type))}>
                 <Text style={styles.filterLabel}>{type.toUpperCase()}</Text>
               </Pressable>
             ))}
 
-            <Text style={styles.filterSectionTitle}>Neighborhoods</Text>
-            {neighborhoods.map((neighborhood) => (
-              <Pressable key={neighborhood} style={[styles.filterRow, selectedNeighborhoods.includes(neighborhood) ? styles.filterRowSelected : null]} onPress={() => setSelectedNeighborhoods((prev) => toggleSelection(prev, neighborhood))}>
-                <Text style={styles.filterLabel}>{neighborhood}</Text>
-              </Pressable>
-            ))}
+            <Text style={styles.filterSectionTitle}>Neighborhood</Text>
+            <View style={styles.dropdownWrap}>
+              <Text style={styles.dropdownOption} onPress={() => setSelectedNeighborhoodDraft('')}>All neighborhoods</Text>
+              {neighborhoods.map((neighborhood) => (
+                <Text key={neighborhood} style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]} onPress={() => setSelectedNeighborhoodDraft(neighborhood)}>{neighborhood}</Text>
+              ))}
+            </View>
 
-            <Text style={styles.filterSectionTitle}>Favorites</Text>
-            <Pressable style={[styles.filterRow, favoritesOnly ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnly((v) => !v)}>
-              <Text style={styles.filterLabel}>Only favorites</Text>
-            </Pressable>
+            <View style={styles.sideMenuFooter}>
+              <View style={styles.menuDivider} />
+              <Pressable style={styles.applyFiltersButton} onPress={applyFilters}>
+                <Text style={styles.applyFiltersButtonText}>Apply Filters</Text>
+              </Pressable>
+            </View>
           </View>
         </View>
       </Modal>
@@ -259,15 +269,13 @@ export default function SpecialsScreen() {
                   const cards = entries.map((entry) => {
                     const bar = payload?.bars?.[String(entry.bar_id)];
                     if (!bar) return null;
-                    if (selectedNeighborhoods.length > 0 && !selectedNeighborhoods.includes(bar.neighborhood)) return null;
+                    if (selectedNeighborhoodApplied && selectedNeighborhoodApplied !== bar.neighborhood) return null;
                     const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
-                    const isBarFavorite = bar.favorite === true;
-                    const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
+                                        const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
                     const filteredSpecials = specials.filter((special) => {
                       const specialType = String(special.special_type || special.type || '').toLowerCase();
-                      const matchesType = selectedTypes.length === 0 || selectedTypes.includes(specialType);
-                      const matchesFavorite = !favoritesOnly || isBarFavorite;
-                      return matchesType && matchesFavorite;
+                      const matchesType = selectedTypesApplied.length === 0 || selectedTypesApplied.includes(specialType);
+                      return matchesType;
                     });
                     if (filteredSpecials.length === 0) return null;
 
@@ -382,4 +390,11 @@ const styles = StyleSheet.create({
   filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12 },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
+  dropdownWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, overflow: 'hidden' },
+  dropdownOption: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: '#eef2f7', color: '#111827' },
+  dropdownOptionSelected: { backgroundColor: '#e6f0ff' },
+  sideMenuFooter: { marginTop: 10, gap: 12 },
+  menuDivider: { height: 1, backgroundColor: '#ccc' },
+  applyFiltersButton: { backgroundColor: '#007bff', borderRadius: 8, height: 52, alignItems: 'center', justifyContent: 'center' },
+  applyFiltersButtonText: { color: '#fff', fontWeight: '700', fontSize: 20 },
 });

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
-import { Animated, Easing, Image, StyleSheet, Text, View } from 'react-native';
+import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { theme } from '../constants/theme';
 import { fetchStartupPayload, StartupPayload } from '../services/api';
@@ -141,6 +141,10 @@ export default function SpecialsScreen() {
   const hasScrolledToDivider = useRef(false);
   const [showSkeleton, setShowSkeleton] = useState(true);
   const [showContent, setShowContent] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const [selectedNeighborhoods, setSelectedNeighborhoods] = useState<string[]>([]);
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
 
@@ -186,6 +190,14 @@ export default function SpecialsScreen() {
   }, [loading, contentOpacity, skeletonOpacity]);
 
   const weekDays = useMemo(() => orderedDayKeys(payload?.general_data?.current_day), [payload?.general_data?.current_day]);
+  const neighborhoods = useMemo(() => {
+    const all = Object.values(payload?.bars || {}).map((b) => b.neighborhood).filter(Boolean);
+    return Array.from(new Set(all)).sort((a, b) => a.localeCompare(b));
+  }, [payload?.bars]);
+
+  function toggleSelection(current: string[], value: string) {
+    return current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
+  }
 
 
   useEffect(() => {
@@ -200,13 +212,39 @@ export default function SpecialsScreen() {
     <View style={styles.toolbar}>
       <View style={styles.toolbarInner}>
         <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
-        <Text style={styles.hamburgerButton}>☰</Text>
+        <Text style={styles.hamburgerButton} onPress={() => setMenuOpen(true)}>☰</Text>
       </View>
     </View>
   );
 
   return (
     <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
+      <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={() => setMenuOpen(false)}>
+        <Pressable style={styles.sideMenuOverlay} onPress={() => setMenuOpen(false)} />
+        <View style={styles.sideMenu}>
+          <Text style={styles.sideMenuHeader}>Filters</Text>
+          <View style={styles.sideMenuContent}>
+            <Text style={styles.filterSectionTitle}>Special Types</Text>
+            {['food', 'drink', 'combo'].map((type) => (
+              <Pressable key={type} style={[styles.filterRow, selectedTypes.includes(type) ? styles.filterRowSelected : null]} onPress={() => setSelectedTypes((prev) => toggleSelection(prev, type))}>
+                <Text style={styles.filterLabel}>{type.toUpperCase()}</Text>
+              </Pressable>
+            ))}
+
+            <Text style={styles.filterSectionTitle}>Neighborhoods</Text>
+            {neighborhoods.map((neighborhood) => (
+              <Pressable key={neighborhood} style={[styles.filterRow, selectedNeighborhoods.includes(neighborhood) ? styles.filterRowSelected : null]} onPress={() => setSelectedNeighborhoods((prev) => toggleSelection(prev, neighborhood))}>
+                <Text style={styles.filterLabel}>{neighborhood}</Text>
+              </Pressable>
+            ))}
+
+            <Text style={styles.filterSectionTitle}>Favorites</Text>
+            <Pressable style={[styles.filterRow, favoritesOnly ? styles.filterRowSelected : null]} onPress={() => setFavoritesOnly((v) => !v)}>
+              <Text style={styles.filterLabel}>Only favorites</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
       {showSkeleton ? <Animated.View style={{ opacity: skeletonOpacity }}><LoadingSkeleton /></Animated.View> : null}
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
       {!loading && !error && showContent ? (
@@ -221,14 +259,22 @@ export default function SpecialsScreen() {
                   const cards = entries.map((entry) => {
                     const bar = payload?.bars?.[String(entry.bar_id)];
                     if (!bar) return null;
+                    if (selectedNeighborhoods.length > 0 && !selectedNeighborhoods.includes(bar.neighborhood)) return null;
                     const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
+                    const isBarFavorite = bar.favorite === true;
                     const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
-                    if (specials.length === 0) return null;
+                    const filteredSpecials = specials.filter((special) => {
+                      const specialType = String(special.special_type || special.type || '').toLowerCase();
+                      const matchesType = selectedTypes.length === 0 || selectedTypes.includes(specialType);
+                      const matchesFavorite = !favoritesOnly || isBarFavorite;
+                      return matchesType && matchesFavorite;
+                    });
+                    if (filteredSpecials.length === 0) return null;
 
                     const hourMeta = payload?.open_hours?.[String(entry.bar_id)]?.[dayKey];
                     const isToday = dayKey === payload?.general_data?.current_day;
                     const isOpen = bar.is_open_now;
-                    const hasActiveOrUpcoming = specials.some((special) => ['active', 'live', 'upcoming'].includes(String(special.current_status || '').toLowerCase()));
+                    const hasActiveOrUpcoming = filteredSpecials.some((special) => ['active', 'live', 'upcoming'].includes(String(special.current_status || '').toLowerCase()));
 
                     return {
                       key: `${dayKey}-${entry.bar_id}`,
@@ -239,7 +285,7 @@ export default function SpecialsScreen() {
                           <View style={styles.cardContent}>
                             <View style={styles.headingRow}><Text style={styles.barName}>{bar.name}</Text><Text style={styles.neighborhood}>{bar.neighborhood}</Text></View>
                             <View style={styles.specialsList}>
-                              {specials.map((special, index) => {
+                              {filteredSpecials.map((special, index) => {
                                 const status = (special.current_status ?? '').toLowerCase();
                                 const isLive = status === 'active' || status === 'live';
                                 return (
@@ -328,4 +374,12 @@ const styles = StyleSheet.create({
   activeUpcomingDivider: { marginTop: 12, marginBottom: 12, flexDirection: 'row', alignItems: 'center', gap: 10 },
   dividerLine: { flex: 1, height: 1, backgroundColor: '#d1d5db' },
   dividerLabel: { color: '#6b7280', fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.4 },
+  sideMenuOverlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sideMenu: { marginLeft: 'auto', width: 300, height: '100%', backgroundColor: '#fff', paddingBottom: 70 },
+  sideMenuHeader: { height: 60, textAlign: 'center', textAlignVertical: 'center', fontWeight: '700', fontSize: 18, borderBottomWidth: 1, borderBottomColor: '#e6ecf5', backgroundColor: '#f7f9fc', paddingTop: 18 },
+  sideMenuContent: { padding: 16, gap: 10 },
+  filterSectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, marginTop: 8 },
+  filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12 },
+  filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
+  filterLabel: { color: '#111827' },
 });

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
+import { Picker } from '@react-native-picker/picker';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
 import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
@@ -155,7 +156,6 @@ export default function SpecialsScreen() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [selectedTypesDraft, setSelectedTypesDraft] = useState<string[]>([]);
   const [selectedNeighborhoodDraft, setSelectedNeighborhoodDraft] = useState<string>('');
-  const [neighborhoodDropdownOpen, setNeighborhoodDropdownOpen] = useState(false);
   const [selectedTypesApplied, setSelectedTypesApplied] = useState<string[]>([]);
   const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
   const contentOpacity = useRef(new Animated.Value(0)).current;
@@ -221,14 +221,12 @@ export default function SpecialsScreen() {
   function closeMenuDiscardDraft() {
     setSelectedTypesDraft(selectedTypesApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
-    setNeighborhoodDropdownOpen(false);
     setMenuOpen(false);
   }
 
   function openMenuWithAppliedDrafts() {
     setSelectedTypesDraft(selectedTypesApplied);
     setSelectedNeighborhoodDraft(selectedNeighborhoodApplied);
-    setNeighborhoodDropdownOpen(false);
     setMenuOpen(true);
   }
 
@@ -267,26 +265,17 @@ export default function SpecialsScreen() {
 
             <Text style={styles.filterSectionTitle}>Neighborhood</Text>
             <View style={styles.dropdownWrap}>
-              <Pressable style={styles.dropdownTrigger} onPress={() => setNeighborhoodDropdownOpen((open) => !open)}>
-                <Text style={styles.dropdownTriggerText}>
-                  {selectedNeighborhoodDraft ? `📍 ${selectedNeighborhoodDraft}` : '📍 All neighborhoods'}
-                </Text>
-                <Ionicons name={neighborhoodDropdownOpen ? 'chevron-up' : 'chevron-down'} size={16} color="#6b7280" />
-              </Pressable>
-              {neighborhoodDropdownOpen ? (
-                <View>
-                  <Text style={[styles.dropdownOption, !selectedNeighborhoodDraft ? styles.dropdownOptionSelected : null]} onPress={() => { setSelectedNeighborhoodDraft(''); setNeighborhoodDropdownOpen(false); }}>📍 All neighborhoods</Text>
-                  {neighborhoods.map((neighborhood) => (
-                    <Text
-                      key={neighborhood}
-                      style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]}
-                      onPress={() => { setSelectedNeighborhoodDraft(neighborhood); setNeighborhoodDropdownOpen(false); }}
-                    >
-                      📍 {neighborhood}
-                    </Text>
-                  ))}
-                </View>
-              ) : null}
+              <Picker
+                selectedValue={selectedNeighborhoodDraft}
+                onValueChange={(value) => setSelectedNeighborhoodDraft(String(value || ''))}
+                mode="dropdown"
+                style={styles.nativePicker}
+              >
+                <Picker.Item label="📍 All neighborhoods" value="" />
+                {neighborhoods.map((neighborhood) => (
+                  <Picker.Item key={neighborhood} label={`📍 ${neighborhood}`} value={neighborhood} />
+                ))}
+              </Picker>
             </View>
 
             <View style={styles.sideMenuFooter}>
@@ -432,10 +421,7 @@ const styles = StyleSheet.create({
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
   dropdownWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, overflow: 'hidden' },
-  dropdownTrigger: { paddingHorizontal: 12, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', backgroundColor: '#fff' },
-  dropdownTriggerText: { color: '#111827', fontSize: 14 },
-  dropdownOption: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: '#eef2f7', color: '#111827' },
-  dropdownOptionSelected: { backgroundColor: '#e6f0ff' },
+  nativePicker: { backgroundColor: '#fff', color: '#111827' },
   sideMenuFooter: { marginTop: 10, gap: 12 },
   menuDivider: { height: 1, backgroundColor: '#ccc' },
   applyFiltersButton: { backgroundColor: '#007bff', borderRadius: 8, height: 52, alignItems: 'center', justifyContent: 'center' },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -63,6 +63,17 @@ function iconForType(type?: string) {
   return [];
 }
 
+function specialMatchesTypeFilters(specialType?: string, selectedTypes: string[] = []) {
+  if (!Array.isArray(selectedTypes) || selectedTypes.length === 0) return true;
+  const normalizedSpecialType = String(specialType || '').trim().toLowerCase();
+  const normalizedSelectedTypes = selectedTypes.map((type) => String(type || '').trim().toLowerCase());
+  if (normalizedSpecialType === 'combo') {
+    return normalizedSelectedTypes.includes('combo')
+      || normalizedSelectedTypes.includes('food')
+      || normalizedSelectedTypes.includes('drink');
+  }
+  return normalizedSelectedTypes.includes(normalizedSpecialType);
+}
 
 
 function LoadingSkeleton() {
@@ -234,15 +245,16 @@ export default function SpecialsScreen() {
             <Text style={styles.filterSectionTitle}>Special Type</Text>
             {['drink', 'food'].map((type) => (
               <Pressable key={type} style={[styles.filterRow, selectedTypesDraft.includes(type) ? styles.filterRowSelected : null]} onPress={() => setSelectedTypesDraft((prev) => toggleSelection(prev, type))}>
-                <Text style={styles.filterLabel}>{type.toUpperCase()}</Text>
+                <Text style={styles.filterLabel}>{type === 'drink' ? 'Drinks' : 'Food'}</Text>
+                <Ionicons name={type === 'drink' ? 'wine-outline' : 'restaurant-outline'} size={18} color="#8e8e93" />
               </Pressable>
             ))}
 
             <Text style={styles.filterSectionTitle}>Neighborhood</Text>
             <View style={styles.dropdownWrap}>
-              <Text style={styles.dropdownOption} onPress={() => setSelectedNeighborhoodDraft('')}>All neighborhoods</Text>
+              <Text style={styles.dropdownOption} onPress={() => setSelectedNeighborhoodDraft('')}>📍 All neighborhoods</Text>
               {neighborhoods.map((neighborhood) => (
-                <Text key={neighborhood} style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]} onPress={() => setSelectedNeighborhoodDraft(neighborhood)}>{neighborhood}</Text>
+                <Text key={neighborhood} style={[styles.dropdownOption, selectedNeighborhoodDraft === neighborhood ? styles.dropdownOptionSelected : null]} onPress={() => setSelectedNeighborhoodDraft(neighborhood)}>📍 {neighborhood}</Text>
               ))}
             </View>
 
@@ -273,9 +285,7 @@ export default function SpecialsScreen() {
                     const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
                                         const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
                     const filteredSpecials = specials.filter((special) => {
-                      const specialType = String(special.special_type || special.type || '').toLowerCase();
-                      const matchesType = selectedTypesApplied.length === 0 || selectedTypesApplied.includes(specialType);
-                      return matchesType;
+                      return specialMatchesTypeFilters(special.special_type || special.type, selectedTypesApplied);
                     });
                     if (filteredSpecials.length === 0) return null;
 
@@ -387,7 +397,7 @@ const styles = StyleSheet.create({
   sideMenuHeader: { height: 60, textAlign: 'center', textAlignVertical: 'center', fontWeight: '700', fontSize: 18, borderBottomWidth: 1, borderBottomColor: '#e6ecf5', backgroundColor: '#f7f9fc', paddingTop: 18 },
   sideMenuContent: { padding: 16, gap: 10 },
   filterSectionTitle: { fontSize: 14, textTransform: 'uppercase', color: '#555', letterSpacing: 1, marginTop: 8 },
-  filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12 },
+  filterRow: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, paddingHorizontal: 14, paddingVertical: 12, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   filterRowSelected: { backgroundColor: '#e6f0ff', borderColor: '#1d4ed8' },
   filterLabel: { color: '#111827' },
   dropdownWrap: { borderWidth: 1.5, borderColor: '#d9d9d9', borderRadius: 5, overflow: 'hidden' },

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-picker/picker": "^2.11.4",
         "@react-navigation/bottom-tabs": "^7.4.2",
         "@react-navigation/native": "^7.1.17",
         "@types/react": "~19.0.10",
@@ -2326,6 +2327,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.4.tgz",
+      "integrity": "sha512-Kf8h1AMnBo54b1fdiVylP2P/iFcZqzpMYcglC28EEFB1DEnOjsNr6Ucqc+3R9e91vHxEDnhZFbYDmAe79P2gjA==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@react-native-picker/picker": "^2.11.4",
     "@react-navigation/bottom-tabs": "^7.4.2",
     "@react-navigation/native": "^7.1.17",
     "@types/react": "~19.0.10",

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -37,6 +37,7 @@ export type StartupPayload = {
     start_time?: string | null;
     end_time?: string | null;
     current_status?: string;
+    favorite?: boolean;
   }>;
   specials_by_day?: Record<string, Array<{ bar_id: number; specials: number[] }>>;
   open_hours?: Record<string, Record<string, {


### PR DESCRIPTION
### Motivation
- Bring the mobile Specials tab filtering UX in line with the web app by adding a right-side filter panel that controls displayed bars and specials.

### Description
- Added a right-docked filter modal opened from the toolbar hamburger in `mobile/app/index.tsx` and implemented overlay dismissal with `Modal` and `Pressable`.
- Introduced filter state (`menuOpen`, `favoritesOnly`, `selectedTypes`, `selectedNeighborhoods`) and derived `neighborhoods` from `payload.bars` plus a `toggleSelection` helper.
- Wired filters into rendering so bars are filtered by neighborhood and specials are filtered by type and favorites, and updated `hasActiveOrUpcoming` to reflect filtered specials.
- Added corresponding styles to the `StyleSheet` in `mobile/app/index.tsx` to mirror the web side-menu look (overlay, right panel, selectable rows, selected state).

### Testing
- Attempted `npm run -s typecheck` in `mobile/` but no `typecheck` script is present, so no typecheck was run.
- Attempted `npm run -s lint` in `mobile/` but the environment failed during Expo lint auto-setup with `TypeError: fetch failed`, so lint could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0634ed98b483309fc6dc37f4715270)