### PR TITLE
Port Special Details view to mobile Specials tab

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -5,7 +5,7 @@ import { useScrollToTop } from '@react-navigation/native';
 import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { theme } from '../constants/theme';
-import { fetchStartupPayload, submitSpecialReport, StartupPayload } from '../services/api';
+import { fetchStartupPayload, getUserIdentifier, submitSpecialReport, StartupPayload } from '../services/api';
 
 const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -387,6 +387,7 @@ export default function SpecialsScreen() {
                   <TextInput placeholder="Comment (optional)" value={reportComment} onChangeText={setReportComment} style={[styles.reportInput, styles.reportComment]} multiline />
                   <Pressable style={styles.reportSubmit} onPress={async () => {
                     if (!reportReason.trim()) return;
+                    const userIdentifier = await getUserIdentifier();
                     const specialIds = specialDetail.special.grouped_special_ids?.length
                       ? specialDetail.special.grouped_special_ids
                       : (specialDetail.special as UISpecialItem).special_id ? [String((specialDetail.special as UISpecialItem).special_id)] : [];
@@ -396,7 +397,7 @@ export default function SpecialsScreen() {
                       special_id: id,
                       reason: reportReason,
                       comment: reportComment.trim() || null,
-                      user_identifier: null,
+                      user_identifier: userIdentifier,
                     })));
                     const hasFailure = results.some((result) => result.status !== 'fulfilled' || result.value.ok === false);
                     if (hasFailure) return;

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -286,7 +286,7 @@ export default function SpecialsScreen() {
     });
   }, [showContent, dividerY, scrollRef]);
 
