### PR TITLE
Match bars neighborhood dropdown styling with specials

### DIFF
--- a/web/css/components-sidebar.css
+++ b/web/css/components-sidebar.css
@@ -74,11 +74,20 @@
 .neighborhood-filter-select {
   width: 100%;
   height: 44px;
-  padding: 10px 12px;
+  padding: 12px 42px 12px 14px;
   border: 1.5px solid #d9d9d9;
   border-radius: 5px;
   background-color: #fff;
   font-size: 0.95rem;
+  color: #1f2937;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #8e8e93 50%), linear-gradient(135deg, #8e8e93 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 12px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
 }
 
 .neighborhood-filter-select:focus {


### PR DESCRIPTION
### Motivation
- Ensure the neighborhood dropdown in the bars side menu visually matches the specials tab dropdown so the sidebar UI is consistent across tabs.

### Description
- Tweak `.neighborhood-filter-select` in `web/css/components-sidebar.css` to adjust padding and spacing, set text `color`, `cursor`, reset native `appearance`, and add a custom chevron via `background-image` and positioning so the select control matches the specials filter style.

### Testing
- Ran `cd web && npm test -- --runInBand` and the test suite completed successfully (`25` tests passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a075e3d5858833089fbd8f58d1b4ecf)