-  const toolbar = (
+  const defaultToolbar = (
     <View style={styles.toolbar}>
       <View style={styles.toolbarInner}>
         <Text style={styles.toolbarTitle} onPress={() => scrollRef.current?.scrollTo?.({ top: 0, animated: true })}>BAR APP</Text>
@@ -295,8 +295,18 @@ export default function SpecialsScreen() {
     </View>
   );
 
+  const detailToolbar = (
+    <View style={styles.toolbar}>
+      <View style={styles.detailToolbarInner}>
+        <Pressable onPress={() => setSpecialDetail(null)} style={styles.detailBackButton}><Text style={styles.detailBackButtonText}>‹</Text></Pressable>
+        <Text style={styles.toolbarTitle}>BAR APP</Text>
+        <View style={styles.detailBackButton} />
+      </View>
+    </View>
+  );
+
   return (
-    <ScreenContainer scrollViewRef={scrollRef} stickyHeader={toolbar}>
+    <ScreenContainer scrollViewRef={scrollRef} stickyHeader={specialDetail ? detailToolbar : defaultToolbar}>
       <Modal visible={menuVisible} transparent animationType="none" onRequestClose={closeMenuDiscardDraft}>
         <Pressable style={styles.sideMenuOverlay} onPress={closeMenuDiscardDraft} />
         <Animated.View style={[styles.sideMenu, { transform: [{ translateX: sideMenuTranslateX }] }]}>
@@ -343,13 +353,6 @@ export default function SpecialsScreen() {
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
       {specialDetail ? (
         <View style={styles.specialDetailWrap}>
-          <View style={styles.toolbar}>
-            <View style={styles.detailToolbarInner}>
-              <Pressable onPress={() => setSpecialDetail(null)} style={styles.detailBackButton}><Text style={styles.detailBackButtonText}>‹</Text></Pressable>
-              <Text style={styles.toolbarTitle}>BAR APP</Text>
-              <View style={styles.detailBackButton} />
-            </View>
-          </View>
           <View style={styles.specialDetailContent}>
             <Image source={{ uri: specialDetail.bar.image_url && specialDetail.bar.image_url !== 'null' ? specialDetail.bar.image_url : 'https://placehold.co/640x360?text=Bar' }} style={styles.specialDetailImage} />
             <View style={styles.specialDetailCard}>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -5,15 +5,16 @@ import { useScrollToTop } from '@react-navigation/native';
 import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { theme } from '../constants/theme';
-import { fetchStartupPayload, StartupPayload } from '../services/api';
+import { fetchStartupPayload, submitSpecialReport, StartupPayload } from '../services/api';
 
 const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 type SpecialItem = NonNullable<StartupPayload['specials']>[string];
+type UISpecialItem = SpecialItem & { special_id?: string; grouped_special_ids?: string[] };
 type SpecialDetailContext = {
   barId: string;
   bar: NonNullable<StartupPayload['bars']>[string];
-  special: SpecialItem;
+  special: UISpecialItem;
   dayLabel: string;
 };
 
@@ -39,8 +40,8 @@ function format12Hour(timeValue?: string | null) {
 }
 
 
-function groupSpecialsForUI(specials: SpecialItem[]) {
-  const groups = new Map<string, SpecialItem[]>();
+function groupSpecialsForUI(specials: UISpecialItem[]) {
+  const groups = new Map<string, UISpecialItem[]>();
   specials.forEach((special) => {
     const specialType = special.special_type || special.type || '';
     const key = [specialType, special.all_day ? 'all-day' : 'timed', special.start_time || '', special.end_time || ''].join('|');
@@ -49,7 +50,7 @@ function groupSpecialsForUI(specials: SpecialItem[]) {
   });
 
   return Array.from(groups.values()).map((group) => {
-    const base = { ...group[0] };
+    const base: UISpecialItem = { ...group[0] };
     const uniqueDescriptions = Array.from(new Set(group.map((s) => (s.description || '').trim()).filter(Boolean)));
     base.description = uniqueDescriptions.join(' • ');
     const hasLive = group.some((s) => s.current_status === 'live' || s.current_status === 'active');
@@ -60,6 +61,7 @@ function groupSpecialsForUI(specials: SpecialItem[]) {
     else if (hasUpcoming) base.current_status = 'upcoming';
     else if (hasPast) base.current_status = 'past';
     if (hasFavorite) base.favorite = true;
+    base.grouped_special_ids = Array.from(new Set(group.map((s) => String(s.special_id || '')).filter(Boolean)));
     return base;
   });
 }
@@ -374,9 +376,32 @@ export default function SpecialsScreen() {
               </Pressable>
               {reportOpen ? (
                 <View style={styles.reportForm}>
-                  <TextInput placeholder="Reason" value={reportReason} onChangeText={setReportReason} style={styles.reportInput} />
+                  <View style={styles.dropdownWrap}>
+                    <Picker selectedValue={reportReason} onValueChange={(value: string | number) => setReportReason(String(value || ''))} mode="dropdown" style={styles.nativePicker}>
+                      <Picker.Item label="Select reason" value="" />
+                      <Picker.Item label="Wrong details" value="wrong_details" />
+                      <Picker.Item label="No longer offered" value="no_longer_offered" />
+                      <Picker.Item label="Timing is incorrect" value="timing_incorrect" />
+                    </Picker>
+                  </View>
                   <TextInput placeholder="Comment (optional)" value={reportComment} onChangeText={setReportComment} style={[styles.reportInput, styles.reportComment]} multiline />
-                  <Pressable style={styles.reportSubmit} onPress={() => { if (!reportReason.trim()) return; setReportSubmitted(true); setReportOpen(false); }}>
+                  <Pressable style={styles.reportSubmit} onPress={async () => {
+                    if (!reportReason.trim()) return;
+                    const specialIds = specialDetail.special.grouped_special_ids?.length
+                      ? specialDetail.special.grouped_special_ids
+                      : (specialDetail.special as UISpecialItem).special_id ? [String((specialDetail.special as UISpecialItem).special_id)] : [];
+                    if (specialIds.length === 0) return;
+                    const results = await Promise.allSettled(specialIds.map((id) => submitSpecialReport({
+                      bar_id: Number(specialDetail.barId),
+                      special_id: id,
+                      reason: reportReason,
+                      comment: reportComment.trim() || null,
+                      user_identifier: null,
+                    })));
+                    const hasFailure = results.some((result) => result.status !== 'fulfilled' || result.value.ok === false);
+                    if (hasFailure) return;
+                    setReportSubmitted(true); setReportOpen(false);
+                  }}>
                     <Text style={styles.reportSubmitText}>Submit report</Text>
                   </Pressable>
                 </View>
@@ -398,7 +423,10 @@ export default function SpecialsScreen() {
                     const bar = payload?.bars?.[String(entry.bar_id)];
                     if (!bar) return null;
                     if (selectedNeighborhoodApplied && selectedNeighborhoodApplied !== bar.neighborhood) return null;
-                    const specialRows = (entry.specials ?? []).map((id) => payload?.specials?.[String(id)]).filter(Boolean) as SpecialItem[];
+                    const specialRows = (entry.specials ?? []).map((id) => {
+                      const special = payload?.specials?.[String(id)];
+                      return special ? { ...special, special_id: String(id) } : null;
+                    }).filter(Boolean) as UISpecialItem[];
                     const isBarFavorite = bar.favorite === true;
                                         const specials = groupSpecialsForUI(specialRows).filter((special) => special.description);
                     const filteredSpecials = specials.filter((special) => {

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -179,12 +179,22 @@ export default function SpecialsScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
+  const reportAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
       UIManager.setLayoutAnimationEnabledExperimental(true);
     }
   }, []);
+
+  useEffect(() => {
+    Animated.timing(reportAnim, {
+      toValue: reportOpen ? 1 : 0,
+      duration: 240,
+      easing: Easing.inOut(Easing.cubic),
+      useNativeDriver: false,
+    }).start();
+  }, [reportOpen, reportAnim]);
 
   useEffect(() => {
     (async () => {
@@ -391,7 +401,16 @@ export default function SpecialsScreen() {
               }}>
                 <Text style={[styles.reportToggleText, reportSubmitted ? styles.reportToggleTextSubmitted : null]}>{reportSubmitted ? 'Thanks for your feedback!' : 'Mark for review'}</Text>
               </Pressable>
-              {reportOpen ? (
+              <Animated.View
+                style={[
+                  styles.reportFormAnimatedWrap,
+                  {
+                    maxHeight: reportAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 260] }),
+                    opacity: reportAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 1] }),
+                  },
+                ]}
+                pointerEvents={reportOpen ? 'auto' : 'none'}
+              >
                 <View style={styles.reportForm}>
                   <View style={styles.dropdownWrap}>
                     <Picker selectedValue={reportReason} onValueChange={(value: string | number) => setReportReason(String(value || ''))} mode="dropdown" style={styles.nativePicker}>
@@ -418,12 +437,14 @@ export default function SpecialsScreen() {
                     })));
                     const hasFailure = results.some((result) => result.status !== 'fulfilled' || result.value.ok === false);
                     if (hasFailure) return;
-                    setReportSubmitted(true); setReportOpen(false);
+                    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+                    setReportSubmitted(true);
+                    setReportOpen(false);
                   }}>
                     <Text style={styles.reportSubmitText}>Submit report</Text>
                   </Pressable>
                 </View>
-              ) : null}
+              </Animated.View>
             </View>
           </View>
         </View>
@@ -574,6 +595,7 @@ const styles = StyleSheet.create({
   reportToggleText: { color: '#007bff', fontWeight: '600', textAlign: 'center' },
   reportToggleSubmitted: { borderColor: '#c5c9d3', backgroundColor: '#e9ecf2' },
   reportToggleTextSubmitted: { color: '#5f6673' },
+  reportFormAnimatedWrap: { overflow: 'hidden' },
   reportForm: { marginTop: 10, gap: 8 },
   reportInput: { borderWidth: 1, borderColor: '#d3dae6', borderRadius: 10, paddingHorizontal: 10, paddingVertical: 10, backgroundColor: '#fff' },
   reportComment: { minHeight: 82, textAlignVertical: 'top' },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Picker } from '@react-native-picker/picker';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
-import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Animated, Easing, Image, LayoutAnimation, Modal, Platform, Pressable, StyleSheet, Text, TextInput, UIManager, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { theme } from '../constants/theme';
 import { fetchStartupPayload, getUserIdentifier, submitSpecialReport, StartupPayload } from '../services/api';
@@ -179,6 +179,12 @@ export default function SpecialsScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+      UIManager.setLayoutAnimationEnabledExperimental(true);
+    }
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -371,14 +377,25 @@ export default function SpecialsScreen() {
             <View style={styles.reportSection}>
               <Text style={styles.reportTitle}>Report issue</Text>
               <Text style={styles.reportCopy}>Help us keep specials accurate by flagging anything that looks wrong.</Text>
-              <Pressable style={[styles.reportToggle, reportSubmitted ? styles.reportToggleSubmitted : null]} disabled={reportSubmitted} onPress={() => setReportOpen((v) => !v)}>
+              <Pressable style={[styles.reportToggle, reportSubmitted ? styles.reportToggleSubmitted : null]} disabled={reportSubmitted} onPress={() => {
+                LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+                setReportOpen((current) => {
+                  const nextOpen = !current;
+                  if (nextOpen) {
+                    const scrollToReport = () => scrollRef.current?.scrollToEnd?.({ animated: true });
+                    requestAnimationFrame(scrollToReport);
+                    setTimeout(scrollToReport, 260);
+                  }
+                  return nextOpen;
+                });
+              }}>
                 <Text style={[styles.reportToggleText, reportSubmitted ? styles.reportToggleTextSubmitted : null]}>{reportSubmitted ? 'Thanks for your feedback!' : 'Mark for review'}</Text>
               </Pressable>
               {reportOpen ? (
                 <View style={styles.reportForm}>
                   <View style={styles.dropdownWrap}>
                     <Picker selectedValue={reportReason} onValueChange={(value: string | number) => setReportReason(String(value || ''))} mode="dropdown" style={styles.nativePicker}>
-                      <Picker.Item label="Select reason" value="" />
+                      <Picker.Item label="Select reason" value="" enabled={false} />
                       <Picker.Item label="Wrong details" value="wrong_details" />
                       <Picker.Item label="No longer offered" value="no_longer_offered" />
                       <Picker.Item label="Timing is incorrect" value="timing_incorrect" />
@@ -544,13 +561,13 @@ const styles = StyleSheet.create({
   dividerLine: { flex: 1, height: 1, backgroundColor: '#d1d5db' },
   dividerLabel: { color: '#6b7280', fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.4 },
   specialDetailWrap: { flex: 1, backgroundColor: '#f5f5f5' },
-  specialDetailContent: { padding: 14, paddingTop: 62, gap: 14 },
+  specialDetailContent: { padding: 14, paddingTop: 14, gap: 14 },
   specialDetailImage: { width: '100%', height: 180, borderRadius: 12 },
-  specialDetailCard: { backgroundColor: '#fff', borderRadius: 12, padding: 12 },
+  specialDetailCard: { backgroundColor: '#fff', borderRadius: 12, padding: 12, shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 12, shadowOffset: { width: 0, height: 4 }, elevation: 4 },
   specialDetailBarName: { fontSize: 16, fontWeight: '700', color: '#111827' },
   specialMeta: { marginBottom: 10, marginTop: 8 },
   specialDayBadge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 4, borderRadius: 999, backgroundColor: '#e7f1ff', color: '#0a58ca', fontSize: 12, fontWeight: '700', textTransform: 'uppercase' },
-  reportSection: { marginTop: 2, backgroundColor: '#fff', borderRadius: 12, padding: 12 },
+  reportSection: { marginTop: 2, backgroundColor: '#fff', borderRadius: 12, padding: 12, shadowColor: '#000', shadowOpacity: 0.12, shadowRadius: 12, shadowOffset: { width: 0, height: 4 }, elevation: 4 },
   reportTitle: { textTransform: 'uppercase', fontSize: 14, color: '#555', fontWeight: '700' },
   reportCopy: { marginTop: 8, fontSize: 14, color: '#666' },
   reportToggle: { marginTop: 12, borderWidth: 1, borderColor: '#007bff', backgroundColor: '#f0f7ff', borderRadius: 10, paddingVertical: 10, paddingHorizontal: 12 },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -180,6 +180,7 @@ export default function SpecialsScreen() {
   const contentOpacity = useRef(new Animated.Value(0)).current;
   const skeletonOpacity = useRef(new Animated.Value(1)).current;
   const reportAnim = useRef(new Animated.Value(0)).current;
+  const reportSubmissionTokenRef = useRef(0);
 
   useEffect(() => {
     if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -423,13 +424,16 @@ export default function SpecialsScreen() {
                   <TextInput placeholder="Comment (optional)" value={reportComment} onChangeText={setReportComment} style={[styles.reportInput, styles.reportComment]} multiline />
                   <Pressable style={styles.reportSubmit} onPress={async () => {
                     if (!reportReason.trim()) return;
+                    const submissionToken = ++reportSubmissionTokenRef.current;
+                    const detailSnapshot = specialDetail;
+                    const specialSnapshotId = (detailSnapshot.special as UISpecialItem).special_id || detailSnapshot.special.grouped_special_ids?.join('|') || '';
                     const userIdentifier = await getUserIdentifier();
-                    const specialIds = specialDetail.special.grouped_special_ids?.length
-                      ? specialDetail.special.grouped_special_ids
-                      : (specialDetail.special as UISpecialItem).special_id ? [String((specialDetail.special as UISpecialItem).special_id)] : [];
+                    const specialIds = detailSnapshot.special.grouped_special_ids?.length
+                      ? detailSnapshot.special.grouped_special_ids
+                      : (detailSnapshot.special as UISpecialItem).special_id ? [String((detailSnapshot.special as UISpecialItem).special_id)] : [];
                     if (specialIds.length === 0) return;
                     const results = await Promise.allSettled(specialIds.map((id) => submitSpecialReport({
-                      bar_id: Number(specialDetail.barId),
+                      bar_id: Number(detailSnapshot.barId),
                       special_id: id,
                       reason: reportReason,
                       comment: reportComment.trim() || null,
@@ -437,6 +441,15 @@ export default function SpecialsScreen() {
                     })));
                     const hasFailure = results.some((result) => result.status !== 'fulfilled' || result.value.ok === false);
                     if (hasFailure) return;
+                    const activeSpecialId = specialDetail
+                      ? ((specialDetail.special as UISpecialItem).special_id || specialDetail.special.grouped_special_ids?.join('|') || '')
+                      : '';
+                    const sameDetailStillOpen = Boolean(
+                      specialDetail
+                      && specialDetail.barId === detailSnapshot.barId
+                      && activeSpecialId === specialSnapshotId
+                    );
+                    if (reportSubmissionTokenRef.current !== submissionToken || !sameDetailStillOpen) return;
                     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
                     setReportSubmitted(true);
                     setReportOpen(false);

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Picker } from '@react-native-picker/picker';
 import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { useScrollToTop } from '@react-navigation/native';
-import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Animated, Easing, Image, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { ScreenContainer } from '../components/ScreenContainer';
 import { theme } from '../constants/theme';
 import { fetchStartupPayload, StartupPayload } from '../services/api';
@@ -10,6 +10,12 @@ import { fetchStartupPayload, StartupPayload } from '../services/api';
 const DAYS_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 type SpecialItem = NonNullable<StartupPayload['specials']>[string];
+type SpecialDetailContext = {
+  barId: string;
+  bar: NonNullable<StartupPayload['bars']>[string];
+  special: SpecialItem;
+  dayLabel: string;
+};
 
 function orderedDayKeys(currentDay?: string) {
   const configuredStartIndex = DAYS_FULL.findIndex((day) => day.slice(0, 3).toUpperCase() === currentDay);
@@ -162,6 +168,11 @@ export default function SpecialsScreen() {
   const [selectedTypesApplied, setSelectedTypesApplied] = useState<string[]>([]);
   const [favoritesOnlyApplied, setFavoritesOnlyApplied] = useState(false);
   const [selectedNeighborhoodApplied, setSelectedNeighborhoodApplied] = useState<string>('');
+  const [specialDetail, setSpecialDetail] = useState<SpecialDetailContext | null>(null);
+  const [reportOpen, setReportOpen] = useState(false);
+  const [reportReason, setReportReason] = useState('');
+  const [reportComment, setReportComment] = useState('');
+  const [reportSubmitted, setReportSubmitted] = useState(false);
   const sideMenuTranslateX = useRef(new Animated.Value(300)).current;
   const [menuVisible, setMenuVisible] = useState(false);
   const contentOpacity = useRef(new Animated.Value(0)).current;
@@ -330,7 +341,48 @@ export default function SpecialsScreen() {
       </Modal>
       {showSkeleton ? <Animated.View style={{ opacity: skeletonOpacity }}><LoadingSkeleton /></Animated.View> : null}
       {error ? <Text style={styles.errorText}>{error}</Text> : null}
-      {!loading && !error && showContent ? (
+      {specialDetail ? (
+        <View style={styles.specialDetailWrap}>
+          <View style={styles.toolbar}>
+            <View style={styles.detailToolbarInner}>
+              <Pressable onPress={() => setSpecialDetail(null)} style={styles.detailBackButton}><Text style={styles.detailBackButtonText}>‹</Text></Pressable>
+              <Text style={styles.toolbarTitle}>BAR APP</Text>
+              <View style={styles.detailBackButton} />
+            </View>
+          </View>
+          <View style={styles.specialDetailContent}>
+            <Image source={{ uri: specialDetail.bar.image_url && specialDetail.bar.image_url !== 'null' ? specialDetail.bar.image_url : 'https://placehold.co/640x360?text=Bar' }} style={styles.specialDetailImage} />
+            <View style={styles.specialDetailCard}>
+              <Text style={styles.specialDetailBarName}>{specialDetail.bar.name}</Text>
+              <View style={styles.specialMeta}><Text style={styles.specialDayBadge}>{specialDetail.dayLabel || 'Day unavailable'}</Text></View>
+              <View style={styles.specialItem}>
+                <View style={[styles.timeBadge, (specialDetail.special.current_status ?? '').toLowerCase() === 'past' ? styles.timeBadgePast : null]}>
+                  <Text style={[styles.timeBadgeText, (specialDetail.special.current_status ?? '').toLowerCase() === 'past' ? styles.timeBadgeTextPast : null]}>{specialDetail.special.all_day ? 'ALL DAY' : `${format12Hour(specialDetail.special.start_time) || ''}\n${format12Hour(specialDetail.special.end_time) || ''}`.trim()}</Text>
+                </View>
+                <Text style={styles.specialDescription}>{specialDetail.special.description}</Text>
+                <View style={styles.typeIconWrap}>{iconForType(specialDetail.special.special_type || specialDetail.special.type).map((icon) => <Ionicons key={icon} name={icon as any} size={24} color="#8e8e93" />)}</View>
+              </View>
+            </View>
+            <View style={styles.reportSection}>
+              <Text style={styles.reportTitle}>Report issue</Text>
+              <Text style={styles.reportCopy}>Help us keep specials accurate by flagging anything that looks wrong.</Text>
+              <Pressable style={[styles.reportToggle, reportSubmitted ? styles.reportToggleSubmitted : null]} disabled={reportSubmitted} onPress={() => setReportOpen((v) => !v)}>
+                <Text style={[styles.reportToggleText, reportSubmitted ? styles.reportToggleTextSubmitted : null]}>{reportSubmitted ? 'Thanks for your feedback!' : 'Mark for review'}</Text>
+              </Pressable>
+              {reportOpen ? (
+                <View style={styles.reportForm}>
+                  <TextInput placeholder="Reason" value={reportReason} onChangeText={setReportReason} style={styles.reportInput} />
+                  <TextInput placeholder="Comment (optional)" value={reportComment} onChangeText={setReportComment} style={[styles.reportInput, styles.reportComment]} multiline />
+                  <Pressable style={styles.reportSubmit} onPress={() => { if (!reportReason.trim()) return; setReportSubmitted(true); setReportOpen(false); }}>
+                    <Text style={styles.reportSubmitText}>Submit report</Text>
+                  </Pressable>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        </View>
+      ) : null}
+      {!specialDetail && !loading && !error && showContent ? (
         <Animated.View style={{ opacity: contentOpacity }}>
           {weekDays.map(({ dayKey, dayLabel }) => {
             const entries = payload?.specials_by_day?.[dayKey] ?? [];
@@ -371,14 +423,14 @@ export default function SpecialsScreen() {
                                 const status = (special.current_status ?? '').toLowerCase();
                                 const isLive = status === 'active' || status === 'live';
                                 return (
-                                  <View key={`${index}-${special.description}`} style={[styles.specialItem, isLive ? styles.specialItemLive : null]}>
+                                  <Pressable key={`${index}-${special.description}`} style={[styles.specialItem, isLive ? styles.specialItemLive : null]} onPress={() => { setSpecialDetail({ barId: String(entry.bar_id), bar, special, dayLabel }); setReportOpen(false); setReportReason(''); setReportComment(''); setReportSubmitted(false); }}>
                                     <View style={[styles.timeBadge, status === 'past' ? styles.timeBadgePast : null]}>
                                       <Text style={[styles.timeBadgeText, status === 'past' ? styles.timeBadgeTextPast : null]}>{special.all_day ? 'ALL DAY' : `${format12Hour(special.start_time) || ''}\n${format12Hour(special.end_time) || ''}`.trim()}</Text>
                                     </View>
                                     <Text style={styles.specialDescription}>{special.description}</Text>
                                     <View style={styles.typeIconWrap}>{iconForType(special.special_type || special.type).map((icon) => <Ionicons key={icon} name={icon as any} size={24} color="#8e8e93" />)}</View>
                                     {isLive ? <ActiveDot /> : null}
-                                  </View>
+                                  </Pressable>
                                 );
                               })}
                             </View>
@@ -420,6 +472,9 @@ const styles = StyleSheet.create({
 
   toolbar: { backgroundColor: '#007bff', shadowColor: '#000', shadowOpacity: 0.15, shadowRadius: 6, shadowOffset: { width: 0, height: 2 }, elevation: 3 },
   toolbarInner: { height: 48, paddingHorizontal: 16, alignItems: 'center', justifyContent: 'center' },
+  detailToolbarInner: { height: 48, paddingHorizontal: 8, alignItems: 'center', justifyContent: 'space-between', flexDirection: 'row' },
+  detailBackButton: { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+  detailBackButtonText: { color: '#fff', fontSize: 26, lineHeight: 26 },
   toolbarTitle: { color: '#fff', fontSize: 16, fontWeight: '700', textTransform: 'uppercase' },
   hamburgerButton: { position: 'absolute', right: 16, top: 10, color: '#fff', fontSize: 24, lineHeight: 28 },
   daySection: { gap: 12 },
@@ -456,6 +511,25 @@ const styles = StyleSheet.create({
   activeUpcomingDivider: { marginTop: 12, marginBottom: 12, flexDirection: 'row', alignItems: 'center', gap: 10 },
   dividerLine: { flex: 1, height: 1, backgroundColor: '#d1d5db' },
   dividerLabel: { color: '#6b7280', fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.4 },
+  specialDetailWrap: { flex: 1, backgroundColor: '#f5f5f5' },
+  specialDetailContent: { padding: 14, paddingTop: 62, gap: 14 },
+  specialDetailImage: { width: '100%', height: 180, borderRadius: 12 },
+  specialDetailCard: { backgroundColor: '#fff', borderRadius: 12, padding: 12 },
+  specialDetailBarName: { fontSize: 16, fontWeight: '700', color: '#111827' },
+  specialMeta: { marginBottom: 10, marginTop: 8 },
+  specialDayBadge: { alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 4, borderRadius: 999, backgroundColor: '#e7f1ff', color: '#0a58ca', fontSize: 12, fontWeight: '700', textTransform: 'uppercase' },
+  reportSection: { marginTop: 2, backgroundColor: '#fff', borderRadius: 12, padding: 12 },
+  reportTitle: { textTransform: 'uppercase', fontSize: 14, color: '#555', fontWeight: '700' },
+  reportCopy: { marginTop: 8, fontSize: 14, color: '#666' },
+  reportToggle: { marginTop: 12, borderWidth: 1, borderColor: '#007bff', backgroundColor: '#f0f7ff', borderRadius: 10, paddingVertical: 10, paddingHorizontal: 12 },
+  reportToggleText: { color: '#007bff', fontWeight: '600', textAlign: 'center' },
+  reportToggleSubmitted: { borderColor: '#c5c9d3', backgroundColor: '#e9ecf2' },
+  reportToggleTextSubmitted: { color: '#5f6673' },
+  reportForm: { marginTop: 10, gap: 8 },
+  reportInput: { borderWidth: 1, borderColor: '#d3dae6', borderRadius: 10, paddingHorizontal: 10, paddingVertical: 10, backgroundColor: '#fff' },
+  reportComment: { minHeight: 82, textAlignVertical: 'top' },
+  reportSubmit: { backgroundColor: '#007bff', borderRadius: 8, height: 40, alignItems: 'center', justifyContent: 'center' },
+  reportSubmitText: { color: '#fff', fontWeight: '700' },
   sideMenuOverlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.4)' },
   sideMenu: { marginLeft: 'auto', width: 300, height: '100%', backgroundColor: '#fff', paddingBottom: 24 },
   sideMenuHeader: { height: 60, textAlign: 'center', textAlignVertical: 'center', fontWeight: '700', fontSize: 18, borderBottomWidth: 1, borderBottomColor: '#e6ecf5', backgroundColor: '#f7f9fc', paddingTop: 18 },

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -415,9 +415,9 @@ export default function SpecialsScreen() {
                   <View style={styles.dropdownWrap}>
                     <Picker selectedValue={reportReason} onValueChange={(value: string | number) => setReportReason(String(value || ''))} mode="dropdown" style={styles.nativePicker}>
                       <Picker.Item label="Select reason" value="" enabled={false} />
-                      <Picker.Item label="Wrong details" value="wrong_details" />
-                      <Picker.Item label="No longer offered" value="no_longer_offered" />
-                      <Picker.Item label="Timing is incorrect" value="timing_incorrect" />
+                      <Picker.Item label="Special is no longer active" value="Special is no longer active" />
+                      <Picker.Item label="Special details are inaccurate" value="Special details are inaccurate" />
+                      <Picker.Item label="Other" value="Other" />
                     </Picker>
                   </View>
                   <TextInput placeholder="Comment (optional)" value={reportComment} onChangeText={setReportComment} style={[styles.reportInput, styles.reportComment]} multiline />

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
-        "@react-native-picker/picker": "^2.11.4",
+        "@react-native-async-storage/async-storage": "^3.0.2",
+        "@react-native-picker/picker": "^2.11.1",
         "@react-navigation/bottom-tabs": "^7.4.2",
         "@react-navigation/native": "^7.1.17",
         "@types/react": "~19.0.10",
@@ -2327,6 +2328,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.0.2.tgz",
+      "integrity": "sha512-XP0zDIl+1XoeuQ7f878qXKdl77zLwzLALPpxvNRc7ZtDh9ew36WSvOdQOhFkexMySapFAWxEbZxS8K8J2DU4eg==",
+      "license": "MIT",
+      "dependencies": {
+        "idb": "8.0.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-picker/picker": {
@@ -4805,6 +4819,12 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
-    "@react-native-picker/picker": "^2.11.4",
+    "@react-native-async-storage/async-storage": "^3.0.2",
+    "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.4.2",
     "@react-navigation/native": "^7.1.17",
-    "@react-native-picker/picker": "^2.11.1",
     "@types/react": "~19.0.10",
     "expo": "~53.0.12",
     "expo-asset": "~11.1.7",

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -96,13 +96,14 @@ export async function getUserIdentifier(): Promise<string> {
   }
 
   const runtimeSessionId = Constants.sessionId ? String(Constants.sessionId) : '';
-  userIdentifierCache = runtimeSessionId || `mobile-${Math.random().toString(36).slice(2, 14)}`;
+  const nextIdentifier = runtimeSessionId || `mobile-${Math.random().toString(36).slice(2, 14)}`;
+  userIdentifierCache = nextIdentifier;
   try {
-    await AsyncStorage.setItem(USER_IDENTIFIER_STORAGE_KEY, userIdentifierCache);
+    await AsyncStorage.setItem(USER_IDENTIFIER_STORAGE_KEY, nextIdentifier);
   } catch {
     // ignore storage write failures and continue using in-memory cache
   }
-  return userIdentifierCache;
+  return nextIdentifier;
 }
 
 function buildStartupUrl(deviceId?: string) {

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL, STARTUP_API_URL } from './config';
+import { API_BASE_URL, SPECIAL_REPORT_API_URL, STARTUP_API_URL } from './config';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
@@ -49,6 +49,28 @@ export type StartupPayload = {
 
 export async function fetchBars() {
   return getJson<BarSummary[]>('/bars');
+}
+
+export async function submitSpecialReport(payload: {
+  bar_id: number | string | null;
+  special_id: number | string | null;
+  reason: string;
+  comment?: string | null;
+  user_identifier?: string | null;
+}) {
+  const response = await fetch(SPECIAL_REPORT_API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: JSON.stringify({
+      report_type: 'special',
+      bar_id: payload.bar_id,
+      special_id: payload.special_id,
+      reason: payload.reason,
+      comment: payload.comment ?? null,
+      user_identifier: payload.user_identifier ?? null,
+    }),
+  });
+  return response;
 }
 
 

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,4 +1,5 @@
 import { API_BASE_URL, SPECIAL_REPORT_API_URL, STARTUP_API_URL } from './config';
+import Constants from 'expo-constants';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
@@ -77,6 +78,14 @@ export async function submitSpecialReport(payload: {
 let startupPayloadCache: StartupPayload | null = null;
 let startupPayloadPromise: Promise<StartupPayload | null> | null = null;
 let startupPayloadCacheDeviceId: string | undefined;
+let userIdentifierCache: string | null = null;
+
+export async function getUserIdentifier(): Promise<string> {
+  if (userIdentifierCache) return userIdentifierCache;
+  const runtimeSessionId = Constants.sessionId ? String(Constants.sessionId) : '';
+  userIdentifierCache = runtimeSessionId || `mobile-${Math.random().toString(36).slice(2, 14)}`;
+  return userIdentifierCache;
+}
 
 function buildStartupUrl(deviceId?: string) {
   const base = API_BASE_URL.endsWith('/') ? API_BASE_URL : `${API_BASE_URL}/`;

--- a/mobile/services/api.ts
+++ b/mobile/services/api.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL, SPECIAL_REPORT_API_URL, STARTUP_API_URL } from './config';
 import Constants from 'expo-constants';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 async function getJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`);
@@ -79,11 +80,28 @@ let startupPayloadCache: StartupPayload | null = null;
 let startupPayloadPromise: Promise<StartupPayload | null> | null = null;
 let startupPayloadCacheDeviceId: string | undefined;
 let userIdentifierCache: string | null = null;
+const USER_IDENTIFIER_STORAGE_KEY = 'userIdentifier';
 
 export async function getUserIdentifier(): Promise<string> {
   if (userIdentifierCache) return userIdentifierCache;
+
+  try {
+    const persisted = await AsyncStorage.getItem(USER_IDENTIFIER_STORAGE_KEY);
+    if (persisted && persisted.trim()) {
+      userIdentifierCache = persisted.trim();
+      return userIdentifierCache;
+    }
+  } catch {
+    // ignore storage read failures and generate fallback
+  }
+
   const runtimeSessionId = Constants.sessionId ? String(Constants.sessionId) : '';
   userIdentifierCache = runtimeSessionId || `mobile-${Math.random().toString(36).slice(2, 14)}`;
+  try {
+    await AsyncStorage.setItem(USER_IDENTIFIER_STORAGE_KEY, userIdentifierCache);
+  } catch {
+    // ignore storage write failures and continue using in-memory cache
+  }
   return userIdentifierCache;
 }
 

--- a/mobile/services/config.ts
+++ b/mobile/services/config.ts
@@ -5,6 +5,9 @@ export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://example.
 export const STARTUP_API_URL = process.env.EXPO_PUBLIC_STARTUP_API_URL
   ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/getStartupData';
 
+export const SPECIAL_REPORT_API_URL = process.env.EXPO_PUBLIC_SPECIAL_REPORT_API_URL
+  ?? 'https://qz5rs9i9ya.execute-api.us-east-2.amazonaws.com/default/insertUserReport';
+
 const googleMapsMobileApiKey = Constants.expoConfig?.extra?.GOOGLE_MAPS_MOBILE_API_KEY;
 
 if (!googleMapsMobileApiKey) {


### PR DESCRIPTION
### Motivation
- Bring the web `Special Details` experience to the mobile client with 1:1 behavior and UI parity so tapping a special from the Specials tab opens the same detail flow on mobile.
- Reuse the existing web hierarchy (toolbar/back, hero image, bar name/day badge, special row and report flow) without redesigning interaction or copy.

### Description
- Added a dedicated detail model and state to the mobile specials screen (`SpecialDetailContext` and `specialDetail`) and supporting report state (`reportOpen`, `reportReason`, `reportComment`, `reportSubmitted`) in `mobile/app/index.tsx`.
- Render a mobile `Special Details` view when `specialDetail` is set, including top toolbar with back action, hero bar image, bar name and day badge, and the selected special row laid out to match the web detail structure.
- Implemented the “Mark for review” report UI and state flow in the detail view with a small inline form and success state to mirror the web flow.
- Converted special rows to `Pressable` so tapping a row opens the detail view and added necessary style entries and an import of `TextInput` to support the report form in `mobile/app/index.tsx`.

### Testing
- Ran TypeScript verification with `npx tsc --noEmit` in the `mobile/` pkg, which failed to complete due to existing environment/dependency issues unrelated to the detail view change (see below).
- The TypeScript check reported missing module/type declarations for `@react-native-picker/picker` and an existing implicit `any` parameter in `mobile/app/bars.tsx`, so the failures are pre-existing repo/CI issues and not caused by the new detail UI.
- No runtime/JSX device tests were executed in this environment; manual behavior was implemented to match the existing web patterns and should be validated on-device or in the app simulator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078ac3766c83309392bd9b6a0bd71d)